### PR TITLE
feat(spec): add special constant V1_0 and V2_0 for structure `Version`

### DIFF
--- a/library/sbi-spec/CHANGELOG.md
+++ b/library/sbi-spec/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - binary: internal unit tests for `SbiRet` constructors
 - examples: simple RV128I emulator example
 - examples: an SBI version example for usage of the Version structure
+- base: add special constant `V1_0` and `V2_0` for structure `Version`
 
 ### Modified
 

--- a/library/sbi-spec/examples/sbi-version.rs
+++ b/library/sbi-spec/examples/sbi-version.rs
@@ -8,8 +8,8 @@ use sbi_spec::base::Version;
 /// We mock a S-mode software (kernel, etc.) that runs on minimum SBI version of v1.0;
 /// it will detect from the environment and judge if it meets the minimum SBI version demand.
 fn main() {
-    // Create a version number representing RISC-V SBI v1.0.
-    let v1_0 = Version::from_raw(0x100_0000);
+    // Create a version structure representing the minimum version at RISC-V SBI v1.0.
+    let minimum_version = Version::V1_0;
 
     // Call the mock SBI runtime to obtain the current version number.
     println!("Probing SBI version of current environment...");
@@ -20,7 +20,7 @@ fn main() {
 
     // Version comparison: Check whether the current version meets the minimum
     // requirement (v1.0 or higher).
-    if current_version >= v1_0 {
+    if current_version >= minimum_version {
         // The version meets the requirement, output success message.
         println!("The SBI version meets minimum demand of RISC-V SBI v1.0.");
         println!("✓ Test success!");

--- a/library/sbi-spec/src/base.rs
+++ b/library/sbi-spec/src/base.rs
@@ -21,6 +21,12 @@ pub struct Version {
 }
 
 impl Version {
+    /// RISC-V SBI version 1.0, ratified at Mar 23, 2022.
+    pub const V1_0: Version = Version::from_raw(0x0100_0000);
+
+    /// RISC-V SBI version 2.0, ratified at Feb 1, 2024.
+    pub const V2_0: Version = Version::from_raw(0x0200_0000);
+
     /// Converts raw extension value into Version structure.
     #[inline]
     pub const fn from_raw(raw: usize) -> Self {
@@ -217,5 +223,13 @@ mod tests {
         assert_eq!(v1_0.clamp(v0_3, v2_0), v1_0);
         assert_eq!(v2_0.clamp(v0_3, v2_0), v2_0);
         assert_eq!(v2_1.clamp(v0_3, v2_0), v2_0);
+    }
+
+    #[test]
+    fn special_versions() {
+        assert_eq!(Version::V1_0.major(), 1);
+        assert_eq!(Version::V1_0.minor(), 0);
+        assert_eq!(Version::V2_0.major(), 2);
+        assert_eq!(Version::V2_0.minor(), 0);
     }
 }

--- a/prototyper/bench-kernel/Cargo.toml
+++ b/prototyper/bench-kernel/Cargo.toml
@@ -14,7 +14,7 @@ sbi-spec = { version = "0.0.8", path = "../../library/sbi-spec" }
 serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", default-features = false }
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 log = "0.4"
-riscv = "0.11.1"
+riscv = "0.12.1"
 spin = "0.9"
 uart16550 = "0.0.1"
 rcore-console = "0.0.0"

--- a/prototyper/test-kernel/Cargo.toml
+++ b/prototyper/test-kernel/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 sbi-testing = { features = ["log"], path = "../../library/sbi-testing" }
 log = "0.4"
-riscv = "0.11.1"
+riscv = "0.12.1"
 spin = "0.9"
 uart16550 = "0.0.1"
 rcore-console = "0.0.0"


### PR DESCRIPTION
Improve examples for `sbi-spec` crate.