### PR TITLE
spec: add some methods for HartMask

### DIFF
--- a/sbi-spec/src/binary.rs
+++ b/sbi-spec/src/binary.rs
@@ -900,6 +900,7 @@ impl HartMask {
 impl Iterator for HartMaskIter {
     type Item = usize;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let non_visited_mask = (!self.visited_mask) & (self.inner.hart_mask);
         if non_visited_mask == 0 {

--- a/sbi-spec/src/binary.rs
+++ b/sbi-spec/src/binary.rs
@@ -806,7 +806,7 @@ pub struct HartMask {
 
 /// Iteration for HartMask, from low to high.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct HartMaskIter {
+pub struct HartIds {
     inner: HartMask,
     visited_mask: usize,
 }
@@ -884,10 +884,10 @@ impl HartMask {
         }
     }
 
-    /// Returns [HartMaskIter] of self.
+    /// Returns [HartIds] of self.
     #[inline]
-    pub const fn iter(&self) -> HartMaskIter {
-        HartMaskIter {
+    pub const fn iter(&self) -> HartIds {
+        HartIds {
             inner: HartMask {
                 hart_mask: self.hart_mask,
                 hart_mask_base: self.hart_mask_base,
@@ -897,7 +897,7 @@ impl HartMask {
     }
 }
 
-impl Iterator for HartMaskIter {
+impl Iterator for HartIds {
     type Item = usize;
 
     #[inline]
@@ -1136,7 +1136,7 @@ mod tests {
             assert!(mask.has_bit(i));
         }
         assert!(mask.has_bit(usize::MAX));
-        // Test HartMaskIter
+        // Test HartIds
         let mut mask_iter = HartMask::from_mask_base(0b101011, 1).iter();
         assert_eq!(mask_iter.next(), Some(1usize));
         assert_eq!(mask_iter.next(), Some(2usize));

--- a/sbi-spec/src/binary.rs
+++ b/sbi-spec/src/binary.rs
@@ -798,19 +798,21 @@ pub(crate) const fn has_bit(mask: usize, base: usize, ignore: usize, bit: usize)
 
 /// Hart mask structure in SBI function calls.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct HartMask {
     hart_mask: usize,
     hart_mask_base: usize,
 }
 
 /// Iteration for HartMask, from low to high.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct HartMaskIter {
     inner: HartMask,
     visited_mask: usize,
 }
 
 /// Error of mask modification.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum MaskError {
     /// This mask has been ignored.
     Ignored,
@@ -1146,7 +1148,6 @@ mod tests {
         assert!(mask.has_bit(1));
         assert!(mask.remove(1).is_ok());
         assert!(!mask.has_bit(1));
-        assert!(mask.insert(0).is_err());
     }
 
     #[test]


### PR DESCRIPTION
- Add `HartIds` structure as iteration of HartMask, also add test for testing it.
- Add `HartMask::insert` and `HartMask::remove`, and add its test.