### PR TITLE
fix: build `sbi-rt` on non-RISC-V targets

### DIFF
--- a/.github/workflows/Rust.yml
+++ b/.github/workflows/Rust.yml
@@ -106,6 +106,19 @@ jobs:
         run: |
           cargo build --target ${{ matrix.TARGET }} --verbose -p sbi-rt
 
+  test-sbi-rt:
+    name: Test sbi-rt
+    needs: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test -p sbi-rt --verbose
+
   build-sbi-testing:
     name: Build sbi-testing
     needs: fmt

--- a/sbi-rt/CHANGELOG.md
+++ b/sbi-rt/CHANGELOG.md
@@ -19,6 +19,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- base: fix wrong `extension_id` of `Suspend` structure
+
 ## [0.0.3] - 2024-02-08
 
 This version adds support to the RISC-V SBI Specification version 2.0 ratified.

--- a/sbi-rt/CHANGELOG.md
+++ b/sbi-rt/CHANGELOG.md
@@ -20,6 +20,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - base: fix wrong `extension_id` of `Suspend` structure
+- binary: allow 8 arguments on internal function `sbi_call_6`.
 
 ## [0.0.3] - 2024-02-08
 

--- a/sbi-rt/src/base.rs
+++ b/sbi-rt/src/base.rs
@@ -135,7 +135,7 @@ define_extension! {
     Reset(sbi_spec::srst::EID_SRST) /// System Reset extension.
     Pmu(sbi_spec::pmu::EID_PMU) /// Performance Monitoring Unit extension.
     Console(sbi_spec::dbcn::EID_DBCN) /// Debug Console extension.
-    Suspend(sbi_spec::susp::SUSPEND) /// System Suspend extension.
+    Suspend(sbi_spec::susp::EID_SUSP) /// System Suspend extension.
     Cppc(sbi_spec::cppc::EID_CPPC) /// SBI CPPC extension.
     Nacl(sbi_spec::nacl::EID_NACL) /// Nested Acceleration extension.
     Sta(sbi_spec::sta::EID_STA) /// Steal-time Accounting extension.

--- a/sbi-rt/src/binary.rs
+++ b/sbi-rt/src/binary.rs
@@ -1,8 +1,11 @@
-﻿//! Chapter 3. Binary Encoding
+//! Chapter 3. Binary Encoding
+// This module is designated to use under RISC-V only, but it builds under non-RISC-V targets
+// to allow unit tests and `cargo fix` operations.
 
 use sbi_spec::binary::SbiRet;
 
 #[inline(always)]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 pub(crate) fn sbi_call_0(eid: usize, fid: usize) -> SbiRet {
     let (error, value);
     unsafe {
@@ -18,6 +21,13 @@ pub(crate) fn sbi_call_0(eid: usize, fid: usize) -> SbiRet {
 }
 
 #[inline(always)]
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub(crate) fn sbi_call_0(_eid: usize, _fid: usize) -> SbiRet {
+    unimplemented!("unsupported architecture")
+}
+
+#[inline(always)]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 pub(crate) fn sbi_call_1(eid: usize, fid: usize, arg0: usize) -> SbiRet {
     let (error, value);
     unsafe {
@@ -33,6 +43,13 @@ pub(crate) fn sbi_call_1(eid: usize, fid: usize, arg0: usize) -> SbiRet {
 }
 
 #[inline(always)]
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub(crate) fn sbi_call_1(_eid: usize, _fid: usize, _arg0: usize) -> SbiRet {
+    unimplemented!("unsupported architecture")
+}
+
+#[inline(always)]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 pub(crate) fn sbi_call_2(eid: usize, fid: usize, arg0: usize, arg1: usize) -> SbiRet {
     let (error, value);
     unsafe {
@@ -48,6 +65,13 @@ pub(crate) fn sbi_call_2(eid: usize, fid: usize, arg0: usize, arg1: usize) -> Sb
 }
 
 #[inline(always)]
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub(crate) fn sbi_call_2(_eid: usize, _fid: usize, _arg0: usize, _arg1: usize) -> SbiRet {
+    unimplemented!("unsupported architecture")
+}
+
+#[inline(always)]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 pub(crate) fn sbi_call_3(eid: usize, fid: usize, arg0: usize, arg1: usize, arg2: usize) -> SbiRet {
     let (error, value);
     unsafe {
@@ -64,6 +88,19 @@ pub(crate) fn sbi_call_3(eid: usize, fid: usize, arg0: usize, arg1: usize, arg2:
 }
 
 #[inline(always)]
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub(crate) fn sbi_call_3(
+    _eid: usize,
+    _fid: usize,
+    _arg0: usize,
+    _arg1: usize,
+    _arg2: usize,
+) -> SbiRet {
+    unimplemented!("unsupported architecture")
+}
+
+#[inline(always)]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 pub(crate) fn sbi_call_4(
     eid: usize,
     fid: usize,
@@ -88,6 +125,20 @@ pub(crate) fn sbi_call_4(
 }
 
 #[inline(always)]
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub(crate) fn sbi_call_4(
+    _eid: usize,
+    _fid: usize,
+    _arg0: usize,
+    _arg1: usize,
+    _arg2: usize,
+    _arg3: usize,
+) -> SbiRet {
+    unimplemented!("unsupported architecture")
+}
+
+#[inline(always)]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 pub(crate) fn sbi_call_5(
     eid: usize,
     fid: usize,
@@ -113,8 +164,23 @@ pub(crate) fn sbi_call_5(
     SbiRet { error, value }
 }
 
-#[cfg(target_pointer_width = "32")]
 #[inline(always)]
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+pub(crate) fn sbi_call_5(
+    _eid: usize,
+    _fid: usize,
+    _arg0: usize,
+    _arg1: usize,
+    _arg2: usize,
+    _arg3: usize,
+    _arg4: usize,
+) -> SbiRet {
+    unimplemented!("unsupported architecture")
+}
+
+#[inline(always)]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+#[allow(unused)] // only used on RV32 for RISC-V SBI 2.0 specification
 pub(crate) fn sbi_call_6(
     eid: usize,
     fid: usize,
@@ -140,4 +206,20 @@ pub(crate) fn sbi_call_6(
         );
     }
     SbiRet { error, value }
+}
+
+#[inline(always)]
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+#[allow(unused)] // only used on RV32 for RISC-V SBI 2.0 specification
+pub(crate) fn sbi_call_6(
+    _eid: usize,
+    _fid: usize,
+    _arg0: usize,
+    _arg1: usize,
+    _arg2: usize,
+    _arg3: usize,
+    _arg4: usize,
+    _arg5: usize,
+) -> SbiRet {
+    unimplemented!("unsupported architecture")
 }

--- a/sbi-rt/src/binary.rs
+++ b/sbi-rt/src/binary.rs
@@ -2,6 +2,9 @@
 // This module is designated to use under RISC-V only, but it builds under non-RISC-V targets
 // to allow unit tests and `cargo fix` operations.
 
+// `sbi_call_6` has 8 arguments which is allowed
+#![allow(clippy::too_many_arguments)]
+
 use sbi_spec::binary::SbiRet;
 
 #[inline(always)]

--- a/sbi-spec/CHANGELOG.md
+++ b/sbi-spec/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Modified
 
+- base: don't derive `PartialOrd` for `Version`, instead manually implement `Ord` and forward it into `PartialOrd`.
+
 ### Fixed
 
 ## [0.0.8] - 2024-10-25

--- a/sbi-spec/src/base.rs
+++ b/sbi-spec/src/base.rs
@@ -14,7 +14,7 @@ pub const UNAVAILABLE_EXTENSION: usize = 0;
 /// Not to be confused with 'implementation version'.
 ///
 /// Declared in §4.1.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Version {
     raw: usize,
@@ -50,9 +50,16 @@ impl core::fmt::Display for Version {
 impl core::cmp::PartialOrd for Version {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl core::cmp::Ord for Version {
+    #[inline]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.major()
-            .partial_cmp(&other.major())
-            .map(|ordering| ordering.then_with(|| self.minor().cmp(&other.minor())))
+            .cmp(&other.major())
+            .then_with(|| self.minor().cmp(&other.minor()))
     }
 }
 


### PR DESCRIPTION
This crate  is designated to use under RISC-V only, but it does not build under non-RISC-V targets to allow unit tests and `cargo fix` operations. We provide implementation on other targets using `unimplemented!` to allow static build checks and tests on structures.

- spec: fix wrong `extension_id` of `Suspend` structure
- rt: binary: allow 8 arguments on internal function `sbi_call_6`.
- spec: base: don't derive `PartialOrd` for `Version`, instead manually implement `Ord` and forward it into `PartialOrd`.
