### PR TITLE
spec: add MPXY extension support to SBI implementation

### DIFF
--- a/sbi-spec/CHANGELOG.md
+++ b/sbi-spec/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - sse: add support for Supervisor Software Events Extension in chapter 17
 - binary: add `HartIds` structure for an iterator over `HartMask`
 - Support `DBTR` extension in Chapter 19
+- mpxy: add support for MPXY extension in chapter 20
 
 ### Modified
 

--- a/sbi-spec/src/lib.rs
+++ b/sbi-spec/src/lib.rs
@@ -52,6 +52,8 @@ pub mod sse;
 pub mod fwft;
 // §19
 pub mod dbtr;
+// §20
+pub mod mpxy;
 
 /// Converts SBI EID from str.
 const fn eid_from_str(name: &str) -> i32 {
@@ -378,5 +380,18 @@ mod tests {
         const_assert_eq!(5, UNINSTALL_TRIGGERS);
         const_assert_eq!(6, ENABLE_TRIGGERS);
         const_assert_eq!(7, DISABLE_TRIGGERS);
+    }
+    // §20
+    #[test]
+    fn test_mpxy() {
+        use crate::mpxy::*;
+        const_assert_eq!(0x4D505859, EID_MPXY);
+        const_assert_eq!(0, SET_SHMEM);
+        const_assert_eq!(1, GET_CHANNEL_IDS);
+        const_assert_eq!(2, READ_ATTRIBUTE);
+        const_assert_eq!(3, WRITE_ATTRIBUTE);
+        const_assert_eq!(4, SEND_MESSAGE_WITH_RESPONSE);
+        const_assert_eq!(5, SEND_MESSAGE_WITHOUT_RESPONSE);
+        const_assert_eq!(6, GET_NOTIFICATION_EVENTS);
     }
 }

--- a/sbi-spec/src/mpxy.rs
+++ b/sbi-spec/src/mpxy.rs
@@ -1,0 +1,37 @@
+//! Chapter 20. Message Proxy Extension (EID #0x4D505859 "MPXY")
+
+/// Extension ID for Message Proxy Extension.
+pub const EID_MPXY: usize = crate::eid_from_str("MPXY") as _;
+pub use fid::*;
+
+/// Declared in §20.12.
+mod fid {
+    /// Function ID to set the shared memory for sending and receiving messages on the calling hart.
+    ///
+    /// Declared in §20.5.
+    pub const SET_SHMEM: usize = 0;
+    /// Function ID to get channel ids of the message channels accessible to the supervisor software in the shared memory of the calling hart.
+    ///
+    /// Declared in §20.6.
+    pub const GET_CHANNEL_IDS: usize = 1;
+    /// Function ID to read message channel attributes.
+    ///
+    /// Declared in §20.7.
+    pub const READ_ATTRIBUTE: usize = 2;
+    /// Function ID to write message channel attributes.
+    ///
+    /// Declared in §20.8.
+    pub const WRITE_ATTRIBUTE: usize = 3;
+    /// Function ID to send a message to the mpxy channel and waits for sbi implementation for the message response.
+    ///
+    /// Declared in 20.9.
+    pub const SEND_MESSAGE_WITH_RESPONSE: usize = 4;
+    /// Function ID to send a message to the mpxy channel and does not waits for response.
+    ///
+    /// Declared in 20.10.
+    pub const SEND_MESSAGE_WITHOUT_RESPONSE: usize = 5;
+    /// Function ID to get the message protocol specific notification events on the mpxy channel.
+    ///
+    /// Declared in 20.11.
+    pub const GET_NOTIFICATION_EVENTS: usize = 6;
+}


### PR DESCRIPTION
this commit add add necessary constants for Extension ID (EID) and Function ID (FID) associated with the Message Proxy Extension (MPXY). ref-https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/src/ext-mpxy.adoc