### PR TITLE
ecall: wrap mip::clear_ssoft() in unsafe

### DIFF
--- a/src/ecall/mod.rs
+++ b/src/ecall/mod.rs
@@ -121,7 +121,9 @@ pub fn handle_ecall(extension: usize, function: usize, param: [usize; 6]) -> Sbi
         }
         #[cfg(feature = "legacy")]
         spec::legacy::LEGACY_CLEAR_IPI => {
-            riscv::register::mip::clear_ssoft();
+            unsafe {
+                riscv::register::mip::clear_ssoft();
+            }
             SbiRet {
                 error: param[0],
                 value: param[1],


### PR DESCRIPTION
Clearing a CSR is marked as being unsafe:
https://github.com/rust-embedded/riscv/blob/e38a68d2e/src/register/macros.rs#L185

Signed-off-by: Daniel Maslowski <info@orangecms.org>
