### PR TITLE
spec: add chapter 4 sbi impl_id: Xen: 7 and PolarFire: 8

### DIFF
--- a/sbi-spec/src/base.rs
+++ b/sbi-spec/src/base.rs
@@ -95,4 +95,8 @@ pub mod impl_id {
     pub const DIOSIX: usize = 5;
     /// Coffer.
     pub const COFFER: usize = 6;
+    /// Xen Project
+    pub const XEN: usize = 7;
+    /// PolarFire Hart Software Services.
+    pub const POLARFIRE_HSS: usize = 8;
 }

--- a/sbi-spec/src/lib.rs
+++ b/sbi-spec/src/lib.rs
@@ -104,6 +104,8 @@ mod tests {
         const_assert_eq!(4, impl_id::RUST_SBI);
         const_assert_eq!(5, impl_id::DIOSIX);
         const_assert_eq!(6, impl_id::COFFER);
+        const_assert_eq!(7, impl_id::XEN);
+        const_assert_eq!(8, impl_id::POLARFIRE_HSS);
     }
     // §5
     #[cfg(feature = "legacy")]

--- a/sbi-testing/src/base.rs
+++ b/sbi-testing/src/base.rs
@@ -88,6 +88,8 @@ pub fn test(mut f: impl FnMut(Case)) {
         impl_id::RUST_SBI => Ok("RustSBI"),
         impl_id::DIOSIX => Ok("Diosix"),
         impl_id::COFFER => Ok("Coffer"),
+        impl_id::XEN => Ok("Xen Project"),
+        impl_id::POLARFIRE_HSS => Ok("PolarFire Hart Software Services"),
         unknown => Err(unknown),
     }));
     f(Case::GetSbiImplVersion(sbi::get_sbi_impl_version()));


### PR DESCRIPTION
翻阅sbi-spec源代码和最新版(version2.0 正式版)的sbi specification手册时发现impl_id缺少：Xen和Polarfire，于是随手添加上了它们并增加了对应的测试用例。
![image](https://github.com/rustsbi/rustsbi/assets/62140360/d56c9b6d-c0a1-4554-b6f5-f564d4baf42d)
