### PR TITLE
Fix multicore for K210 platform.

### DIFF
--- a/platform/k210/link-k210.ld
+++ b/platform/k210/link-k210.ld
@@ -1,13 +1,13 @@
 MEMORY {
     /* 存储单元的物理地址 */
-    SRAM : ORIGIN = 0x80000000, LENGTH = 2M
+    SRAM : ORIGIN = 0x80000000, LENGTH = 128K
 }
 
 _max_hart_id = 1; 
 
 PROVIDE(_stext = 0x80000000);
-PROVIDE(_heap_size = 128K);
-PROVIDE(_hart_stack_size = 64K);
+PROVIDE(_heap_size = 32K);
+PROVIDE(_hart_stack_size = 16K);
 
 REGION_ALIAS("REGION_TEXT", SRAM);
 REGION_ALIAS("REGION_RODATA", SRAM);

--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> ! {
         csrr    a2, mhartid
         lui     t0, %hi(_max_hart_id)
         add     t0, t0, %lo(_max_hart_id)
-        bgt     a2, t0, _start_abort
+        bgtu    a2, t0, _start_abort
         la      sp, _stack_start
         lui     t0, %hi(_hart_stack_size)
         add     t0, t0, %lo(_hart_stack_size)
@@ -104,8 +104,7 @@ fn main() -> ! {
     "
         )
     };
-    let hart_boot = mp_hook();
-    if hart_boot {
+    if mp_hook() {
         extern "C" {
             static mut _ebss: u32;
             static mut _sbss: u32;

--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -211,6 +211,10 @@ fn main() -> ! {
             pac::PLIC::unmask(mhartid::read(), Interrupt::GPIOHS0);
         }
         boot.clear_interrupt_pending_bits();
+
+        // wake other harts, especially hart1 on k210
+        k210_hal::clint::msip::set_ipi(1);
+        k210_hal::clint::msip::clear_ipi(1);
     }
     
     unsafe {

--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -158,15 +158,6 @@ fn main() -> ! {
                 for i in 0..=1 {
                     if hart_mask.has_bit(i) {
                         msip::set_ipi(i);
-                        /*
-                        use k210_hal::clint::mtime;
-                        let cur_time = mtime::read();
-                        loop {
-                            if mtime::read() > cur_time + 100 {
-                                break;
-                            }
-                        }
-                         */
                         msip::clear_ipi(i);
                     }
                 }


### PR DESCRIPTION
* decrease RustSBI size from 2M to 128K;
* shrink SBI heap and hart stack size to 32K and 16K respectively;
* wakeup hart1 after initialization so that all harts can go into S Mode freely.