### PR TITLE
fix: `hart_stop` can only stop the calling hart

### DIFF
--- a/src/ecall/hsm.rs
+++ b/src/ecall/hsm.rs
@@ -10,7 +10,7 @@ const FUNCTION_HSM_HART_SUSPEND: u32 = 0x3;
 pub fn handle_ecall_hsm(function: u32, param0: usize, param1: usize, param2: usize) -> SbiRet {
     match function {
         FUNCTION_HSM_HART_START => hart_start(param0, param1, param2),
-        FUNCTION_HSM_HART_STOP => hart_stop(param0),
+        FUNCTION_HSM_HART_STOP => hart_stop(),
         FUNCTION_HSM_HART_GET_STATUS => hart_get_status(param0),
         FUNCTION_HSM_HART_SUSPEND => hart_suspend(param0, param1, param2),
         _ => SbiRet::not_supported(),
@@ -23,8 +23,8 @@ fn hart_start(hartid: usize, start_addr: usize, opaque: usize) -> SbiRet {
 }
 
 #[inline]
-fn hart_stop(hartid: usize) -> SbiRet {
-    crate::hsm::hart_stop(hartid)
+fn hart_stop() -> SbiRet {
+    crate::hsm::hart_stop()
 }
 
 #[inline]

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -93,7 +93,7 @@ pub trait Hsm: Send {
     /// | Error code  | Description
     /// |:------------|:------------
     /// | SBI_ERR_FAILED | Failed to stop execution of the current hart
-    fn hart_stop(&self, hartid: usize) -> SbiRet;
+    fn hart_stop(&self) -> SbiRet;
     /// Get the current status (or HSM state id) of the given hart.
     ///
     /// The harts may transition HSM states at any time due to any concurrent `sbi_hart_start()`
@@ -215,9 +215,9 @@ pub(crate) fn hart_start(hartid: usize, start_addr: usize, opaque: usize) -> Sbi
     SbiRet::not_supported()
 }
 
-pub(crate) fn hart_stop(hartid: usize) -> SbiRet {
+pub(crate) fn hart_stop() -> SbiRet {
     if let Some(obj) = HSM.get() {
-        return obj.hart_stop(hartid);
+        return obj.hart_stop();
     }
     SbiRet::not_supported()
 }


### PR DESCRIPTION
In SBI 1.0.0 Spec, `sbi_hart_stop` is described as:

> 9.2. Function: HART stop (FID #1)
>
> ```c
> struct sbiret sbi_hart_stop(void)
> ```
>
> Request the SBI implementation to stop executing the calling hart in supervisor-mode and return it’s ownership to the SBI implementation. This call is not expected to return under normal conditions. The sbi_hart_stop() must be called with the supervisor-mode interrupts disabled.
