### PR TITLE
lib: dynamic #[derive(RustSBI)] implementation

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -350,18 +350,7 @@ fn impl_derive_rustsbi_static(name: &Ident, imp: StaticImpl, generics: &Generics
 
 fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generics) -> TokenStream {
     let mut fence_contents = quote! {};
-    let mut prober_ipi = quote! {};
     let mut prober_fence = quote! {};
-    let mut prober_timer = quote! {};
-    let mut prober_base = quote! {};
-    let mut prober_reset = quote! {};
-    let mut prober_hsm = quote! {};
-    let mut prober_pmu = quote! {};
-    let mut prober_console = quote! {};
-    let mut prober_susp = quote! {};
-    let mut prober_cppc = quote! {};
-    let mut prober_nacl = quote! {};
-    let mut prober_sta = quote! {};
     for fence in &imp.fence {
         fence_contents.extend(quote! {
             if ::rustsbi::_rustsbi_fence_probe(&self.#fence) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -376,6 +365,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut timer_contents = quote! {};
+    let mut prober_timer = quote! {};
     for timer in &imp.timer {
         timer_contents.extend(quote! {
             if ::rustsbi::_rustsbi_timer_probe(&self.#timer) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -390,6 +380,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut ipi_contents = quote! {};
+    let mut prober_ipi = quote! {};
     for ipi in &imp.ipi {
         ipi_contents.extend(quote! {
             if ::rustsbi::_rustsbi_ipi_probe(&self.#ipi) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -404,6 +395,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut hsm_contents = quote! {};
+    let mut prober_hsm = quote! {};
     for hsm in &imp.hsm {
         hsm_contents.extend(quote! {
             if ::rustsbi::_rustsbi_hsm_probe(&self.#hsm) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -418,6 +410,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut reset_contents = quote! {};
+    let mut prober_reset = quote! {};
     for reset in &imp.reset {
         reset_contents.extend(quote! {
             if ::rustsbi::_rustsbi_reset_probe(&self.#reset) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -432,6 +425,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut pmu_contents = quote! {};
+    let mut prober_pmu = quote! {};
     for pmu in &imp.pmu {
         pmu_contents.extend(quote! {
             if ::rustsbi::_rustsbi_pmu_probe(&self.#pmu) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -446,6 +440,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut console_contents = quote! {};
+    let mut prober_console = quote! {};
     for console in &imp.console {
         console_contents.extend(quote! {
             if ::rustsbi::_rustsbi_console_probe(&self.#console) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -460,6 +455,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut susp_contents = quote! {};
+    let mut prober_susp = quote! {};
     for susp in &imp.susp {
         susp_contents.extend(quote! {
             if ::rustsbi::_rustsbi_susp_probe(&self.#susp) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -474,6 +470,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut cppc_contents = quote! {};
+    let mut prober_cppc = quote! {};
     for cppc in &imp.cppc {
         cppc_contents.extend(quote! {
             if ::rustsbi::_rustsbi_cppc_probe(&self.#cppc) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -488,6 +485,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut nacl_contents = quote! {};
+    let mut prober_nacl = quote! {};
     for nacl in &imp.nacl {
         nacl_contents.extend(quote! {
             if ::rustsbi::_rustsbi_nacl_probe(&self.#nacl) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -502,6 +500,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
         });
     }
     let mut sta_contents = quote! {};
+    let mut prober_sta = quote! {};
     for sta in &imp.sta {
         sta_contents.extend(quote! {
             if ::rustsbi::_rustsbi_sta_probe(&self.#sta) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -522,7 +521,7 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             #[inline(always)]
             fn probe_extension(&self, extension: usize) -> usize {
                 match extension {
-                    ::rustsbi::spec::base::EID_BASE => { #prober_base ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::base::EID_BASE => 1,
                     ::rustsbi::spec::time::EID_TIME => { #prober_timer ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
                     ::rustsbi::spec::spi::EID_SPI => { #prober_ipi ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
                     ::rustsbi::spec::rfnc::EID_RFNC => { #prober_fence ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -350,7 +350,18 @@ fn impl_derive_rustsbi_static(name: &Ident, imp: StaticImpl, generics: &Generics
 
 fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generics) -> TokenStream {
     let mut fence_contents = quote! {};
+    let mut prober_ipi = quote! {};
     let mut prober_fence = quote! {};
+    let mut prober_timer = quote! {};
+    let mut prober_base = quote! {};
+    let mut prober_reset = quote! {};
+    let mut prober_hsm = quote! {};
+    let mut prober_pmu = quote! {};
+    let mut prober_console = quote! {};
+    let mut prober_susp = quote! {};
+    let mut prober_cppc = quote! {};
+    let mut prober_nacl = quote! {};
+    let mut prober_sta = quote! {};
     for fence in &imp.fence {
         fence_contents.extend(quote! {
             if ::rustsbi::_rustsbi_fence_probe(&self.#fence) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
@@ -370,7 +381,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_timer_probe(&self.#timer) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_timer(&self.#timer, param, function)
             }
-        })
+        });
+        prober_timer.extend(quote! {
+            let value = ::rustsbi::_rustsbi_timer_probe(&self.0.#timer);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut ipi_contents = quote! {};
     for ipi in &imp.ipi {
@@ -378,7 +395,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_ipi_probe(&self.#ipi) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_ipi(&self.#ipi, param, function)
             }
-        })
+        });
+        prober_ipi.extend(quote! {
+            let value = ::rustsbi::_rustsbi_ipi_probe(&self.0.#ipi);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut hsm_contents = quote! {};
     for hsm in &imp.hsm {
@@ -386,7 +409,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_hsm_probe(&self.#hsm) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_hsm(&self.#hsm, param, function)
             }
-        })
+        });
+        prober_hsm.extend(quote! {
+            let value = ::rustsbi::_rustsbi_hsm_probe(&self.0.#hsm);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut reset_contents = quote! {};
     for reset in &imp.reset {
@@ -394,7 +423,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_reset_probe(&self.#reset) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_reset(&self.#reset, param, function)
             }
-        })
+        });
+        prober_reset.extend(quote! {
+            let value = ::rustsbi::_rustsbi_reset_probe(&self.0.#reset);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut pmu_contents = quote! {};
     for pmu in &imp.pmu {
@@ -402,7 +437,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_pmu_probe(&self.#pmu) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_pmu(&self.#pmu, param, function)
             }
-        })
+        });
+        prober_pmu.extend(quote! {
+            let value = ::rustsbi::_rustsbi_pmu_probe(&self.0.#pmu);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut console_contents = quote! {};
     for console in &imp.console {
@@ -410,7 +451,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_console_probe(&self.#console) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_console(&self.#console, param, function)
             }
-        })
+        });
+        prober_console.extend(quote! {
+            let value = ::rustsbi::_rustsbi_console_probe(&self.0.#console);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut susp_contents = quote! {};
     for susp in &imp.susp {
@@ -418,7 +465,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_susp_probe(&self.#susp) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_susp(&self.#susp, param, function)
             }
-        })
+        });
+        prober_susp.extend(quote! {
+            let value = ::rustsbi::_rustsbi_susp_probe(&self.0.#susp);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut cppc_contents = quote! {};
     for cppc in &imp.cppc {
@@ -426,7 +479,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_cppc_probe(&self.#cppc) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_cppc(&self.#cppc, param, function)
             }
-        })
+        });
+        prober_cppc.extend(quote! {
+            let value = ::rustsbi::_rustsbi_cppc_probe(&self.0.#cppc);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut nacl_contents = quote! {};
     for nacl in &imp.nacl {
@@ -434,7 +493,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_nacl_probe(&self.#nacl) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_nacl(&self.#nacl, param, function)
             }
-        })
+        });
+        prober_nacl.extend(quote! {
+            let value = ::rustsbi::_rustsbi_nacl_probe(&self.0.#nacl);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
     let mut sta_contents = quote! {};
     for sta in &imp.sta {
@@ -442,7 +507,13 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             if ::rustsbi::_rustsbi_sta_probe(&self.#sta) != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
                 return ::rustsbi::_rustsbi_sta(&self.#sta, param, function)
             }
-        })
+        });
+        prober_sta.extend(quote! {
+            let value = ::rustsbi::_rustsbi_sta_probe(&self.0.#sta);
+            if value != ::rustsbi::spec::base::UNAVAILABLE_EXTENSION {
+                return value
+            }
+        });
     }
 
     let define_prober = quote! {
@@ -451,18 +522,18 @@ fn impl_derive_rustsbi_dynamic(name: &Ident, imp: DynamicImpl, generics: &Generi
             #[inline(always)]
             fn probe_extension(&self, extension: usize) -> usize {
                 match extension {
-                    // ::rustsbi::spec::base::EID_BASE => self.base,
-                    // ::rustsbi::spec::time::EID_TIME => self.timer,
-                    // ::rustsbi::spec::spi::EID_SPI => self.ipi,
+                    ::rustsbi::spec::base::EID_BASE => { #prober_base ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::time::EID_TIME => { #prober_timer ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::spi::EID_SPI => { #prober_ipi ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
                     ::rustsbi::spec::rfnc::EID_RFNC => { #prober_fence ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
-                    // ::rustsbi::spec::srst::EID_SRST => self.reset,
-                    // ::rustsbi::spec::hsm::EID_HSM => self.hsm,
-                    // ::rustsbi::spec::pmu::EID_PMU => self.pmu,
-                    // ::rustsbi::spec::dbcn::EID_DBCN => self.console,
-                    // ::rustsbi::spec::susp::EID_SUSP => self.susp,
-                    // ::rustsbi::spec::cppc::EID_CPPC => self.cppc,
-                    // ::rustsbi::spec::nacl::EID_NACL => self.nacl,
-                    // ::rustsbi::spec::sta::EID_STA => self.sta,
+                    ::rustsbi::spec::srst::EID_SRST => { #prober_reset ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::hsm::EID_HSM => { #prober_hsm ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::pmu::EID_PMU => { #prober_pmu ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::dbcn::EID_DBCN => { #prober_console ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::susp::EID_SUSP => { #prober_susp ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::cppc::EID_CPPC => { #prober_cppc ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::nacl::EID_NACL => { #prober_nacl ::rustsbi::spec::base::UNAVAILABLE_EXTENSION },
+                    ::rustsbi::spec::sta::EID_STA => { #prober_sta ::rustsbi::spec::base::UNAVAILABLE_EXTENSION}
                     _ => ::rustsbi::spec::base::UNAVAILABLE_EXTENSION,
                 }
             }

--- a/src/console.rs
+++ b/src/console.rs
@@ -84,6 +84,12 @@ pub trait Console {
     /// | `SbiRet::success()`       | Byte written successfully.
     /// | `SbiRet::failed()`        | Failed to write the byte due to I/O errors.
     fn write_byte(&self, byte: u8) -> SbiRet;
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Console> Console for &T {

--- a/src/cppc.rs
+++ b/src/cppc.rs
@@ -113,6 +113,12 @@ pub trait Cppc {
     /// | `SbiRet::denied()`        | `reg_id` is a read-only register.
     /// | `SbiRet::failed()`        | The write-request failed for unspecified or unknown other reasons.
     fn write(&self, reg_id: u32, val: u64) -> SbiRet;
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Cppc> Cppc for &T {

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -201,6 +201,12 @@ pub trait Hsm {
         let _ = (suspend_type, resume_addr, opaque);
         SbiRet::not_supported()
     }
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Hsm> Hsm for &T {

--- a/src/ipi.rs
+++ b/src/ipi.rs
@@ -10,6 +10,12 @@ pub trait Ipi {
     ///
     /// Should return `SbiRet::success()` if IPI was sent to all the targeted harts successfully.
     fn send_ipi(&self, hart_mask: HartMask) -> SbiRet;
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Ipi> Ipi for &T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1063,7 +1063,13 @@ pub use traits::{EnvInfo, RustSBI};
 pub use traits::_rustsbi_base_bare;
 #[doc(hidden)]
 pub use traits::{
-    _StandardExtensionProbe, _rustsbi_base_env_info, _rustsbi_console, _rustsbi_cppc,
-    _rustsbi_fence, _rustsbi_hsm, _rustsbi_ipi, _rustsbi_nacl, _rustsbi_pmu, _rustsbi_reset,
-    _rustsbi_sta, _rustsbi_susp, _rustsbi_timer,
+    _ExtensionProbe, _StandardExtensionProbe, _rustsbi_base_env_info, _rustsbi_console,
+    _rustsbi_cppc, _rustsbi_fence, _rustsbi_hsm, _rustsbi_ipi, _rustsbi_nacl, _rustsbi_pmu,
+    _rustsbi_reset, _rustsbi_sta, _rustsbi_susp, _rustsbi_timer,
+};
+#[doc(hidden)]
+pub use traits::{
+    _rustsbi_console_probe, _rustsbi_cppc_probe, _rustsbi_fence_probe, _rustsbi_hsm_probe,
+    _rustsbi_ipi_probe, _rustsbi_nacl_probe, _rustsbi_pmu_probe, _rustsbi_reset_probe,
+    _rustsbi_sta_probe, _rustsbi_susp_probe, _rustsbi_timer_probe,
 };

--- a/src/nacl.rs
+++ b/src/nacl.rs
@@ -141,6 +141,12 @@ pub trait Nacl {
     /// | `SbiRet::not_supported()` | SBI_NACL_FEAT_SYNC_SRET feature is not available.
     /// | `SbiRet::no_shmem()`      | Nested acceleration shared memory not available.
     fn sync_sret(&self) -> SbiRet;
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Nacl> Nacl for &T {

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -224,6 +224,12 @@ pub trait Pmu {
             }
         }
     }
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Pmu> Pmu for &T {

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -41,6 +41,12 @@ pub trait Reset {
     /// | `SbiRet::not_supported()` | `reset_type` is valid but not implemented.
     /// | `SbiRet::failed()`        | Reset request failed for unknown reasons.
     fn system_reset(&self, reset_type: u32, reset_reason: u32) -> SbiRet;
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Reset> Reset for &T {

--- a/src/sta.rs
+++ b/src/sta.rs
@@ -57,6 +57,12 @@ pub trait Sta {
     /// | `SbiRet::invalid_address()` | The shared memory pointed to by the `shmem` parameter is not writable or does not satisfy other requirements of shared memory physical address range.
     /// | `SbiRet::failed()`          | The request failed for unspecified or unknown other reasons.
     fn set_shmem(&self, shmem: SharedPtr<[u8; 64]>, flags: usize) -> SbiRet;
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Sta> Sta for &T {

--- a/src/susp.rs
+++ b/src/susp.rs
@@ -84,6 +84,12 @@ pub trait Susp {
     /// | `SbiRet::failed()`
     /// | The suspend request failed for unspecified or unknown other reasons.
     fn system_suspend(&self, sleep_type: u32, resume_addr: usize, opaque: usize) -> SbiRet;
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Susp> Susp for &T {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -8,6 +8,12 @@ pub trait Timer {
     /// it can either request a timer interrupt infinitely far into the future (i.e., (uint64_t)-1),
     /// or it can instead mask the timer interrupt by clearing `sie.STIE` CSR bit.
     fn set_timer(&self, stime_value: u64);
+    /// Function internal to macros. Do not use.
+    #[doc(hidden)]
+    #[inline]
+    fn _rustsbi_probe(&self) -> usize {
+        sbi_spec::base::UNAVAILABLE_EXTENSION.wrapping_add(1)
+    }
 }
 
 impl<T: Timer> Timer for &T {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -392,3 +392,69 @@ pub fn _rustsbi_sta<T: crate::Sta>(sta: &T, param: [usize; 6], function: usize) 
 const fn concat_u32(h: usize, l: usize) -> u64 {
     ((h as u64) << 32) | (l as u64)
 }
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_fence_probe<T: crate::Fence>(fence: &T) -> usize {
+    fence._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_timer_probe<T: crate::Timer>(timer: &T) -> usize {
+    timer._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_ipi_probe<T: crate::Ipi>(ipi: &T) -> usize {
+    ipi._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_hsm_probe<T: crate::Hsm>(hsm: &T) -> usize {
+    hsm._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_reset_probe<T: crate::Reset>(reset: &T) -> usize {
+    reset._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_pmu_probe<T: crate::Pmu>(pmu: &T) -> usize {
+    pmu._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_console_probe<T: crate::Console>(console: &T) -> usize {
+    console._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_susp_probe<T: crate::Susp>(susp: &T) -> usize {
+    susp._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_cppc_probe<T: crate::Cppc>(cppc: &T) -> usize {
+    cppc._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_nacl_probe<T: crate::Nacl>(nacl: &T) -> usize {
+    nacl._rustsbi_probe()
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _rustsbi_sta_probe<T: crate::Sta>(sta: &T) -> usize {
+    sta._rustsbi_probe()
+}

--- a/tests/build-rename.rs
+++ b/tests/build-rename.rs
@@ -136,6 +136,7 @@ impl rustsbi::EnvInfo for DummyEnvInfo {
     }
 }
 
+#[allow(unused)] // FIXME: hot fix, use it on unit test in the future.
 struct RealEnvInfo;
 
 impl rustsbi::EnvInfo for RealEnvInfo {

--- a/tests/dynamic-priority.rs
+++ b/tests/dynamic-priority.rs
@@ -1,0 +1,91 @@
+use rustsbi::{RustSBI, SbiRet};
+use sbi_spec::rfnc::EID_RFNC;
+
+#[derive(RustSBI)]
+#[rustsbi(dynamic)]
+struct MultipleFences {
+    #[rustsbi(fence)]
+    fence_one: Option<FenceOne>,
+    #[rustsbi(fence)]
+    fence_two: Option<FenceTwo>,
+    env_info: DummyEnvInfo,
+}
+
+struct FenceOne;
+
+impl rustsbi::Fence for FenceOne {
+    fn remote_fence_i(&self, _: rustsbi::HartMask) -> SbiRet {
+        SbiRet::success(1)
+    }
+
+    fn remote_sfence_vma(&self, _: rustsbi::HartMask, _: usize, _: usize) -> SbiRet {
+        SbiRet::success(2)
+    }
+
+    fn remote_sfence_vma_asid(&self, _: rustsbi::HartMask, _: usize, _: usize, _: usize) -> SbiRet {
+        SbiRet::success(3)
+    }
+}
+
+struct FenceTwo;
+
+impl rustsbi::Fence for FenceTwo {
+    fn remote_fence_i(&self, _: rustsbi::HartMask) -> SbiRet {
+        SbiRet::success(4)
+    }
+
+    fn remote_sfence_vma(&self, _: rustsbi::HartMask, _: usize, _: usize) -> SbiRet {
+        SbiRet::success(5)
+    }
+
+    fn remote_sfence_vma_asid(&self, _: rustsbi::HartMask, _: usize, _: usize, _: usize) -> SbiRet {
+        SbiRet::success(6)
+    }
+}
+
+#[test]
+fn priority() {
+    let sbi = MultipleFences {
+        fence_one: Some(FenceOne),
+        fence_two: None,
+        env_info: DummyEnvInfo,
+    };
+    assert_eq!(sbi.handle_ecall(EID_RFNC, 0x0, [0; 6]), SbiRet::success(1));
+    let sbi = MultipleFences {
+        fence_one: None,
+        fence_two: Some(FenceTwo),
+        env_info: DummyEnvInfo,
+    };
+    assert_eq!(sbi.handle_ecall(EID_RFNC, 0x0, [0; 6]), SbiRet::success(4));
+    let sbi = MultipleFences {
+        fence_one: Some(FenceOne),
+        fence_two: Some(FenceTwo),
+        env_info: DummyEnvInfo,
+    };
+    assert_eq!(sbi.handle_ecall(EID_RFNC, 0x0, [0; 6]), SbiRet::success(1));
+    let sbi = MultipleFences {
+        fence_one: None,
+        fence_two: None,
+        env_info: DummyEnvInfo,
+    };
+    assert_eq!(
+        sbi.handle_ecall(EID_RFNC, 0x0, [0; 6]),
+        SbiRet::not_supported()
+    );
+}
+
+struct DummyEnvInfo;
+
+impl rustsbi::EnvInfo for DummyEnvInfo {
+    fn mvendorid(&self) -> usize {
+        36
+    }
+
+    fn marchid(&self) -> usize {
+        37
+    }
+
+    fn mimpid(&self) -> usize {
+        38
+    }
+}

--- a/tests/forward-struct.rs
+++ b/tests/forward-struct.rs
@@ -2,6 +2,7 @@ use rustsbi::{Forward, RustSBI};
 
 // The `Forward` structure must build
 
+#[allow(unused)] // FIXME: hot fix, use it on unit test in the future.
 #[derive(RustSBI)]
 struct ForwardAll {
     #[rustsbi(


### PR DESCRIPTION
Previously, The `#[derive(RustSBI)]` macros only provides implementation with statically known implementation for each extensions. It allows generating RustSBI implementations on a fixed peripheral board, but it cannot select one among multiple implementations based on dynamic detection results. To support SBI implementations that dynamically scan the hardware of the board (such as FDT-based boards or firmware similar to `fw_dynamic`), we need to design a dynamic capable RustSBI macro implementation.

The dynamic `#[derive(RustSBI)]` implementation is generated by using `#[rustsbi(dynamic)]`. For example:

```rust
#[derive(RustSBI)]
#[rustsbi(dynamic)]
struct MultipleFences {
    #[rustsbi(fence)]
    fence_one: Option<FenceOne>,
    #[rustsbi(fence)]
    fence_two: Option<FenceTwo>,
    // other fields ...
}
```

In this example, dynamic RustSBI chooses between two RISC-V SBI fence implementation `fence_one` and `fence_two`:
- If `fence_one` matches `Some(_)`, RustSBI uses `fence_one` as SBI fence implementation;
- Then, `fence_two` is used as the fence implementation if it exists;
- RustSBI only returns `SbiRet::not_supported()` when both the two fences match `None`.

By this way, RustSBI is now capable of implementing firmware on boards with peripherals that cannot be known on compile time. By supporting dynamic firmware, the application scenarios of RustSBI will be expanded.

Contributors to this pull request: special thanks to DongQing (@Placebo27) for contributions on this pull request.