### PR TITLE
spec: add FWFT extension support to SBI implementation

### DIFF
--- a/sbi-spec/src/fwft.rs
+++ b/sbi-spec/src/fwft.rs
@@ -1,0 +1,17 @@
+//! Chapter 18. Firmware Features Extension (EID #0x46574654 "FWFT").
+
+/// Extension ID for Firmware Features Extension.
+pub const EID_FWFT: usize = crate::eid_from_str("FWFT") as _;
+pub use fid::*;
+
+/// Declared in §18.3.
+mod fid{
+    /// Set the firmware function of the request based on Value and Flags parameters.
+    ///
+    /// Declared in §18.1.
+    pub const SET: usize = 0;
+    /// Return to the firmware function configuration value.
+    ///
+    /// Declared in §18.2.
+    pub const GET: usize = 1;
+}

--- a/sbi-spec/src/lib.rs
+++ b/sbi-spec/src/lib.rs
@@ -46,6 +46,7 @@ pub mod cppc;
 pub mod nacl;
 // §16
 pub mod sta;
+pub mod fwft;
 
 /// Converts SBI EID from str.
 const fn eid_from_str(name: &str) -> i32 {
@@ -334,5 +335,13 @@ mod tests {
         use crate::sta::*;
         const_assert_eq!(0x535441, EID_STA);
         const_assert_eq!(0, SET_SHMEM);
+    }
+    // §18
+    #[test]
+    fn test_fwft(){
+        use crate::fwft::*;
+        const_assert_eq!(0x46574654, EID_FWFT);
+        const_assert_eq!(0,SET);
+        const_assert_eq!(1,GET);
     }
 }


### PR DESCRIPTION
This commit introduces support for the Firmware Feature (FWFT) extension as defined in the RISC-V SBI specification 3.0. It includes the implementation of `sbi_fwft_set` and `sbi_fwft_get` functions, along with their respective unit tests.

Signed-off-by: Longbing Zheng <1211998648@qq.com>