### PR TITLE
fix: Use \r\n in println instead of \n

### DIFF
--- a/src/legacy_stdio.rs
+++ b/src/legacy_stdio.rs
@@ -138,6 +138,6 @@ macro_rules! print {
 #[macro_export(local_inner_macros)]
 macro_rules! println {
     ($fmt: literal $(, $($arg: tt)+)?) => {
-        $crate::legacy_stdio::_print(core::format_args!(core::concat!($fmt, "\n") $(, $($arg)+)?));
+        $crate::legacy_stdio::_print(core::format_args!(core::concat!($fmt, "\r\n") $(, $($arg)+)?));
     }
 }


### PR DESCRIPTION
We noticed that we need `\r\n` instead of `\n`

For `println!("Hello"); println!("World");`

`\n`
```
Hello
     World
```

`\r\n`
```
Hello
World
```

May need more test