### PR TITLE
rustsbi: guest instance; u32 function and module id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2021-02-23
 ### Added
-- Support for RISC-V SBI v0.3 Specification
+- Support for RISC-V SBI v1.0 and v0.3 Specification
 - S-level Illegal instruction exception is now delegated into S-level software handler
 - Support RFENCE extension in RustSBI framework
 - Added a test kernel to test SBI function on RustSBI implementations
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build under new asm! macro
 
 ### Modified
+
 - Reform RustSBI project into a library
+- Use `u32` function and module id width for SBI 1.0
 - Function `rustsbi::ecall` now require `a0`-`a5` input parameters
 - Enhanced in-line code documents from SBI standard
 - Now IPI module requires to return an `SbiRet` value

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,15 @@ keywords = ["riscv", "sbi", "rustsbi"]
 categories = ["os", "embedded", "hardware-support", "no-std"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+embedded-hal = "0.2.6"
+nb = "1.0"
+riscv = "0.7"
+
+[features]
+default = []
+# Dynamic pointer widths on SBI implementations; useful for developing hypervisors
+guest = []
 
 [package.metadata.docs.rs]
 default-target = "riscv64imac-unknown-none-elf"
@@ -23,7 +31,4 @@ targets = [
     "riscv32imac-unknown-none-elf", "riscv64imac-unknown-none-elf",
 ]
 
-[dependencies]
-embedded-hal = "0.2.6"
-nb = "1.0"
-riscv = "0.7"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ecall.rs
+++ b/src/ecall.rs
@@ -10,23 +10,23 @@ mod rfence;
 mod srst;
 mod timer;
 
-pub const EXTENSION_BASE: usize = 0x10;
-pub const EXTENSION_TIMER: usize = 0x54494D45;
-pub const EXTENSION_IPI: usize = 0x735049;
-pub const EXTENSION_RFENCE: usize = 0x52464E43;
-pub const EXTENSION_HSM: usize = 0x48534D;
-pub const EXTENSION_SRST: usize = 0x53525354;
-pub const EXTENSION_PMU: usize = 0x504D55;
+pub const EXTENSION_BASE: u32 = 0x10;
+pub const EXTENSION_TIMER: u32 = 0x54494D45;
+pub const EXTENSION_IPI: u32 = 0x735049;
+pub const EXTENSION_RFENCE: u32 = 0x52464E43;
+pub const EXTENSION_HSM: u32 = 0x48534D;
+pub const EXTENSION_SRST: u32 = 0x53525354;
+pub const EXTENSION_PMU: u32 = 0x504D55;
 
-const LEGACY_SET_TIMER: usize = 0x0;
-const LEGACY_CONSOLE_PUTCHAR: usize = 0x01;
-const LEGACY_CONSOLE_GETCHAR: usize = 0x02;
-// const LEGACY_CLEAR_IPI: usize = 0x03;
-const LEGACY_SEND_IPI: usize = 0x04;
-// const LEGACY_REMOTE_FENCE_I: usize = 0x05;
-// const LEGACY_REMOTE_SFENCE_VMA: usize = 0x06;
-// const LEGACY_REMOTE_SFENCE_VMA_ASID: usize = 0x07;
-const LEGACY_SHUTDOWN: usize = 0x08;
+const LEGACY_SET_TIMER: u32 = 0x0;
+const LEGACY_CONSOLE_PUTCHAR: u32 = 0x01;
+const LEGACY_CONSOLE_GETCHAR: u32 = 0x02;
+// const LEGACY_CLEAR_IPI: u32 = 0x03;
+const LEGACY_SEND_IPI: u32 = 0x04;
+// const LEGACY_REMOTE_FENCE_I: u32 = 0x05;
+// const LEGACY_REMOTE_SFENCE_VMA: u32 = 0x06;
+// const LEGACY_REMOTE_SFENCE_VMA_ASID: u32 = 0x07;
+const LEGACY_SHUTDOWN: u32 = 0x08;
 
 /// Supervisor environment call handler function
 ///
@@ -65,6 +65,14 @@ const LEGACY_SHUTDOWN: usize = 0x08;
 /// This skips the `ecall` instruction itself which is 4-byte long in all conditions.
 #[inline]
 pub fn handle_ecall(extension: usize, function: usize, param: [usize; 6]) -> SbiRet {
+    // RISC-V SBI requires SBI extension IDs (EIDs) and SBI function IDs (FIDs)
+    // are encoded as signed 32-bit integers
+    #[cfg(not(target_pointer_width = "32"))]
+    if extension > u32::MAX as usize || function > u32::MAX as usize {
+        return SbiRet::not_supported();
+    }
+    let (extension, function) = (extension as u32, function as u32);
+    // process actual environment calls
     match extension {
         EXTENSION_RFENCE => {
             rfence::handle_ecall_rfence(function, param[0], param[1], param[2], param[3], param[4])

--- a/src/ecall/hsm.rs
+++ b/src/ecall/hsm.rs
@@ -1,13 +1,13 @@
 //! hsm extension
 use super::SbiRet;
 
-const FUNCTION_HSM_HART_START: usize = 0x0;
-const FUNCTION_HSM_HART_STOP: usize = 0x1;
-const FUNCTION_HSM_HART_GET_STATUS: usize = 0x2;
-const FUNCTION_HSM_HART_SUSPEND: usize = 0x3;
+const FUNCTION_HSM_HART_START: u32 = 0x0;
+const FUNCTION_HSM_HART_STOP: u32 = 0x1;
+const FUNCTION_HSM_HART_GET_STATUS: u32 = 0x2;
+const FUNCTION_HSM_HART_SUSPEND: u32 = 0x3;
 
 #[inline]
-pub fn handle_ecall_hsm(function: usize, param0: usize, param1: usize, param2: usize) -> SbiRet {
+pub fn handle_ecall_hsm(function: u32, param0: usize, param1: usize, param2: usize) -> SbiRet {
     match function {
         FUNCTION_HSM_HART_START => hart_start(param0, param1, param2),
         FUNCTION_HSM_HART_STOP => hart_stop(param0),

--- a/src/ecall/ipi.rs
+++ b/src/ecall/ipi.rs
@@ -2,10 +2,10 @@ use super::SbiRet;
 use crate::hart_mask::HartMask;
 use crate::ipi::{max_hart_id, send_ipi_many};
 
-const FUNCTION_IPI_SEND_IPI: usize = 0x0;
+const FUNCTION_IPI_SEND_IPI: u32 = 0x0;
 
 #[inline]
-pub fn handle_ecall_ipi(function: usize, param0: usize, param1: usize) -> SbiRet {
+pub fn handle_ecall_ipi(function: u32, param0: usize, param1: usize) -> SbiRet {
     match function {
         FUNCTION_IPI_SEND_IPI => send_ipi(param0, param1),
         _ => SbiRet::not_supported(),

--- a/src/ecall/pmu.rs
+++ b/src/ecall/pmu.rs
@@ -2,17 +2,17 @@
 use super::SbiRet;
 use crate::pmu;
 
-const FUNCTION_PMU_NUM_COUNTERS: usize = 0x0;
-const FUNCTION_PMU_COUNTER_GET_INFO: usize = 0x1;
-const FUNCTION_PMU_COUNTER_CONFIG_MATCHING: usize = 0x2;
-const FUNCTION_PMU_COUNTER_START: usize = 0x3;
-const FUNCTION_PMU_COUNTER_STOP: usize = 0x4;
-const FUNCTION_PMU_COUNTER_FW_READ: usize = 0x5;
+const FUNCTION_PMU_NUM_COUNTERS: u32 = 0x0;
+const FUNCTION_PMU_COUNTER_GET_INFO: u32 = 0x1;
+const FUNCTION_PMU_COUNTER_CONFIG_MATCHING: u32 = 0x2;
+const FUNCTION_PMU_COUNTER_START: u32 = 0x3;
+const FUNCTION_PMU_COUNTER_STOP: u32 = 0x4;
+const FUNCTION_PMU_COUNTER_FW_READ: u32 = 0x5;
 
 #[inline]
 #[cfg(target_pointer_width = "64")]
 pub fn handle_ecall_pmu_64(
-    function: usize,
+    function: u32,
     param0: usize,
     param1: usize,
     param2: usize,
@@ -35,7 +35,7 @@ pub fn handle_ecall_pmu_64(
 #[inline]
 #[cfg(target_pointer_width = "32")]
 pub fn handle_ecall_pmu_32(
-    function: usize,
+    function: u32,
     param0: usize,
     param1: usize,
     param2: usize,

--- a/src/ecall/rfence.rs
+++ b/src/ecall/rfence.rs
@@ -3,17 +3,17 @@ use crate::hart_mask::HartMask;
 use crate::ipi::max_hart_id;
 use crate::rfence;
 
-const FUNCTION_RFENCE_REMOTE_FENCE_I: usize = 0x0;
-const FUNCTION_RFENCE_REMOTE_SFENCE_VMA: usize = 0x1;
-const FUNCTION_RFENCE_REMOTE_SFENCE_VMA_ASID: usize = 0x2;
-const FUNCTION_RFENCE_REMOTE_HFENCE_GVMA_VMID: usize = 0x3;
-const FUNCTION_RFENCE_REMOTE_HFENCE_GVMA: usize = 0x4;
-const FUNCTION_RFENCE_REMOTE_HFENCE_VVMA_ASID: usize = 0x5;
-const FUNCTION_RFENCE_REMOTE_HFENCE_VVMA: usize = 0x6;
+const FUNCTION_RFENCE_REMOTE_FENCE_I: u32 = 0x0;
+const FUNCTION_RFENCE_REMOTE_SFENCE_VMA: u32 = 0x1;
+const FUNCTION_RFENCE_REMOTE_SFENCE_VMA_ASID: u32 = 0x2;
+const FUNCTION_RFENCE_REMOTE_HFENCE_GVMA_VMID: u32 = 0x3;
+const FUNCTION_RFENCE_REMOTE_HFENCE_GVMA: u32 = 0x4;
+const FUNCTION_RFENCE_REMOTE_HFENCE_VVMA_ASID: u32 = 0x5;
+const FUNCTION_RFENCE_REMOTE_HFENCE_VVMA: u32 = 0x6;
 
 #[inline]
 pub fn handle_ecall_rfence(
-    function: usize,
+    function: u32,
     param0: usize,
     param1: usize,
     param2: usize,

--- a/src/ecall/srst.rs
+++ b/src/ecall/srst.rs
@@ -1,9 +1,9 @@
 use super::SbiRet;
 
-const FUNCTION_SYSTEM_RESET: usize = 0x0;
+const FUNCTION_SYSTEM_RESET: u32 = 0x0;
 
 #[inline]
-pub fn handle_ecall_srst(function: usize, param0: usize, param1: usize) -> SbiRet {
+pub fn handle_ecall_srst(function: u32, param0: usize, param1: usize) -> SbiRet {
     match function {
         FUNCTION_SYSTEM_RESET => system_reset(param0, param1),
         _ => SbiRet::not_supported(),

--- a/src/ecall/timer.rs
+++ b/src/ecall/timer.rs
@@ -1,10 +1,10 @@
 use super::SbiRet;
 
-const FUNCTION_TIMER_SET_TIMER: usize = 0x0;
+const FUNCTION_TIMER_SET_TIMER: u32 = 0x0;
 
 #[inline]
 #[cfg(target_pointer_width = "64")]
-pub fn handle_ecall_timer_64(function: usize, param0: usize) -> SbiRet {
+pub fn handle_ecall_timer_64(function: u32, param0: usize) -> SbiRet {
     match function {
         FUNCTION_TIMER_SET_TIMER => set_timer(param0),
         _ => SbiRet::not_supported(),
@@ -13,7 +13,7 @@ pub fn handle_ecall_timer_64(function: usize, param0: usize) -> SbiRet {
 
 #[inline]
 #[cfg(target_pointer_width = "32")]
-pub fn handle_ecall_timer_32(function: usize, param0: usize, param1: usize) -> SbiRet {
+pub fn handle_ecall_timer_32(function: u32, param0: usize, param1: usize) -> SbiRet {
     match function {
         FUNCTION_TIMER_SET_TIMER => set_timer(param0, param1),
         _ => SbiRet::not_supported(),

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,7 +1,7 @@
 use crate::ecall::*;
 
 #[inline]
-pub fn probe_extension(extension: usize) -> bool {
+pub fn probe_extension(extension: u32) -> bool {
     match extension {
         EXTENSION_BASE => true,
         EXTENSION_TIMER => crate::timer::probe_timer(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,11 @@ mod timer;
 
 mod util;
 
+#[cfg(feature = "guest")]
+mod guest;
+
+pub mod instance;
+
 const SBI_SPEC_MAJOR: usize = 0;
 const SBI_SPEC_MINOR: usize = 3;
 


### PR DESCRIPTION
Instance based interface could make it convenient to develop a hypervisor. That requires a guest pointer width different to host pointer width. This feature is gated under 'guest' feature gate; current bootloader design does not need to change code for default feature of RustSBI package does not contain 'guest' feature.

This pull request also includes a u32-indexed modules and functions to comply with RISC-V SBI version 1.0. This is only an internal design change, the current API remains usize-indexed to reduce the cost of development when handling trap contexts (you don't need to change them to type u32).

Draft: instance based interface has not (by now) been proved under concept; will be marked as ready after a hypervisor with integrated RustSBI is developed.