### PR TITLE
spec: add `EVENT_GET_INFO` for PMU and feature type for FWFT extentions

### DIFF
--- a/sbi-spec/src/fwft.rs
+++ b/sbi-spec/src/fwft.rs
@@ -15,3 +15,49 @@ mod fid {
     /// Declared in §18.2.
     pub const GET: usize = 1;
 }
+
+/// FWFT Feature Types.
+///
+/// Declared in §18.
+pub mod feature_type {
+    /// Control misaligned access exception delegation.
+    ///
+    /// Declared in §18.
+    pub const MISALIGNED_EXC_DELEG: usize = 0;
+    /// Control landing pad support.
+    ///
+    /// Declared in §18.
+    pub const LANDING_PAD: usize = 1;
+    /// Control shadow stack support.
+    ///
+    /// Declared in §18.
+    pub const SHADOW_STACK: usize = 2;
+    /// Control double trap support.
+    ///
+    /// Declared in §18.
+    pub const DOUBLE_TRAP: usize = 3;
+    /// Control hardware updating of PTE A/D bits.
+    ///
+    /// Declared in §18.
+    pub const PTE_AD_HW_UPDATING: usize = 4;
+    /// Control the pointer masking tag length.
+    ///
+    /// Declared in §18.
+    pub const POINTER_MASKING_PMLEN: usize = 5;
+}
+
+/// Firmware Features Set.
+///
+/// Declared in §18.1.
+pub mod flags {
+    use bitflags::bitflags;
+
+    bitflags! {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        /// Declared in Table 94.
+        pub struct SetFlags: usize {
+            /// If provided, once set, the feature value can no longer be modified.
+            const LOCK = 1 << 0;
+        }
+    }
+}

--- a/sbi-spec/src/pmu.rs
+++ b/sbi-spec/src/pmu.rs
@@ -38,6 +38,10 @@ mod fid {
     ///
     /// Declared in §11.13.
     pub const SNAPSHOT_SET_SHMEM: usize = 7;
+    /// Function ID to get details about any PMU event via shared memory.
+    ///
+    /// Declared in §11.14.
+    pub const EVENT_GET_INFO: usize = 8;
 }
 
 /// PMU Event Types.
@@ -56,9 +60,13 @@ pub mod event_type {
     ///
     /// Declared in §11.3.
     pub const HARDWARE_RAW: usize = 2;
-    /// Type for all firmware events.
+    /// Type for all hardware raw events v2.
     ///
     /// Declared in §11.4.
+    pub const HARDWARE_RAW_V2: usize = 3;
+    /// Type for all firmware events.
+    ///
+    /// Declared in §11.5.
     pub const FIRMWARE: usize = 15;
 }
 
@@ -78,7 +86,7 @@ pub mod hardware_event {
     pub const CACHE_MISSES: usize = 4;
     /// Event for a branch instruction.
     pub const BRANCH_INSTRUCTIONS: usize = 5;
-    /// Event for a branch mis-prediction.
+    /// Event for a branch misprediction.
     pub const BRANCH_MISSES: usize = 6;
     /// Event for each BUS cycle.
     pub const BUS_CYCLES: usize = 7;
@@ -134,7 +142,7 @@ pub mod cache_result {
 
 /// Firmware Event Codes.
 ///
-/// Declared in §11.4.
+/// Declared in §11.5.
 pub mod firmware_event {
     /// Misaligned load trap event.
     pub const MISALIGNED_LOAD: usize = 0;
@@ -198,13 +206,13 @@ pub mod shmem_size {
 /// Start a set of counters.
 /// Stop a set of counters.
 ///  
-/// Declared in §11.7, §11.8 and §11.9.
+/// Declared in §11.8, §11.9 and §11.10.
 pub mod flags {
     use bitflags::bitflags;
 
     bitflags! {
         #[derive(Clone, Copy, PartialEq, Eq)]
-        /// Declared in Table 36.
+        /// Declared in Table 37.
         pub struct CounterCfgFlags: usize {
             /// Skip the counter matching.
             const SKIP_MATCH = 1 << 0;
@@ -227,7 +235,7 @@ pub mod flags {
 
     bitflags! {
         #[derive(Clone, Copy, PartialEq, Eq)]
-        /// Declared in Table 38
+        /// Declared in Table 39.
         pub struct CounterStartFlags: usize {
             /// Set the value of counters based on the initial_value parameter.
             const INIT_VALUE = 1 << 0;
@@ -238,7 +246,7 @@ pub mod flags {
 
     bitflags! {
         #[derive(Clone, Copy, PartialEq, Eq)]
-        /// Declared in Table 40.
+        /// Declared in Table 41.
         pub struct CounterStopFlags: usize {
             /// Reset the counter to event mapping.
             const RESET = 1 << 0;


### PR DESCRIPTION
This PR update support for SBI standards:
- Add function `sbi_pmu_event_get_info` and update documentation for PMU extension in chapter 11.
- Add feature types and features set flags for Firemware Features extension in chapter 18.

Refs: https://github.com/riscv-non-isa/riscv-sbi-doc/releases/download/vv3.0-rc1/riscv-sbi.pdf