### PR TITLE
Disabling M external when software delegating M timer into S mode

### DIFF
--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -365,6 +365,14 @@ extern "C" fn start_trap_rust(trap_frame: &mut TrapFrame) {
             if trap_frame.a7 == 0x09 {
                 unsafe { DEVINTRENTRY = trap_frame.a0; }
             } else {
+                if trap_frame.a7 == 0x0 {
+                    unsafe {
+                        let mtip = mip::read().mtimer();
+                        if mtip {
+                            mie::set_mext();
+                        }
+                    }
+                }
                 let params = [trap_frame.a0, trap_frame.a1, trap_frame.a2, trap_frame.a3];
                 let ans = rustsbi::ecall(trap_frame.a7, trap_frame.a6, params);
                 trap_frame.a0 = ans.error;

--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -471,21 +471,10 @@ extern "C" fn start_trap_rust(trap_frame: &mut TrapFrame) {
             }
         }
         cause => panic!(
-            "Unhandled trap! mcause: {:?}, mepc: {:016x?}, mtval: {:016x?}, sp: {:#x}, _stack_start = {:#x}",
+            "Unhandled trap! mcause: {:?}, mepc: {:016x?}, mtval: {:016x?}",
             cause,
             mepc::read(),
             mtval::read(),
-            unsafe {
-                let mut sp: usize;
-                llvm_asm!("mv $0, sp" : "=r"(sp) ::: "volatile");
-                sp
-            },
-            {
-                extern "C" {
-                    fn _stack_start();
-                }
-                _stack_start as usize
-            }
         ),
     }
 }

--- a/rustsbi/src/ecall/legacy.rs
+++ b/rustsbi/src/ecall/legacy.rs
@@ -34,11 +34,13 @@ pub fn set_timer_64(time_value: usize) -> SbiRet {
     if mtip {
         unsafe {
             mie::clear_mtimer();
+            mie::clear_mext();
             mip::set_stimer();
         }
     } else {
         unsafe {
             mie::set_mtimer();
+            mie::set_mext();
             mip::clear_stimer();
         }
     }
@@ -55,11 +57,13 @@ pub fn set_timer_32(arg0: usize, arg1: usize) -> SbiRet {
     if mtip {
         unsafe {
             mie::clear_mtimer();
+            mie::clear_mext();
             mip::set_stimer();
         }
     } else {
         unsafe {
             mie::set_mtimer();
+            mie::set_mext();
             mip::clear_stimer();
         }
     }

--- a/rustsbi/src/ecall/legacy.rs
+++ b/rustsbi/src/ecall/legacy.rs
@@ -34,13 +34,11 @@ pub fn set_timer_64(time_value: usize) -> SbiRet {
     if mtip {
         unsafe {
             mie::clear_mtimer();
-            mie::clear_mext();
             mip::set_stimer();
         }
     } else {
         unsafe {
             mie::set_mtimer();
-            mie::set_mext();
             mip::clear_stimer();
         }
     }
@@ -57,13 +55,11 @@ pub fn set_timer_32(arg0: usize, arg1: usize) -> SbiRet {
     if mtip {
         unsafe {
             mie::clear_mtimer();
-            mie::clear_mext();
             mip::set_stimer();
         }
     } else {
         unsafe {
             mie::set_mtimer();
-            mie::set_mext();
             mip::clear_stimer();
         }
     }


### PR DESCRIPTION
In M timer handler of RustSBI, we just disable M timer and software delegate it to S timer by setting mip.stip. Later the S application can call `set_timer` to update mtimecmp, enable M timer, and clear mip.stip(actually it should be cleared by S application). They are start and end of the timer handle session.
However, after we introduced `sbi_register_devintr`, a deadlock problem occured. To be specific, when we are in S timer handler delegated by M timer before calling `set_timer`, a M external may be triggered and handled. On K210 platform, we know it will call `devintr` to manipulate S mode data structures while still in M mode. If we acquire a lock in S timer handler and acquire it in `devintr` again before we releasing it(it can happen for the reason that S timer handler and `devintr` both access S mode data), we know it leads to a deadlock issue.
The simplest solution is disable M external in M timer handler and enable it in `set_timer` just like M timer, forbidding M external to be triggered during the timer handle session. See `platform/k210/src/main.rs` and ` rustsbi/src/ecall/legacy.rs`.