### PR TITLE
docs: update MSRV in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or consult vendors if they provide discrete RustSBI package support.
 
 ## Minimum supported Rust version
 
-To compile RustSBI library, you need at least stable Rust version of `rustc 1.65.0`.
+To compile RustSBI library, you need at least stable Rust version of `rustc 1.83.0`.
 
 ## Build this project
 


### PR DESCRIPTION
docs: update MSRV in README.md

Here are some unstable features used by RustSBI with the original MSRV `1.65.0` in README.md:

- `is_sorted`: stable at `1.82.0` (https://github.com/rust-lang/rust/pull/128279)
- `is_some_and`: stable at `1.70.0` (https://github.com/rust-lang/rust/pull/110019)
- `&mut` in const: stable at `1.83.0` (https://github.com/rust-lang/rust/pull/129195)

I tested by myself and found out that `1.83.0` and above can compile successful, while `1.82.0` cannot.

Fixes: #87.

Signed-off-by: Nuoxian Wang <bosswnx@qq.com>