### PR TITLE
rt: add SBI firmware features extension support

### DIFF
--- a/library/sbi-rt/CHANGELOG.md
+++ b/library/sbi-rt/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - pmu: add missing `pmu_snapshot_set_shmem` function.
 - pmu: `pmu_snapshot_set_shmem` function signature, documents and implementation
 - lib: re-export `sbi_spec::base::CounterMask` on crate root.
+- rt: add FWFT extension support to SBI implementation.
 
 ### Modified
 

--- a/library/sbi-rt/src/fwft.rs
+++ b/library/sbi-rt/src/fwft.rs
@@ -20,14 +20,12 @@ use sbi_spec::{
 ///
 /// | Error code                  | Description
 /// |:----------------------------|:---------------------------------
-/// | `SbiRet::success()`               | `feature` was set successfully.
-/// | `SbiRet::not_supported()`     | `feature` is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
-/// | `SbiRet::invalid_param()`     | Provided `value` or `flags` parameter is invalid.
-/// | `SbiRet::denied()`            | `feature` set operation failed because either:
-///                             - it was denied by the SBI implementation
-///                             - `feature` is reserved or is platform-specific and unimplemented
-/// | `SbiRet::denied_locked()`     | `feature` set operation failed because the `feature` is locked.
-/// | `SbiRet::failed()`            | The set operation failed for unspecified or unknown other reasons.
+/// | `SbiRet::success()`         | `feature` was set successfully.
+/// | `SbiRet::not_supported()`   | `feature` is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
+/// | `SbiRet::invalid_param()`   | Provided `value` or `flags` parameter is invalid.
+/// | `SbiRet::denied()`          | `feature` set operation failed because either it was denied by the SBI implementation, or`feature` is reserved or is platform-specific and unimplemented.
+/// | `SbiRet::denied_locked()`   | `feature` set operation failed because the `feature` is locked.
+/// | `SbiRet::failed()`          | The set operation failed for unspecified or unknown other reasons.
 ///
 /// This function is defined in RISC-V SBI Specification chapter 18.1.
 #[inline]
@@ -47,10 +45,10 @@ pub fn fwft_set(feature: u32, value: usize, flags: usize) -> SbiRet {
 ///
 /// | Error code                  | Description
 /// |:----------------------------|:---------------------------------
-/// | `SbiRet::success()`               | Feature status was retrieved successfully.
-/// | `SbiRet::not_supported()`     | `feature` is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
-/// | `SbiRet::denied()`            | `feature` is reserved or is platform-specific and unimplemented.
-/// | `SbiRet::failed()`            | The get operation failed for unspecified or unknown other reasons.
+/// | `SbiRet::success()`         | Feature status was retrieved successfully.
+/// | `SbiRet::not_supported()`   | `feature` is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
+/// | `SbiRet::denied()`          | `feature` is reserved or is platform-specific and unimplemented.
+/// | `SbiRet::failed()`          | The get operation failed for unspecified or unknown other reasons.
 ///
 /// This function is defined in RISC-V SBI Specification chapter 18.2.
 #[inline]

--- a/library/sbi-rt/src/fwft.rs
+++ b/library/sbi-rt/src/fwft.rs
@@ -1,32 +1,33 @@
-//! Chapter 18. SBI Firmware Features Extension (EID #0x46574654 "FWFT")
+//! Chapter 18. SBI Firmware Features Extension (EID #0x46574654 "FWFT").
 
 use crate::binary::{sbi_call_1, sbi_call_3};
 use sbi_spec::{
     binary::SbiRet,
-    fwft::{EID_FWFT, SET, GET},
+    fwft::{EID_FWFT, GET, SET},
 };
 
-/// Set the value of a specific firmware feature
+/// Set the configuration value of a specific firmware feature.
 ///
 /// # Parameters
+///
 /// - `feature`: The identifier of the feature to set.
 /// - `value`: The value to set for the feature.
 /// - `flags`: Flags to modify the behavior of the set operation.
 ///
 /// # Return value
 ///
-/// `SbiRet.value` is set to zero, and the possible error codes returned in `SbiRet.error` are shown in the table below:
+/// A successful return results in the requested firmware feature to be set according to the `value` and `flags` parameters. In case of failure, `feature` value is not modified and the possible error codes returned in `SbiRet.error` are shown in the table below:
 ///
 /// | Error code                  | Description
 /// |:----------------------------|:---------------------------------
-/// | `SBI_SUCCESS`               | feature was set successfully.
-/// | `SBI_ERR_NOT_SUPPORTED`     | feature is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
-/// | `SBI_ERR_INVALID_PARAM`     | Provided value or flags parameter is invalid.
-/// | `SBI_ERR_DENIED`            | feature set operation failed because either:
+/// | `SbiRet::success()`               | `feature` was set successfully.
+/// | `SbiRet::not_supported()`     | `feature` is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
+/// | `SbiRet::invalid_param()`     | Provided `value` or `flags` parameter is invalid.
+/// | `SbiRet::denied()`            | `feature` set operation failed because either:
 ///                             - it was denied by the SBI implementation
-///                             - feature is reserved or is platform-specific and unimplemented
-/// | `SBI_ERR_DENIED_LOCKED`     | feature set operation failed because the feature is locked.
-/// | `SBI_ERR_FAILED`            | The set operation failed for unspecified or unknown other reasons.
+///                             - `feature` is reserved or is platform-specific and unimplemented
+/// | `SbiRet::denied_locked()`     | `feature` set operation failed because the `feature` is locked.
+/// | `SbiRet::failed()`            | The set operation failed for unspecified or unknown other reasons.
 ///
 /// This function is defined in RISC-V SBI Specification chapter 18.1.
 #[inline]
@@ -34,21 +35,22 @@ pub fn fwft_set(feature: u32, value: usize, flags: usize) -> SbiRet {
     sbi_call_3(EID_FWFT, SET, feature as _, value, flags)
 }
 
-/// Get the value of a specific firmware feature
+/// Get the configuration value of a specific firmware feature.
 ///
 /// # Parameters
+///
 /// - `feature`: The identifier of the feature to get.
 ///
 /// # Return value
 ///
-/// `SbiRet.value` is set to zero, and the possible error codes returned in `SbiRet.error` are shown in the table below:
+/// A successful return results in the firmware feature configuration value to be returned in `SbiRet.value`. In case of failure, the content of `SbiRet.value` is zero and the possible error codes returned in `SbiRet.error` are shown in the table below:
 ///
 /// | Error code                  | Description
 /// |:----------------------------|:---------------------------------
-/// | `SBI_SUCCESS`               | Feature status was retrieved successfully.
-/// | `SBI_ERR_NOT_SUPPORTED`     | feature is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
-/// | `SBI_ERR_DENIED`            | feature is reserved or is platform-specific and unimplemented.
-/// | `SBI_ERR_FAILED`            | The get operation failed for unspecified or unknown other reasons.
+/// | `SbiRet::success()`               | Feature status was retrieved successfully.
+/// | `SbiRet::not_supported()`     | `feature` is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
+/// | `SbiRet::denied()`            | `feature` is reserved or is platform-specific and unimplemented.
+/// | `SbiRet::failed()`            | The get operation failed for unspecified or unknown other reasons.
 ///
 /// This function is defined in RISC-V SBI Specification chapter 18.2.
 #[inline]

--- a/library/sbi-rt/src/fwft.rs
+++ b/library/sbi-rt/src/fwft.rs
@@ -1,0 +1,57 @@
+//! Chapter 18. SBI Firmware Features Extension (EID #0x46574654 "FWFT")
+
+use crate::binary::{sbi_call_1, sbi_call_3};
+use sbi_spec::{
+    binary::SbiRet,
+    fwft::{EID_FWFT, SET, GET},
+};
+
+/// Set the value of a specific firmware feature
+///
+/// # Parameters
+/// - `feature`: The identifier of the feature to set.
+/// - `value`: The value to set for the feature.
+/// - `flags`: Flags to modify the behavior of the set operation.
+///
+/// # Return value
+///
+/// `SbiRet.value` is set to zero, and the possible error codes returned in `SbiRet.error` are shown in the table below:
+///
+/// | Error code                  | Description
+/// |:----------------------------|:---------------------------------
+/// | `SBI_SUCCESS`               | feature was set successfully.
+/// | `SBI_ERR_NOT_SUPPORTED`     | feature is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
+/// | `SBI_ERR_INVALID_PARAM`     | Provided value or flags parameter is invalid.
+/// | `SBI_ERR_DENIED`            | feature set operation failed because either:
+///                             - it was denied by the SBI implementation
+///                             - feature is reserved or is platform-specific and unimplemented
+/// | `SBI_ERR_DENIED_LOCKED`     | feature set operation failed because the feature is locked.
+/// | `SBI_ERR_FAILED`            | The set operation failed for unspecified or unknown other reasons.
+///
+/// This function is defined in RISC-V SBI Specification chapter 18.1.
+#[inline]
+pub fn fwft_set(feature: u32, value: usize, flags: usize) -> SbiRet {
+    sbi_call_3(EID_FWFT, SET, feature as _, value, flags)
+}
+
+/// Get the value of a specific firmware feature
+///
+/// # Parameters
+/// - `feature`: The identifier of the feature to get.
+///
+/// # Return value
+///
+/// `SbiRet.value` is set to zero, and the possible error codes returned in `SbiRet.error` are shown in the table below:
+///
+/// | Error code                  | Description
+/// |:----------------------------|:---------------------------------
+/// | `SBI_SUCCESS`               | Feature status was retrieved successfully.
+/// | `SBI_ERR_NOT_SUPPORTED`     | feature is not reserved and valid, but the platform does not support it due to one or more missing dependencies (Hardware or SBI implementation).
+/// | `SBI_ERR_DENIED`            | feature is reserved or is platform-specific and unimplemented.
+/// | `SBI_ERR_FAILED`            | The get operation failed for unspecified or unknown other reasons.
+///
+/// This function is defined in RISC-V SBI Specification chapter 18.2.
+#[inline]
+pub fn fwft_get(feature: u32) -> SbiRet {
+    sbi_call_1(EID_FWFT, GET, feature as _)
+}

--- a/library/sbi-rt/src/lib.rs
+++ b/library/sbi-rt/src/lib.rs
@@ -40,6 +40,8 @@ mod cppc;
 mod nacl;
 // §16
 mod sta;
+// §18
+mod fwft;
 
 pub use sbi_spec::{
     base::Version,
@@ -52,6 +54,7 @@ pub use sbi_spec::{
 pub use base::*;
 pub use cppc::*;
 pub use dbcn::*;
+pub use fwft::*;
 pub use hsm::*;
 pub use nacl::*;
 pub use pmu::*;


### PR DESCRIPTION
This commit implements the SBI Firmware Features Extension (EID #0x46574654 FWFT),
as defined in the RISC-V SBI Specification chapter 18.

The extension provides two main functions:
- fwft_set: Sets the value of a specific firmware feature.
- fwft_get: Retrieves the value of a specific firmware feature.

Signed-off-by: joeschmo456 <imzhangxiangbo@gmail.com>

