### PR TITLE
Allow legacy console_getchar work again on k210 platform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /target
 /.idea
+/platform/k210/.idea
+/platform/qemu/.idea
+/rustsbi/.idea
 Cargo.lock
 
 .DS_Store

--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -205,9 +205,11 @@ fn main() -> ! {
         }
         boot.clear_interrupt_pending_bits();
     }
-    
+
+    println!("??????");
+
     unsafe {
-        mideleg::set_sext();
+        //mideleg::set_sext();
         mideleg::set_stimer();
         mideleg::set_ssoft();
         medeleg::set_instruction_misaligned();
@@ -225,7 +227,7 @@ fn main() -> ! {
         medeleg::set_instruction_fault();
         medeleg::set_load_fault();
         medeleg::set_store_fault();
-        mie::set_mext();
+        // 默认不打开mie::set_mext
         // 不打开mie::set_mtimer
         mie::set_msoft();
     }
@@ -362,12 +364,14 @@ extern "C" fn start_trap_rust(trap_frame: &mut TrapFrame) {
     let cause = mcause::read().cause();
     match cause {
         Trap::Exception(Exception::SupervisorEnvCall) => {
-            if trap_frame.a7 == 0x0A000004 && trap_frame.a6 == 0x210 { 
+            if trap_frame.a7 == 0x0A000004 && trap_frame.a6 == 0x210 {
                 // We use implementation specific sbi_rustsbi_k210_sext function (extension 
                 // id: 0x0A000004, function id: 0x210) to register S-level interrupt handler
                 // for K210 chip only. This chip uses 1.9.1 version of privileged spec,
                 // which did not declare any S-level external interrupts. 
                 unsafe { DEVINTRENTRY = trap_frame.a0; }
+                // enable mext
+                unsafe { mie::set_mext(); }
                 // return values
                 trap_frame.a0 = 0; // SbiRet::error = SBI_SUCCESS
                 trap_frame.a1 = 0; // SbiRet::value = 0
@@ -382,7 +386,9 @@ extern "C" fn start_trap_rust(trap_frame: &mut TrapFrame) {
                     unsafe {
                         let mtip = mip::read().mtimer();
                         if mtip {
-                            mie::set_mext();
+                            if DEVINTRENTRY != 0 {
+                                mie::set_mext();
+                            }
                         }
                     }
                 }

--- a/platform/k210/src/main.rs
+++ b/platform/k210/src/main.rs
@@ -206,8 +206,6 @@ fn main() -> ! {
         boot.clear_interrupt_pending_bits();
     }
 
-    println!("??????");
-
     unsafe {
         //mideleg::set_sext();
         mideleg::set_stimer();

--- a/platform/qemu/link-qemu.ld
+++ b/platform/qemu/link-qemu.ld
@@ -1,11 +1,11 @@
 MEMORY {
     /* 存储单元的物理地址 */
-    SRAM : ORIGIN = 0x80000000, LENGTH = 2M
+    SRAM : ORIGIN = 0x80000000, LENGTH = 128K
 }
 
 PROVIDE(_stext = 0x80000000);
-PROVIDE(_heap_size = 128K);
-PROVIDE(_hart_stack_size = 64K);
+PROVIDE(_heap_size = 32K);
+PROVIDE(_hart_stack_size = 16K);
 PROVIDE(_max_hart_id = 7); /* todo */
 
 REGION_ALIAS("REGION_TEXT", SRAM);

--- a/platform/qemu/link-qemu.ld
+++ b/platform/qemu/link-qemu.ld
@@ -1,6 +1,6 @@
 MEMORY {
     /* 存储单元的物理地址 */
-    SRAM : ORIGIN = 0x80000000, LENGTH = 128K
+    SRAM : ORIGIN = 0x80000000, LENGTH = 2M
 }
 
 PROVIDE(_stext = 0x80000000);

--- a/platform/qemu/link-qemu.ld
+++ b/platform/qemu/link-qemu.ld
@@ -4,8 +4,8 @@ MEMORY {
 }
 
 PROVIDE(_stext = 0x80000000);
-PROVIDE(_heap_size = 32K);
-PROVIDE(_hart_stack_size = 16K);
+PROVIDE(_heap_size = 128K);
+PROVIDE(_hart_stack_size = 64K);
 PROVIDE(_max_hart_id = 7); /* todo */
 
 REGION_ALIAS("REGION_TEXT", SRAM);

--- a/platform/qemu/src/main.rs
+++ b/platform/qemu/src/main.rs
@@ -198,7 +198,7 @@ fn main() -> ! {
         }
         println!("[rustsbi] mideleg: {:#x}", mideleg::read().bits());
         println!("[rustsbi] medeleg: {:#x}", medeleg::read().bits());
-        println!("[rustsbi] Kernel entry: 0x80200000");
+        println!("[rustsbi] Kernel entry: 0x80020000");
     }
 
     extern "C" {
@@ -222,7 +222,7 @@ _s_mode_start:
     jr ra
     .align  3
 1:
-    .dword 0x80200000
+    .dword 0x80020000
 .option pop
 ");
 

--- a/platform/qemu/src/main.rs
+++ b/platform/qemu/src/main.rs
@@ -172,6 +172,9 @@ fn main() -> ! {
         medeleg::set_instruction_page_fault();
         medeleg::set_load_page_fault();
         medeleg::set_store_page_fault();
+        medeleg::set_instruction_fault();
+        medeleg::set_load_fault();
+        medeleg::set_store_fault();
         mie::set_mext();
         // 不打开mie::set_mtimer
         mie::set_msoft();

--- a/platform/qemu/src/main.rs
+++ b/platform/qemu/src/main.rs
@@ -201,7 +201,7 @@ fn main() -> ! {
         }
         println!("[rustsbi] mideleg: {:#x}", mideleg::read().bits());
         println!("[rustsbi] medeleg: {:#x}", medeleg::read().bits());
-        println!("[rustsbi] Kernel entry: 0x80020000");
+        println!("[rustsbi] Kernel entry: 0x80200000");
     }
 
     extern "C" {
@@ -225,7 +225,7 @@ _s_mode_start:
     jr ra
     .align  3
 1:
-    .dword 0x80020000
+    .dword 0x80200000
 .option pop
 ");
 


### PR DESCRIPTION
In the previous version on k210 platform, users have to register a device interrupt handler to deal with the keyboard input manually and clear the corresponding interrupt, otherwise rustsbi will jump to a default entry(0x0) after receiving the external interrupt, leading lots of issues and finally causing rustsbi panic. However, for users who do not care performance and just want to busy loop, the conventional `console_getchar` interface does not work because of the same reason.

Now, if you do not call `sbi_rustsbi_k210_sext`, the `mie.mext` will never be set. Thus users can choose freely between calling `console_getchar` and handle all external interrupts by themselves.

Additionally, on qemu platform, LoadFault/InstructionFault/StoreFault are also delegated to S mode to handle for some reasons.