### PR TITLE
now rCore-Tutorial lab1-6(include 3+) worked on k210+rustsbi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.idea
 Cargo.lock
 
 .DS_Store


### PR DESCRIPTION
## MMU Exception Delegation
```diff
/* Page Faults are Reserved in 1.9.1 version */
- medeleg::set_instruction_page_fault();
- medeleg::set_load_page_fault();
- medeleg::set_store_page_fault();
/* Actually, They are merged into more general exceptions */
+ medeleg::set_instruction_fault();
+ medeleg::set_load_fault();
+ medeleg::set_store_fault();
```
## UARTHS interrupt soft delegation
```rust
Trap::Interrupt(Interrupt::MachineExternal) => {
    // PLIC target0(Always Hart0-M-Interrupt) acquire
    let irq_id = unsafe { (0x0c20_0004 as *const u32).read_volatile() };
    // read from UARTHS RXFIFO
    let ch: u8 = unsafe { (0x3800_0004 as *const u32).read_volatile() & 0xFF } as u8;
    // black magic @_@, soft delegation won't success without it!
    print!("{}", 0 as char);
    // PLIC complete
    unsafe { (0x0c20_0004 as *mut u32).write_volatile(irq_id); }
    // communicate with delegated interrupt with stval CSR 
    unsafe { llvm_asm!("csrw stval, $0" :: "r"(ch as usize) :: "volatile"); }
    // soft delegate to S Mode soft interrupt
    unsafe { mip::set_ssoft(); }
}
```
## Example
Built image `rustsbi-k210.bin` has been integrated into [lab3+ branch](https://github.com/rcore-os/rCore-Tutorial/tree/lab-3+), which you can run using `make run BOARD=k210`.