### PR TITLE
fix: marchid, mimpid registers in base extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ categories = ["os", "embedded", "hardware-support", "no-std"]
 edition = "2021"
 
 [dependencies]
-riscv = "0.8"
+riscv = { git = "git@github.com:rust-embedded/riscv.git", commit = "e38a68d" }
+# todo: change to a release version when the fix is released
+# riscv = "0.8"
 sbi-spec = "0.0.2"
 
 [features]


### PR DESCRIPTION
upstreams https://github.com/rust-embedded/riscv/pull/107. We should change to specific release number in the future other than a git commit number.