### PR TITLE
fix: derive dynamic RustSBI on struct with generics(type, const, lifetime, where clause)

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,6 +21,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0.33"
 syn = "2.0.39"
+proc-macro2 = "1.0.82"
 
 [features]
 default = []

--- a/tests/dynamic-generics.rs
+++ b/tests/dynamic-generics.rs
@@ -1,0 +1,111 @@
+use rustsbi::RustSBI;
+use sbi_spec::binary::SbiRet;
+
+// These structs should pass Rust build.
+
+#[derive(RustSBI)]
+#[rustsbi(dynamic)]
+struct WithGenerics<T: rustsbi::Timer> {
+    reset: DummyReset,
+    timer: T,
+    info: DummyEnvInfo,
+}
+
+#[derive(RustSBI)]
+#[rustsbi(dynamic)]
+struct WithWhereClause<T>
+where
+    T: rustsbi::Timer,
+{
+    reset: DummyReset,
+    timer: T,
+    info: DummyEnvInfo,
+}
+
+#[derive(RustSBI)]
+#[rustsbi(dynamic)]
+struct WithConstantGenerics<const N: usize> {
+    info: DummyEnvInfo,
+    _dummy: [u8; N],
+}
+
+#[derive(RustSBI)]
+#[rustsbi(dynamic)]
+struct WithLifetime<'a> {
+    info: &'a DummyEnvInfo,
+}
+
+#[derive(RustSBI)]
+#[rustsbi(dynamic)]
+struct WithEverythingCombined<'a, T: rustsbi::Timer, U, const N: usize>
+where
+    U: rustsbi::Reset,
+{
+    timer: T,
+    reset: U,
+    info: &'a DummyEnvInfo,
+    _dummy: [u8; N],
+}
+
+#[test]
+fn test_impl_id() {
+    let sbi = WithGenerics {
+        reset: DummyReset,
+        timer: DummyTimer,
+        info: DummyEnvInfo,
+    };
+    assert_eq!(sbi.handle_ecall(0x10, 0x1, [0; 6]).value, 4);
+    let sbi = WithWhereClause {
+        reset: DummyReset,
+        timer: DummyTimer,
+        info: DummyEnvInfo,
+    };
+    assert_eq!(sbi.handle_ecall(0x10, 0x1, [0; 6]).value, 4);
+    let sbi = WithConstantGenerics {
+        info: DummyEnvInfo,
+        _dummy: [0; 100],
+    };
+    assert_eq!(sbi.handle_ecall(0x10, 0x1, [0; 6]).value, 4);
+    let dummy_info = DummyEnvInfo;
+    let sbi = WithLifetime { info: &dummy_info };
+    assert_eq!(sbi.handle_ecall(0x10, 0x1, [0; 6]).value, 4);
+    let sbi = WithEverythingCombined {
+        timer: DummyTimer,
+        reset: DummyReset,
+        info: &dummy_info,
+        _dummy: [0; 10],
+    };
+    assert_eq!(sbi.handle_ecall(0x10, 0x1, [0; 6]).value, 4);
+}
+
+struct DummyReset;
+
+impl rustsbi::Reset for DummyReset {
+    fn system_reset(&self, _: u32, _: u32) -> SbiRet {
+        unimplemented!()
+    }
+}
+
+struct DummyTimer;
+
+impl rustsbi::Timer for DummyTimer {
+    fn set_timer(&self, _: u64) {
+        unimplemented!()
+    }
+}
+
+struct DummyEnvInfo;
+
+impl rustsbi::EnvInfo for DummyEnvInfo {
+    fn mvendorid(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn marchid(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn mimpid(&self) -> usize {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
In PR #67 , a RustSBI macro implementation that can be processed dynamically has been added. 

But the current implementation has some problems. Take the following struct as an example.
``` rust
#[derive(RustSBI)]
#[rustsbi(dynamic)]
struct WithLifetime<'a> {
    info: &'a DummyEnvInfo,
}
```
The macro code cannot compile this struct because its `strcut prober` struct does not handle lifetime situations. In fact, all generics are not handled, including lifetime, type generics, constant generics, and where clauses. These problems limit the application of `rustsbi dynamic` in actual projects.

This pull request solves the problem of generics not being processed. The definition of `struct _Prober` is extended to include generics, which is composed of impl generics, type generics and where clause. We add them to the generated code of `struct _Prober`, thus solving the problem.
``` rust
struct _Prober #impl_generics (&'_lt #name #origin_ty_generics) #where_clause;
impl #impl_generics ::rustsbi::_ExtensionProbe for _Prober #ty_generics #where_clause 
```
Until now,`rustsbi dynamic` can be used for struct with lifetime, and its application scope will be expanded.

In order to verify the effectiveness of this modification, an additional unit test module(`tests/dynamic-generics.rs`) has been added. All structures in this unit test file contain different types of generics to comprehensively test the correctness of the macro generated code, thereby verifying the repair results of this pull request.