### PR TITLE
docs: add instructions for derive macro dynamic implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -866,6 +866,44 @@ pub use sbi_spec::binary::{HartMask, Physical, SbiRet, SharedPtr};
 /// # }
 /// ```
 ///
+/// When using the `#[rustsbi(dynamic)]` attribute, it is possible to include multiple
+/// fields that indicate the same SBI extension.
+///
+/// ```rust
+/// # use rustsbi::RustSBI;
+/// #[derive(RustSBI)]
+/// #[rustsbi(dynamic)]
+/// struct MySBI {
+///     // Fields in `#[rustsbi(dynamic)]` structures are usually wrapped in `Option`s.
+///     fence: Option<MyFence>,
+///     rfnc: Option<MyFence>,
+///     // ^ Both the two fields are identified as `rustsbi::Fence` implementation.
+///     info: MyEnvInfo,
+///     // ^ However, environment information should only be introduced *once*.
+/// }
+///
+/// // RustSBI will sequentially examine these fields, starting from the first one.
+/// // Upon encountering the first `Option` that is `Some`, it will utilize this
+/// // field as the implementation.
+/// // i.e., if the first field `fence` in `MySBI` is `Some`, RustSBI uses `fence`.
+/// // Else, if the second field `rfnc` is `Some`, RustSBI uses `rfnc`.
+/// // Otherwise, RustSBI returns `SbiRet::not_supported`.
+///
+/// # use sbi_spec::binary::{SbiRet, HartMask};
+/// # struct MyFence;
+/// # impl rustsbi::Fence for MyFence {
+/// #     fn remote_fence_i(&self, _: HartMask) -> SbiRet { unimplemented!() }
+/// #     fn remote_sfence_vma(&self, _: HartMask, _: usize, _: usize) -> SbiRet { unimplemented!() }
+/// #     fn remote_sfence_vma_asid(&self, _: HartMask, _: usize, _: usize, _: usize) -> SbiRet { unimplemented!() }
+/// # }
+/// # struct MyEnvInfo;
+/// # impl rustsbi::EnvInfo for MyEnvInfo {
+/// #     fn mvendorid(&self) -> usize { 1 }
+/// #     fn marchid(&self) -> usize { 2 }
+/// #     fn mimpid(&self) -> usize { 3 }
+/// # }
+/// ```
+///
 /// The struct as derive input may include generics, specifically type generics, lifetimes,
 /// constant generics and where clauses.
 ///


### PR DESCRIPTION
In PR #67 , #68 and #69 ,  the `#[rustsbi(dynamic)]` macro implementation can dynamically adapt extensions.
However, this section is not in the current documentation, which has been updated for completeness and to make it easier for readers to learn about the latest dynamic features. Now we can see the usage of the section and an example description in the documentation are as follow:
_**Usage**_
![image](https://github.com/rustsbi/rustsbi/assets/129254646/d88956eb-2840-47a9-b74b-79226f6da3de)
_**Example**_
![image](https://github.com/rustsbi/rustsbi/assets/129254646/5b775bb2-b4e1-40c5-8aed-2962ba92ff77)

This pull request add usage and an example for dynamic implementations to the Derive Macro documentation.

Contributors to this pull request: special thanks to @Plucky923 for contributions on this pull request.