### PR TITLE
spec: add FWFT extension support to SBI implementation

### DIFF
--- a/sbi-spec/CHANGELOG.md
+++ b/sbi-spec/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+
 - pmu: add config flags with bitflags in chapter 11
+- fwft: add support for FWFT extension in chapter 18
 
 ### Modified
 

--- a/sbi-spec/src/fwft.rs
+++ b/sbi-spec/src/fwft.rs
@@ -1,0 +1,17 @@
+//! Chapter 18. Firmware Features Extension (EID #0x46574654 "FWFT").
+
+/// Extension ID for Firmware Features Extension.
+pub const EID_FWFT: usize = crate::eid_from_str("FWFT") as _;
+pub use fid::*;
+
+/// Declared in §18.3.
+mod fid {
+    /// Set the firmware function of the request based on Value and Flags parameters.
+    ///
+    /// Declared in §18.1.
+    pub const SET: usize = 0;
+    /// Return to the firmware function configuration value.
+    ///
+    /// Declared in §18.2.
+    pub const GET: usize = 1;
+}

--- a/sbi-spec/src/lib.rs
+++ b/sbi-spec/src/lib.rs
@@ -46,7 +46,8 @@ pub mod cppc;
 pub mod nacl;
 // §16
 pub mod sta;
-
+// §18
+pub mod fwft;
 /// Converts SBI EID from str.
 const fn eid_from_str(name: &str) -> i32 {
     match *name.as_bytes() {
@@ -334,5 +335,13 @@ mod tests {
         use crate::sta::*;
         const_assert_eq!(0x535441, EID_STA);
         const_assert_eq!(0, SET_SHMEM);
+    }
+    // §18
+    #[test]
+    fn test_fwft() {
+        use crate::fwft::*;
+        const_assert_eq!(0x46574654, EID_FWFT);
+        const_assert_eq!(0, SET);
+        const_assert_eq!(1, GET);
     }
 }


### PR DESCRIPTION
This commit introduces the necessary constants for Extension ID (EID) and Function ID (FID) associated with the Firmware Features Table (FWFT) extension, as per the RISC-V SBI specification. Documentation for these constants has also been updated to facilitate better understanding and usage.

Signed-off-by: Longbing Zheng <1211998648@qq.com>