### PR TITLE
Fix multiboot for qemu/k210

### DIFF
--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -202,10 +202,6 @@ fn main() -> ! {
             pac::PLIC::unmask(mhartid::read(), Interrupt::GPIOHS0);
         }
         boot.clear_interrupt_pending_bits();
-
-        // wake other harts, especially hart1 on k210
-        k210_hal::clint::msip::set_ipi(1);
-        k210_hal::clint::msip::clear_ipi(1);
     }
     
     unsafe {

--- a/platform/qemu/src/hal/clint.rs
+++ b/platform/qemu/src/hal/clint.rs
@@ -32,12 +32,12 @@ impl Clint {
         }
     }
 
-    // pub fn clear_soft(&mut self, hart_id: usize) {
-    //     unsafe {
-    //         let base = self.base as *mut u8;
-    //         core::ptr::write_volatile((base as *mut u32).add(hart_id), 0);
-    //     }
-    // }
+    pub fn clear_soft(&mut self, hart_id: usize) {
+        unsafe {
+            let base = self.base as *mut u8;
+            core::ptr::write_volatile((base as *mut u32).add(hart_id), 0);
+        }
+    }
 }
 
 use rustsbi::{HartMask, Ipi, Timer};


### PR DESCRIPTION
## Robust and extensible multiboot pattern
After discussion, we think that the harts other than bootstrap hart(always hart0) should wait for soft interrupt in RustSBI, and bootstrap hart should go into S Mode directly to initialize the S Mode program and then wake up other harts by sending soft interrupt.
So, in S Mode program:
```rust
// just pseudocode
if hartid == 0 {
    global_initialization();
    for i in 1..CPU_NUM {
        send_ipi(i);
    }
}
per_hart_initialization();
...
```
## Modifications
### for k210 platform
We do not wake up other harts in RustSBI.
``` rust
        /* remove */ 
        // wake other harts, especially hart1 on k210
        k210_hal::clint::msip::set_ipi(1);
        k210_hal::clint::msip::clear_ipi(1);
```
### for qemu platform
For other harts, waiting for ipi from hart0 just like k210 platform.
``` rust
/* modified */
pub extern "C" fn mp_hook() -> bool {
    let hartid = mhartid::read();
    if hartid == 0 {
        true
    } else {
        use riscv::asm::wfi;
        use hal::Clint;
        unsafe {
            let mut clint = Clint::new(0x200_0000 as *mut u8);
            // Clear IPI
            clint.clear_soft(hartid);
            // Start listening for software interrupts
            mie::set_msoft();

            loop {
                wfi();
                if mip::read().msoft() {
                    break;
                }
            }

            // Stop listening for software interrupts
            mie::clear_msoft();
            // Clear IPI
            clint.clear_soft(hartid);
        }
        false
    }
}
```