### PR TITLE
feat: probe function now probe legacy extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Expose `init_*` functions on instance based RustSBI implementation
 
 ### Modified
+- Probe function now returns if legacy extensions are available
+
+### Removed
 - Remove dependency on crate alloc; RustSBI now works without heap
 - Remove embedded-hal serial adapter to legacy console
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -12,13 +12,14 @@ pub fn probe_extension(extension: usize) -> bool {
         // Legacy extensions
         // if feature 'legacy' is not enabled, these extensions fall back to false.
         #[cfg(feature = "legacy")]
-        legacy::LEGACY_SET_TIMER
-        | legacy::LEGACY_CLEAR_IPI
-        | legacy::LEGACY_SEND_IPI
-        | legacy::LEGACY_REMOTE_FENCE_I
-        | legacy::LEGACY_REMOTE_SFENCE_VMA
-        | legacy::LEGACY_REMOTE_SFENCE_VMA_ASID
-        | legacy::LEGACY_SHUTDOWN => true,
+        legacy::LEGACY_SET_TIMER => crate::timer::probe_timer(),
+        #[cfg(feature = "legacy")]
+        legacy::LEGACY_SEND_IPI => crate::ipi::probe_ipi(),
+        #[cfg(feature = "legacy")]
+        legacy::LEGACY_SHUTDOWN => crate::reset::probe_reset(),
+        // we don't include LEGACY_REMOTE_FENCE_I, LEGACY_REMOTE_SFENCE_VMA,
+        // LEGACY_CLEAR_IPI and LEGACY_REMOTE_SFENCE_VMA_ASID here,
+        // for RustSBI ecall/mod.rs did not implement these legacy extensions.
         #[cfg(feature = "legacy")]
         legacy::LEGACY_CONSOLE_PUTCHAR | legacy::LEGACY_CONSOLE_GETCHAR => {
             crate::legacy_stdio::probe_legacy_stdio()

--- a/src/base.rs
+++ b/src/base.rs
@@ -9,6 +9,20 @@ pub fn probe_extension(extension: usize) -> bool {
         srst::EID_SRST => crate::reset::probe_reset(),
         hsm::EID_HSM => crate::hsm::probe_hsm(),
         pmu::EID_PMU => crate::pmu::probe_pmu(),
+        // Legacy extensions
+        // if feature 'legacy' is not enabled, these extensions fall back to false.
+        #[cfg(feature = "legacy")]
+        legacy::LEGACY_SET_TIMER
+        | legacy::LEGACY_CLEAR_IPI
+        | legacy::LEGACY_SEND_IPI
+        | legacy::LEGACY_REMOTE_FENCE_I
+        | legacy::LEGACY_REMOTE_SFENCE_VMA
+        | legacy::LEGACY_REMOTE_SFENCE_VMA_ASID
+        | legacy::LEGACY_SHUTDOWN => true,
+        #[cfg(feature = "legacy")]
+        legacy::LEGACY_CONSOLE_PUTCHAR | legacy::LEGACY_CONSOLE_GETCHAR => {
+            crate::legacy_stdio::probe_legacy_stdio()
+        }
         _ => false,
     }
 }

--- a/src/ecall/mod.rs
+++ b/src/ecall/mod.rs
@@ -17,8 +17,7 @@ mod pmu;
 
 #[cfg(feature = "legacy")]
 use crate::{
-    legacy_stdio_getchar, legacy_stdio_putchar,
-    ipi::send_ipi_many, reset::legacy_reset, HartMask,
+    ipi::send_ipi_many, legacy_stdio_getchar, legacy_stdio_putchar, reset::legacy_reset, HartMask,
 };
 use sbi_spec::{self as spec, binary::SbiRet};
 

--- a/src/legacy_stdio.rs
+++ b/src/legacy_stdio.rs
@@ -44,6 +44,11 @@ pub fn legacy_stdio_getchar() -> usize {
     }
 }
 
+#[inline]
+pub(crate) fn probe_legacy_stdio() -> bool {
+    LEGACY_STDIO.get().is_some()
+}
+
 struct Stdout;
 
 impl fmt::Write for Stdout {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,9 +142,9 @@
 //! it's better to include minimal feature in core repository, and leave other features for downstream developers.
 //!
 //! # Notes for RustSBI developers
-//! 
+//!
 //! Following useful hints are for firmware and kernel developers when working with SBI and RustSBI.
-//! 
+//!
 //! ## RustSBI is a library for interfaces
 //!
 //! This library adapts to individual Rust traits to provide basic SBI features.
@@ -159,23 +159,23 @@
 //! Note that this crate is a library which contains common building blocks in SBI implementation.
 //! It is not intended to be used directly; users should build own platforms with this library.
 //! RustSBI provides implementations on common platforms in separate platform crates.
-//! 
+//!
 //! ## Legacy SBI extension
-//! 
+//!
 //! Note: RustSBI legacy support is only designed for backward compability. It's disabled by default and it's not
 //! suggested to include legacy functions in newer firmware designs. Modules other than legacy console is replaced by
-//! individual modules in SBI. Legacy console is not suggested to use in kernels. 
+//! individual modules in SBI. Legacy console is not suggested to use in kernels.
 //! If you are a kernel developer, newer designs should consider relying on each SBI module other than
 //! legacy functions.
-//! 
+//!
 //! The SBI includes legacy extension which dated back to SBI 0.1 specification. Most of its features
 //! are replaced by individual SBI modules, thus the entire legacy extension is deprecated by
 //! SBI version 0.2. However, some users may find out SBI 0.1 legacy console useful in some situations
 //! even if it's deprecated.
-//! 
+//!
 //! RustSBI keeps SBI 0.1 legacy support under feature gate `legacy`. To use RustSBI with legacy feature,
 //! you may change dependency code to:
-//! 
+//!
 //! ```toml
 //! [dependencies]
 //! rustsbi = { version = "0.3.0", features = ["legacy"] }
@@ -199,9 +199,6 @@ mod reset;
 mod rfence;
 mod timer;
 mod util;
-
-#[cfg(feature = "guest")]
-mod guest;
 
 // pub mod instance; // TODO: SBI instances, useful for developing hypervisors
 


### PR DESCRIPTION
This pull request also includes a reformat to code. There are 9 legacy functions, where legacy console should decide whether 2 of them are available. If feature legacy is disabled, probes to all legacy extensions will return `false`.