### PR TITLE
feat: support System Suspend extension and CPPC extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- support System Suspend and CPPC extension 
+- support System Suspend extension
+- support CPPC extension 
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- support System Suspend and CPPC extension 
+
 ### Modified
 
 - run on provided `MachineInfo` by default; bare metal M-mode environment should gate `machine`

--- a/src/cppc.rs
+++ b/src/cppc.rs
@@ -1,0 +1,131 @@
+use sbi_spec::binary::SbiRet;
+
+/// CPPC Extension
+///
+/// ACPI defines the Collaborative Processor Performance Control (CPPC) mechanism,
+/// which is an abstract and flexible mechanism for the supervisor-mode
+/// power-management software to collaborate with an entity in the platform to
+/// manage the performance of the processors.
+///
+/// The SBI CPPC extension provides an abstraction to access the CPPC registers
+/// through SBI calls. The CPPC registers can be memory locations shared with a
+/// separate platform entity such as a BMC. Even though CPPC is defined in the ACPI
+/// specification, it may be possible to implement a CPPC driver based on
+/// Device Tree.
+///
+/// The table below defines 32-bit identifiers for all CPPC registers
+/// to be used by the SBI CPPC functions. The first half of the 32-bit register
+/// space corresponds to the registers as defined by the ACPI specification.
+/// The second half provides the information not defined in the ACPI specification,
+/// but is additionally required by the supervisor-mode power-management software.
+///
+/// | Register ID             | Register                              | Bit Width | Attribute    | Description               
+/// | ----------------------- | ------------------------------------- | --------- | ------------ | ---------------------------
+/// | 0x00000000              | HighestPerformance                    | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.1  
+/// | 0x00000001              | NominalPerformance                    | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.2   
+/// | 0x00000002              | LowestNonlinearPerformance            | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.4
+/// | 0x00000003              | LowestPerformance                     | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.5
+/// | 0x00000004              | GuaranteedPerformanceRegister         | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.6
+/// | 0x00000005              | DesiredPerformanceRegister            | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.2.3
+/// | 0x00000006              | MinimumPerformanceRegister            | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.2.2
+/// | 0x00000007              | MaximumPerformanceRegister            | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.2.1
+/// | 0x00000008              | PerformanceReductionToleranceRegister | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.2.4
+/// | 0x00000009              | TimeWindowRegister                    | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.2.5
+/// | 0x0000000A              | CounterWraparoundTime                 | 32 / 64   | Read-only    | ACPI Spec 6.5: 8.4.6.1.3.1
+/// | 0x0000000B              | ReferencePerformanceCounterRegister   | 32 / 64   | Read-only    | ACPI Spec 6.5: 8.4.6.1.3.1
+/// | 0x0000000C              | DeliveredPerformanceCounterRegister   | 32 / 64   | Read-only    | ACPI Spec 6.5: 8.4.6.1.3.1
+/// | 0x0000000D              | PerformanceLimitedRegister            | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.3.2
+/// | 0x0000000E              | CPPCEnableRegister                    | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.4
+/// | 0x0000000F              | AutonomousSelectionEnable             | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.5
+/// | 0x00000010              | AutonomousActivityWindowRegister      | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.6
+/// | 0x00000011              | EnergyPerformancePreferenceRegister   | 32        | Read / Write | ACPI Spec 6.5: 8.4.6.1.7  
+/// | 0x00000012              | ReferencePerformance                  | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.3  
+/// | 0x00000013              | LowestFrequency                       | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.7
+/// | 0x00000014              | NominalFrequency                      | 32        | Read-only    | ACPI Spec 6.5: 8.4.6.1.1.7
+/// | 0x00000015 - 0x7FFFFFFF |                                       |           |              | Reserved for future use.     
+/// | 0x80000000              | TransitionLatency                     | 32        | Read-only    | Provides the maximum (worst-case) performance state transition latency in nanoseconds.
+/// | 0x80000001 - 0xFFFFFFFF |                                       |           |              | Reserved for future use.   
+///
+pub trait Cppc: Send + Sync {
+    /// Probe whether the CPPC register as specified by the `reg_id` parameter
+    /// is implemented or not by the platform.
+    ///
+    /// # Return value
+    ///
+    /// If the register is implemented, `SbiRet.value` will contain the register
+    /// width. If the register is not implemented, `SbiRet.value` will be set to 0.
+    ///
+    /// The possible return error codes returned in `SbiRet.error` are shown in the table below:
+    ///
+    /// | Error code                | Description   
+    /// | ------------------------- | ---------------
+    /// | `SbiRet::success()`       | Probe completed successfully.
+    /// | `SbiRet::invalid_param()` | `reg_id` is reserved.
+    /// | `SbiRet::failed()`        | The probe request failed for unspecified or unknown other reasons.
+    fn probe(&self, reg_id: u32) -> SbiRet;
+    /// Reads the register as specified in the `reg_id` parameter.
+    ///
+    /// # Return value
+    ///
+    /// Returns the value of the register in `SbiRet.value`. When supervisor mode XLEN is 32,
+    /// the `SbiRet.value` will only contain the lower 32 bits of the CPPC register value.
+    ///
+    /// The possible return error codes returned in `SbiRet.error` are shown in the table below:
+    ///
+    /// | Error code                | Description
+    /// | ------------------------- | -------------------
+    /// | `SbiRet::success()`       | Read completed successfully.
+    /// | `SbiRet::invalid_param()` | `reg_id` is reserved.
+    /// | `SbiRet::not_supported()` | `reg_id` is not implemented by the platform.
+    /// | `SbiRet::denied()`        | `reg_id` is a write-only register.  
+    /// | `SbiRet::failed()`        | The read request failed for unspecified or unknown other reasons.
+    fn read(&self, reg_id: u32) -> SbiRet;
+    /// Reads the upper 32-bit value of the register specified in the `reg_id`
+    /// parameter.
+    ///
+    /// # Return value
+    ///
+    /// Returns the value of the register in `SbiRet.value`. This function always
+    /// returns zero in `SbiRet.value` when supervisor mode XLEN is 64 or higher.
+    ///
+    /// The possible return error codes returned in `SbiRet.error` are shown in the table below:
+    ///
+    /// | Error code                | Description
+    /// | ------------------------- | -------------------
+    /// | `SbiRet::success()`       | Read completed successfully.
+    /// | `SbiRet::invalid_param()` | `reg_id` is reserved.
+    /// | `SbiRet::not_supported()` | `reg_id` is not implemented by the platform.
+    /// | `SbiRet::denied()`        | `reg_id` is a write-only register.  
+    /// | `SbiRet::failed()`        | The read request failed for unspecified or unknown other reasons.
+    fn read_hi(&self, reg_id: u32) -> SbiRet;
+    /// Writes the value passed in the `val` parameter to the register as
+    /// specified in the `reg_id` parameter.
+    ///
+    /// # Return value
+    ///
+    /// The possible return error codes returned in `SbiRet.error` are shown in the table below:
+    ///
+    /// | Error code                | Description        
+    /// | ------------------------- | -------------------
+    /// | `SbiRet::success()`       | Write completed successfully.  
+    /// | `SbiRet::invalid_param()` | `reg_id` is reserved.       
+    /// | `SbiRet::not_supported()` | `reg_id` is not implemented by the platform.  
+    /// | `SbiRet::denied()`        | `reg_id` is a read-only register.
+    /// | `SbiRet::failed()`        | The write request failed for unspecified or unknown other reasons.
+    fn write(&self, reg_id: u32, val: u64) -> SbiRet;
+}
+
+impl<T: Cppc> Cppc for &T {
+    fn probe(&self, reg_id: u32) -> SbiRet {
+        T::probe(self, reg_id)
+    }
+    fn read(&self, reg_id: u32) -> SbiRet {
+        T::read(self, reg_id)
+    }
+    fn read_hi(&self, reg_id: u32) -> SbiRet {
+        T::read_hi(self, reg_id)
+    }
+    fn write(&self, reg_id: u32, val: u64) -> SbiRet {
+        T::write(self, reg_id, val)
+    }
+}

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -359,7 +359,7 @@ impl<T: Timer, I: Ipi, R: Fence, H: Hsm, S: Reset, P: Pmu, C: Console, SU: Susp,
                     match function {
                         spec::cppc::PROBE => cppc.probe(param0),
                         spec::cppc::READ => cppc.read(param0),
-                        spec::cppc::READ_HI => cppc.read(param0),
+                        spec::cppc::READ_HI => cppc.read_hi(param0),
                         spec::cppc::WRITE => cppc.write(param0, concat_u32(param2, param1)),
                         _ => SbiRet::not_supported(),
                     }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -357,10 +357,10 @@ impl<T: Timer, I: Ipi, R: Fence, H: Hsm, S: Reset, P: Pmu, C: Console, SU: Susp,
                     };
                     let [param0, param1, param2] = [param[0], param[1], param[2]];
                     match function {
-                        spec::cppc::PROBE => cppc.probe(param0),
-                        spec::cppc::READ => cppc.read(param0),
-                        spec::cppc::READ_HI => cppc.read_hi(param0),
-                        spec::cppc::WRITE => cppc.write(param0, concat_u32(param2, param1)),
+                        spec::cppc::PROBE => cppc.probe(param0 as _),
+                        spec::cppc::READ => cppc.read(param0 as _),
+                        spec::cppc::READ_HI => cppc.read_hi(param0 as _),
+                        spec::cppc::WRITE => cppc.write(param0 as _, concat_u32(param2, param1)),
                         _ => SbiRet::not_supported(),
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@
 //! # struct MyBoardPower;
 //! # struct MyPlatPmu;
 //! # struct MyPlatDbcn;
+//! # struct MyPlatSusp;
 //! use rustsbi::RustSBI;
 //!
 //! # struct SupervisorContext;
@@ -174,7 +175,7 @@
 //! struct Executor {
 //!     ctx: SupervisorContext,
 //!     /* other environment variables ... */
-//!     sbi: RustSBI<Clint, Clint, MyPlatRfnc, MyPlatHsm, MyBoardPower, MyPlatPmu, MyPlatDbcn>,
+//!     sbi: RustSBI<Clint, Clint, MyPlatRfnc, MyPlatHsm, MyBoardPower, MyPlatPmu, MyPlatDbcn, MyPlatSusp>,
 //!     /* custom_1: CustomSBI<...> */
 //! }
 //!
@@ -511,6 +512,7 @@ mod pmu;
 mod reset;
 mod rfence;
 mod timer;
+mod susp;
 
 /// The RustSBI logo without blank lines on the beginning
 pub const LOGO: &str = r".______       __    __      _______.___________.  _______..______   __
@@ -548,6 +550,7 @@ pub use pmu::Pmu;
 pub use reset::Reset;
 pub use rfence::Rfence as Fence;
 pub use timer::Timer;
+pub use susp::Susp;
 
 #[cfg(not(feature = "machine"))]
 pub use instance::MachineInfo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@
 //! # struct MyPlatPmu;
 //! # struct MyPlatDbcn;
 //! # struct MyPlatSusp;
+//! # struct MyPlatCppc;
 //! use rustsbi::RustSBI;
 //!
 //! # struct SupervisorContext;
@@ -175,7 +176,7 @@
 //! struct Executor {
 //!     ctx: SupervisorContext,
 //!     /* other environment variables ... */
-//!     sbi: RustSBI<Clint, Clint, MyPlatRfnc, MyPlatHsm, MyBoardPower, MyPlatPmu, MyPlatDbcn, MyPlatSusp>,
+//!     sbi: RustSBI<Clint, Clint, MyPlatRfnc, MyPlatHsm, MyBoardPower, MyPlatPmu, MyPlatDbcn, MyPlatSusp, MyPlatCppc>,
 //!     /* custom_1: CustomSBI<...> */
 //! }
 //!
@@ -504,6 +505,7 @@
 #![no_std]
 
 mod console;
+mod cppc;
 mod hart_mask;
 mod hsm;
 mod instance;
@@ -511,8 +513,8 @@ mod ipi;
 mod pmu;
 mod reset;
 mod rfence;
-mod timer;
 mod susp;
+mod timer;
 
 /// The RustSBI logo without blank lines on the beginning
 pub const LOGO: &str = r".______       __    __      _______.___________.  _______..______   __
@@ -542,6 +544,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub extern crate sbi_spec as spec;
 pub use console::Console;
+pub use cppc::Cppc;
 pub use hart_mask::HartMask;
 pub use hsm::Hsm;
 pub use instance::{Builder, RustSBI};
@@ -549,8 +552,8 @@ pub use ipi::Ipi;
 pub use pmu::Pmu;
 pub use reset::Reset;
 pub use rfence::Rfence as Fence;
-pub use timer::Timer;
 pub use susp::Susp;
+pub use timer::Timer;
 
 #[cfg(not(feature = "machine"))]
 pub use instance::MachineInfo;

--- a/src/susp.rs
+++ b/src/susp.rs
@@ -1,0 +1,88 @@
+use sbi_spec::binary::SbiRet;
+
+/// System Suspend Extension
+///
+/// The system suspend extension defines a set of system-level sleep states and a
+/// function which allows the supervisor-mode software to request that the system
+/// transitions to a sleep state. Sleep states are identified with 32-bit wide
+/// identifiers (`sleep_type`). The possible values for the identifiers are shown
+/// in the table below:
+///
+/// | Type                    | Name           | Description    
+/// |-------------------------|----------------|-------------------------------
+/// | 0                       | SUSPEND_TO_RAM | This is a "suspend to RAM" sleep type, similar to ACPI’s S2 or S3. Entry requires all but the calling hart be in the HSM `STOPPED` state and all hart registers and CSRs saved to RAM.
+/// | 0x00000001 - 0x7fffffff |                | Reserved for future use
+/// | 0x80000000 - 0xffffffff |                | Platform-specific system sleep types
+/// | > 0xffffffff            |                | Reserved                
+///
+/// The term "system" refers to the world-view of supervisor software. The
+/// underlying SBI implementation may be provided by machine mode firmware or a
+/// hypervisor.
+///
+/// The system suspend extension does not provide any way for supported sleep types
+/// to be probed. Platforms are expected to specify their supported system sleep
+/// types and per-type wake up devices in their hardware descriptions. The
+/// `SUSPEND_TO_RAM` sleep type is the one exception, and its presence is implied
+/// by that of the extension.
+pub trait Susp: Send + Sync {
+    /// Request the SBI implementation to put the system transitions to a sleep state.
+    ///
+    /// A return from a `system_suspend()` call implies an error and an error code
+    /// will be in `sbiret.error`. A successful suspend and wake up, results in the
+    /// hart which initiated the suspend, resuming from the `STOPPED` state. To resume,
+    /// the hart will jump to supervisor-mode, at the address specified by `resume_addr`,
+    /// with the specific register values described in the table below.
+    ///
+    /// | Register Name                                     | Register Value     
+    /// | ------------------------------------------------- | ------------------
+    /// | satp                                              | 0                  
+    /// | sstatus.SIE                                       | 0                  
+    /// | a0                                                | hartid             
+    /// | a1                                                | `opaque` parameter
+    /// All other registers remain in an undefined state.
+    ///
+    /// # Parameters
+    ///
+    /// The `resume_addr` parameter points to a runtime-specified physical address,
+    /// where the hart can resume execution in supervisor-mode after a system suspend.
+    ///
+    /// *NOTE:* A single `usize` parameter is sufficient as `resume_addr`,
+    /// because the hart will resume execution in supervisor-mode with the MMU off,
+    /// hence `resume_addr` must be less than XLEN bits wide.
+    ///
+    /// The `opaque` parameter is an XLEN-bit value which will be set in the `a1`
+    /// register when the hart resumes exectution at `resume_addr` after a
+    /// system suspend.
+    ///
+    /// Besides ensuring all entry criteria for the selected sleep type are met, such
+    /// as ensuring other harts are in the `STOPPED` state, the caller must ensure all
+    /// power units and domains are in a state compatible with the selected sleep type.
+    /// The preparation of the power units, power domains, and wake-up devices used for
+    /// resumption from the system sleep state is platform specific and beyond the
+    /// scope of this specification.
+    ///
+    /// When supervisor software is running inside a virtual machine, the SBI
+    /// implementation is provided by a hypervisor. The system suspend will behave
+    /// functionally the same as the native case, but might not result in any physical
+    /// power changes.
+    ///
+    /// # Return value
+    ///
+    /// The possible return error codes returned in `SbiRet.error` are shown in the table below:
+    ///
+    /// | Error code              | Description
+    /// | ----------------------- | -----------------------
+    /// | SBI_SUCCESS             | System has suspended and resumed successfully.        
+    /// | SBI_ERR_INVALID_PARAM   | `sleep_type` is reserved or is platform-specific and unimplemented.
+    /// | SBI_ERR_NOT_SUPPORTED   | `sleep_type` is not reserved and is implemented, but the platform does not support it due to one or more missing dependencies.
+    /// | SBI_ERR_INVALID_ADDRESS | `resume_addr` is not valid, possibly due to the following reasons: * It is not a valid physical address. * Executable access to the address is prohibited by a physical memory protection mechanism or H-extension G-stage for supervisor mode.
+    /// | SBI_ERR_FAILED          | The suspend request failed for unspecified or unknown other reasons.
+    fn system_suspend(&self, sleep_type: u32, resume_addr: usize, opaque: usize) -> SbiRet;
+}
+
+impl<T: Susp> Susp for &T {
+    #[inline]
+    fn system_suspend(&self, sleep_type: u32, resume_addr: usize, opaque: usize) -> SbiRet {
+        T::system_suspend(self, sleep_type, resume_addr, opaque)
+    }
+}

--- a/src/susp.rs
+++ b/src/susp.rs
@@ -70,13 +70,13 @@ pub trait Susp: Send + Sync {
     ///
     /// The possible return error codes returned in `SbiRet.error` are shown in the table below:
     ///
-    /// | Error code              | Description
-    /// | ----------------------- | -----------------------
-    /// | SBI_SUCCESS             | System has suspended and resumed successfully.        
-    /// | SBI_ERR_INVALID_PARAM   | `sleep_type` is reserved or is platform-specific and unimplemented.
-    /// | SBI_ERR_NOT_SUPPORTED   | `sleep_type` is not reserved and is implemented, but the platform does not support it due to one or more missing dependencies.
-    /// | SBI_ERR_INVALID_ADDRESS | `resume_addr` is not valid, possibly due to the following reasons: * It is not a valid physical address. * Executable access to the address is prohibited by a physical memory protection mechanism or H-extension G-stage for supervisor mode.
-    /// | SBI_ERR_FAILED          | The suspend request failed for unspecified or unknown other reasons.
+    /// | Error code                  | Description  
+    /// | --------------------------- | -------------------
+    /// | `SbiRet::success()`         | System has suspended and resumed successfully.
+    /// | `SbiRet::invalid_param()`   | `sleep_type` is reserved or is platform-specific and unimplemented.
+    /// | `SbiRet::not_supported()`   | `sleep_type` is not reserved and is implemented, but the platform does not support it due to one or more missing dependencies.
+    /// | `SbiRet::invalid_address()` | `resume_addr` is not valid, possibly due to the following reasons: * It is not a valid physical address. * Executable access to the address is prohibited by a physical memory protection mechanism or H-extension G-stage for supervisor mode.
+    /// | `SbiRet::failed()`          | The suspend request failed for unspecified or unknown other reasons. 
     fn system_suspend(&self, sleep_type: u32, resume_addr: usize, opaque: usize) -> SbiRet;
 }
 

--- a/src/susp.rs
+++ b/src/susp.rs
@@ -76,7 +76,7 @@ pub trait Susp: Send + Sync {
     /// | `SbiRet::invalid_param()`   | `sleep_type` is reserved or is platform-specific and unimplemented.
     /// | `SbiRet::not_supported()`   | `sleep_type` is not reserved and is implemented, but the platform does not support it due to one or more missing dependencies.
     /// | `SbiRet::invalid_address()` | `resume_addr` is not valid, possibly due to the following reasons: * It is not a valid physical address. * Executable access to the address is prohibited by a physical memory protection mechanism or H-extension G-stage for supervisor mode.
-    /// | `SbiRet::failed()`          | The suspend request failed for unspecified or unknown other reasons. 
+    /// | `SbiRet::failed()`          | The suspend request failed for unspecified or unknown other reasons.
     fn system_suspend(&self, sleep_type: u32, resume_addr: usize, opaque: usize) -> SbiRet;
 }
 


### PR DESCRIPTION
Add support for System Suspend extension and CPPC extension. 

Renference: 
https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/riscv-sbi.adoc#sbi-system-suspend-extension-eid-0x53555350-susp
https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/riscv-sbi.adoc#cppc-extension-eid-0x43505043-cppc