### PR TITLE
fix cargo build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 # RustSBI library and all supported platforms
 members = [
     "rustsbi",
-    "platform/*",
+    "platform/k210",
+    "platform/qemu",
 ]


### PR DESCRIPTION
The line in  `Cargo.toml` file:  
```
"platform/*",
```

This line may makes the `cargo build` error because of the platform/README.md file.  
So I change this line to two lines:  
```
"platform/k210",
 "platform/qemu",
```  
Then I can successfully build the sbi.  