### PR TITLE
spec: add func ids for SSE extension in SBI implementation

### DIFF
--- a/sbi-spec/CHANGELOG.md
+++ b/sbi-spec/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - pmu: add config flags with bitflags in chapter 11
 - fwft: add support for FWFT extension in chapter 18
+- sse: add support for Supervisor Software Events Extension in chapter 17
 
 ### Modified
 

--- a/sbi-spec/src/lib.rs
+++ b/sbi-spec/src/lib.rs
@@ -46,6 +46,8 @@ pub mod cppc;
 pub mod nacl;
 // §16
 pub mod sta;
+// §17
+pub mod sse;
 // §18
 pub mod fwft;
 /// Converts SBI EID from str.
@@ -335,6 +337,22 @@ mod tests {
         use crate::sta::*;
         const_assert_eq!(0x535441, EID_STA);
         const_assert_eq!(0, SET_SHMEM);
+    }
+    // §17
+    #[test]
+    fn test_sse() {
+        use crate::sse::*;
+        const_assert_eq!(0x535345, EID_SSE);
+        const_assert_eq!(0, READ_ATTRS);
+        const_assert_eq!(1, WRITE_ATTRS);
+        const_assert_eq!(2, REGISTER);
+        const_assert_eq!(3, UNREGISTER);
+        const_assert_eq!(4, ENABLE);
+        const_assert_eq!(5, DISABLE);
+        const_assert_eq!(6, COMPLETE);
+        const_assert_eq!(7, INJECT);
+        const_assert_eq!(8, HART_UNMASK);
+        const_assert_eq!(9, HART_MASK);
     }
     // §18
     #[test]

--- a/sbi-spec/src/sse.rs
+++ b/sbi-spec/src/sse.rs
@@ -1,0 +1,49 @@
+//! Chapter 17. Supervisor Software Events Extension (EID #0x535345 "SSE").
+
+/// Extension ID for Supervisor Software Events Extension.
+pub const EID_SSE: usize = crate::eid_from_str("SSE") as _;
+pub use fid::*;
+
+/// Declared in Table 90 at §17.17.
+mod fid {
+    /// Function ID to read software event attributes.
+    ///
+    /// Declared in §17.7
+    pub const READ_ATTRS: usize = 0;
+    /// Function ID to write software event attributes.
+    ///
+    /// Declared in §17.8
+    pub const WRITE_ATTRS: usize = 1;
+    /// Function ID to register a software event.
+    ///
+    /// Declared in §17.9.
+    pub const REGISTER: usize = 2;
+    /// Function ID to unregister a software event.
+    ///
+    /// Declared in §17.10.
+    pub const UNREGISTER: usize = 3;
+    /// Function ID to enable a software event.
+    ///
+    /// Declared in §17.11.
+    pub const ENABLE: usize = 4;
+    /// Function ID to disable a software event.
+    ///
+    /// Declared in §17.12.
+    pub const DISABLE: usize = 5;
+    /// Function ID to complete software event handling.
+    ///
+    /// Declared in §17.13.
+    pub const COMPLETE: usize = 6;
+    /// Function ID to inject a software event.
+    ///
+    /// Declared in §17.14.
+    pub const INJECT: usize = 7;
+    /// Function ID to unmask software events on the calling hart.
+    ///
+    /// Declared in §17.15.
+    pub const HART_UNMASK: usize = 8;
+    /// Function ID to mask software events on the calling hart.
+    ///
+    /// Declared in §17.16.
+    pub const HART_MASK: usize = 9;
+}


### PR DESCRIPTION
Introduced the necessary constants for Function IDs (FID) associated with the Supervisor Software Events (SSE) extension. Updated documentation to facilitate better understanding and usage of these new constants. For more details, please refer to the corresponding RISC-V SBI specification section for the SSE extension [here](https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/src/ext-sse.adoc).