### PR TITLE
feat: add C language alias documentation support for RustSBI ecosystem library

### DIFF
--- a/library/sbi-rt/CHANGELOG.md
+++ b/library/sbi-rt/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - pmu: `pmu_snapshot_set_shmem` function signature, documents and implementation
 - lib: re-export `sbi_spec::base::CounterMask` on crate root.
 - rt: add FWFT extension support to SBI implementation.
+- Add C language naming alias tags to all functions of the sbi-rt library
 
 ### Modified
 

--- a/library/sbi-rt/src/base.rs
+++ b/library/sbi-rt/src/base.rs
@@ -17,6 +17,7 @@ use sbi_spec::base::{
 /// According to the introduction of chapter 4, all base extension functions
 /// must success and return no error code.
 #[inline]
+#[doc(alias = "sbi_get_spec_version")]
 pub fn get_spec_version() -> Version {
     Version::from_raw(sbi_call_0(EID_BASE, GET_SBI_SPEC_VERSION).value)
 }
@@ -31,6 +32,7 @@ pub fn get_spec_version() -> Version {
 /// According to the introduction of chapter 4, all base extension functions
 /// must success and return no error code.
 #[inline]
+#[doc(alias = "sbi_get_impl_id")]
 pub fn get_sbi_impl_id() -> usize {
     sbi_call_0(EID_BASE, GET_SBI_IMPL_ID).value
 }
@@ -43,6 +45,7 @@ pub fn get_sbi_impl_id() -> usize {
 /// According to the introduction of chapter 4, all base extension functions
 /// must success and return no error code.
 #[inline]
+#[doc(alias = "sbi_get_impl_version")]
 pub fn get_sbi_impl_version() -> usize {
     sbi_call_0(EID_BASE, GET_SBI_IMPL_VERSION).value
 }
@@ -57,6 +60,7 @@ pub fn get_sbi_impl_version() -> usize {
 /// According to the introduction of chapter 4, all base extension functions
 /// must success and return no error code.
 #[inline]
+#[doc(alias = "sbi_probe_extension")]
 pub fn probe_extension<E>(extension: E) -> ExtensionInfo
 where
     E: Extension,
@@ -74,6 +78,7 @@ where
 /// According to the introduction of chapter 4, all base extension functions
 /// must success and return no error code.
 #[inline]
+#[doc(alias = "sbi_get_mvendorid")]
 pub fn get_mvendorid() -> usize {
     sbi_call_0(EID_BASE, GET_MVENDORID).value
 }
@@ -87,6 +92,7 @@ pub fn get_mvendorid() -> usize {
 /// According to the introduction of chapter 4, all base extension functions
 /// must success and return no error code.
 #[inline]
+#[doc(alias = "sbi_get_marchid")]
 pub fn get_marchid() -> usize {
     sbi_call_0(EID_BASE, GET_MARCHID).value
 }
@@ -100,6 +106,7 @@ pub fn get_marchid() -> usize {
 /// According to the introduction of chapter 4, all base extension functions
 /// must success and return no error code.
 #[inline]
+#[doc(alias = "sbi_get_mimpid")]
 pub fn get_mimpid() -> usize {
     sbi_call_0(EID_BASE, GET_MIMPID).value
 }

--- a/library/sbi-rt/src/cppc.rs
+++ b/library/sbi-rt/src/cppc.rs
@@ -31,6 +31,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 14.1.
 #[inline]
+#[doc(alias = "sbi_cppc_probe")]
 pub fn cppc_probe(cppc_reg_id: u32) -> SbiRet {
     sbi_call_1(EID_CPPC, PROBE, cppc_reg_id as _)
 }
@@ -58,6 +59,7 @@ pub fn cppc_probe(cppc_reg_id: u32) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 14.2.
 #[inline]
+#[doc(alias = "sbi_cppc_read")]
 pub fn cppc_read(cppc_reg_id: u32) -> SbiRet {
     sbi_call_1(EID_CPPC, READ, cppc_reg_id as _)
 }
@@ -85,6 +87,7 @@ pub fn cppc_read(cppc_reg_id: u32) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 14.3.
 #[inline]
+#[doc(alias = "sbi_cppc_read_hi")]
 pub fn cppc_read_hi(cppc_reg_id: u32) -> SbiRet {
     sbi_call_1(EID_CPPC, READ_HI, cppc_reg_id as _)
 }
@@ -111,6 +114,7 @@ pub fn cppc_read_hi(cppc_reg_id: u32) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 14.4.
 #[inline]
+#[doc(alias = "sbi_cppc_write")]
 pub fn cppc_write(cppc_reg_id: u32, value: u64) -> SbiRet {
     match () {
         #[cfg(target_pointer_width = "32")]

--- a/library/sbi-rt/src/dbcn.rs
+++ b/library/sbi-rt/src/dbcn.rs
@@ -31,6 +31,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 12.1.
 #[inline]
+#[doc(alias = "sbi_debug_console_write")]
 pub fn console_write(bytes: Physical<&[u8]>) -> SbiRet {
     sbi_call_3(
         EID_DBCN,
@@ -68,6 +69,7 @@ pub fn console_write(bytes: Physical<&[u8]>) -> SbiRet {
 /// | `SbiRet::failed()`        | Failed to read due to I/O errors.
 ///
 /// This function is defined in RISC-V SBI Specification chapter 12.2.
+#[doc(alias = "sbi_debug_console_read")]
 pub fn console_read(bytes: Physical<&mut [u8]>) -> SbiRet {
     sbi_call_3(
         EID_DBCN,
@@ -97,6 +99,7 @@ pub fn console_read(bytes: Physical<&mut [u8]>) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 12.3.
 #[inline]
+#[doc(alias = "sbi_debug_console_write_byte")]
 pub fn console_write_byte(byte: u8) -> SbiRet {
     sbi_call_1(EID_DBCN, CONSOLE_WRITE_BYTE, byte as usize)
 }

--- a/library/sbi-rt/src/fwft.rs
+++ b/library/sbi-rt/src/fwft.rs
@@ -29,6 +29,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 18.1.
 #[inline]
+#[doc(alias = "sbi_fwft_set")]
 pub fn fwft_set(feature: u32, value: usize, flags: usize) -> SbiRet {
     sbi_call_3(EID_FWFT, SET, feature as _, value, flags)
 }
@@ -52,6 +53,7 @@ pub fn fwft_set(feature: u32, value: usize, flags: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 18.2.
 #[inline]
+#[doc(alias = "sbi_fwft_get")]
 pub fn fwft_get(feature: u32) -> SbiRet {
     sbi_call_1(EID_FWFT, GET, feature as _)
 }

--- a/library/sbi-rt/src/hsm.rs
+++ b/library/sbi-rt/src/hsm.rs
@@ -58,6 +58,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 9.1.
 #[inline]
+#[doc(alias = "sbi_hart_start")]
 pub fn hart_start(hartid: usize, start_addr: usize, opaque: usize) -> SbiRet {
     sbi_call_3(EID_HSM, HART_START, hartid, start_addr, opaque)
 }
@@ -80,6 +81,7 @@ pub fn hart_start(hartid: usize, start_addr: usize, opaque: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 9.2.
 #[inline]
+#[doc(alias = "sbi_hart_stop")]
 pub fn hart_stop() -> SbiRet {
     sbi_call_0(EID_HSM, HART_STOP)
 }
@@ -113,6 +115,7 @@ pub fn hart_stop() -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 9.3.
 #[inline]
+#[doc(alias = "sbi_hart_get_status")]
 pub fn hart_get_status(hartid: usize) -> SbiRet {
     sbi_call_1(EID_HSM, HART_GET_STATUS, hartid)
 }
@@ -189,6 +192,7 @@ pub fn hart_get_status(hartid: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 9.4.
 #[inline]
+#[doc(alias = "sbi_hart_suspend")]
 pub fn hart_suspend<T>(suspend_type: T, resume_addr: usize, opaque: usize) -> SbiRet
 where
     T: SuspendType,

--- a/library/sbi-rt/src/nacl.rs
+++ b/library/sbi-rt/src/nacl.rs
@@ -24,6 +24,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 15.5.
 #[inline]
+#[doc(alias = "sbi_nacl_probe_feature")]
 pub fn nacl_probe_feature(feature_id: u32) -> SbiRet {
     sbi_call_1(EID_NACL, PROBE_FEATURE, feature_id as _)
 }
@@ -53,6 +54,7 @@ pub fn nacl_probe_feature(feature_id: u32) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 15.6.
 #[inline]
+#[doc(alias = "sbi_nacl_set_shmem")]
 pub fn nacl_set_shmem(shmem: SharedPtr<[u8; shmem_size::NATIVE]>, flags: usize) -> SbiRet {
     sbi_call_3(
         EID_NACL,
@@ -89,6 +91,7 @@ pub fn nacl_set_shmem(shmem: SharedPtr<[u8; shmem_size::NATIVE]>, flags: usize) 
 ///
 /// This function is defined in RISC-V SBI Specification chapter 15.7.
 #[inline]
+#[doc(alias = "sbi_nacl_sync_csr")]
 pub fn nacl_sync_csr(csr_num: usize) -> SbiRet {
     sbi_call_1(EID_NACL, SYNC_CSR, csr_num)
 }
@@ -118,6 +121,7 @@ pub fn nacl_sync_csr(csr_num: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 15.8.
 #[inline]
+#[doc(alias = "sbi_nacl_sync_hfence")]
 pub fn nacl_sync_hfence(entry_index: usize) -> SbiRet {
     sbi_call_1(EID_NACL, SYNC_HFENCE, entry_index)
 }
@@ -141,6 +145,7 @@ pub fn nacl_sync_hfence(entry_index: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 15.9.
 #[inline]
+#[doc(alias = "sbi_nacl_sync_sret")]
 pub fn nacl_sync_sret() -> SbiRet {
     sbi_call_0(EID_NACL, SYNC_SRET)
 }

--- a/library/sbi-rt/src/pmu.rs
+++ b/library/sbi-rt/src/pmu.rs
@@ -16,6 +16,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.6.
 #[inline]
+#[doc(alias = "sbi_pmu_num_counters")]
 pub fn pmu_num_counters() -> usize {
     sbi_call_0(EID_PMU, NUM_COUNTERS).value
 }
@@ -48,6 +49,7 @@ pub fn pmu_num_counters() -> usize {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.7.
 #[inline]
+#[doc(alias = "sbi_pmu_counter_get_info")]
 pub fn pmu_counter_get_info(counter_idx: usize) -> SbiRet {
     sbi_call_1(EID_PMU, COUNTER_GET_INFO, counter_idx)
 }
@@ -103,6 +105,7 @@ pub fn pmu_counter_get_info(counter_idx: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.8.
 #[inline]
+#[doc(alias = "sbi_pmu_counter_config_matching")]
 pub fn pmu_counter_config_matching<T>(
     counter_idx: CounterMask,
     config_flags: T,
@@ -167,6 +170,7 @@ where
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.9.
 #[inline]
+#[doc(alias = "sbi_pmu_counter_start")]
 pub fn pmu_counter_start<T>(counter_idx: CounterMask, start_flags: T, initial_value: u64) -> SbiRet
 where
     T: StartFlags,
@@ -219,6 +223,7 @@ where
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.10.
 #[inline]
+#[doc(alias = "sbi_pmu_counter_stop")]
 pub fn pmu_counter_stop<T>(counter_idx: CounterMask, stop_flags: T) -> SbiRet
 where
     T: StopFlags,
@@ -254,6 +259,7 @@ where
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.11.
 #[inline]
+#[doc(alias = "sbi_pmu_counter_fw_read")]
 pub fn pmu_counter_fw_read(counter_idx: usize) -> SbiRet {
     sbi_call_1(EID_PMU, COUNTER_FW_READ, counter_idx)
 }
@@ -273,6 +279,7 @@ pub fn pmu_counter_fw_read(counter_idx: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.12.
 #[inline]
+#[doc(alias = "sbi_pmu_counter_fw_read_hi")]
 pub fn pmu_counter_fw_read_hi(counter_idx: usize) -> SbiRet {
     sbi_call_1(EID_PMU, COUNTER_FW_READ_HI, counter_idx)
 }
@@ -306,6 +313,7 @@ pub fn pmu_counter_fw_read_hi(counter_idx: usize) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 11.13.
 #[inline]
+#[doc(alias = "sbi_pmu_snapshot_set_shmem")]
 pub fn pmu_snapshot_set_shmem(shmem: SharedPtr<[u8; SIZE]>, flags: usize) -> SbiRet {
     sbi_call_3(
         EID_PMU,

--- a/library/sbi-rt/src/rfnc.rs
+++ b/library/sbi-rt/src/rfnc.rs
@@ -18,6 +18,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 8.1.
 #[inline]
+#[doc(alias = "sbi_remote_fence_i")]
 pub fn remote_fence_i(hart_mask: HartMask) -> SbiRet {
     let (hart_mask, hart_mask_base) = hart_mask.into_inner();
     sbi_call_2(EID_RFNC, REMOTE_FENCE_I, hart_mask, hart_mask_base)
@@ -39,6 +40,7 @@ pub fn remote_fence_i(hart_mask: HartMask) -> SbiRet {
 ///
 /// This function is defined in RISC-V SBI Specification chapter 8.2.
 #[inline]
+#[doc(alias = "sbi_remote_sfence_vma")]
 pub fn remote_sfence_vma(hart_mask: HartMask, start_addr: usize, size: usize) -> SbiRet {
     let (hart_mask, hart_mask_base) = hart_mask.into_inner();
     sbi_call_4(
@@ -68,6 +70,7 @@ pub fn remote_sfence_vma(hart_mask: HartMask, start_addr: usize, size: usize) ->
 ///
 /// This function is defined in RISC-V SBI Specification chapter 8.3.
 #[inline]
+#[doc(alias = "sbi_remote_sfence_vma_asid")]
 pub fn remote_sfence_vma_asid(
     hart_mask: HartMask,
     start_addr: usize,
@@ -106,6 +109,7 @@ pub fn remote_sfence_vma_asid(
 ///
 /// This function is defined in RISC-V SBI Specification chapter 8.4.
 #[inline]
+#[doc(alias = "sbi_remote_hfence_gvma_vmid")]
 pub fn remote_hfence_gvma_vmid(
     hart_mask: HartMask,
     start_addr: usize,
@@ -144,6 +148,7 @@ pub fn remote_hfence_gvma_vmid(
 ///
 /// This function is defined in RISC-V SBI Specification chapter 8.5.
 #[inline]
+#[doc(alias = "sbi_remote_hfence_gvma")]
 pub fn remote_hfence_gvma(hart_mask: HartMask, start_addr: usize, size: usize) -> SbiRet {
     let (hart_mask, hart_mask_base) = hart_mask.into_inner();
     sbi_call_4(
@@ -177,6 +182,7 @@ pub fn remote_hfence_gvma(hart_mask: HartMask, start_addr: usize, size: usize) -
 ///
 /// This function is defined in RISC-V SBI Specification chapter 8.6.
 #[inline]
+#[doc(alias = "sbi_remote_hfence_vvma_asid")]
 pub fn remote_hfence_vvma_asid(
     hart_mask: HartMask,
     start_addr: usize,
@@ -215,6 +221,7 @@ pub fn remote_hfence_vvma_asid(
 ///
 /// This function is defined in RISC-V SBI Specification chapter 8.7.
 #[inline]
+#[doc(alias = "sbi_remote_hfence_vvma")]
 pub fn remote_hfence_vvma(hart_mask: HartMask, start_addr: usize, size: usize) -> SbiRet {
     let (hart_mask, hart_mask_base) = hart_mask.into_inner();
     sbi_call_4(

--- a/library/sbi-rt/src/spi.rs
+++ b/library/sbi-rt/src/spi.rs
@@ -17,6 +17,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 7.1.
 #[inline]
+#[doc(alias = "sbi_send_ipi")]
 pub fn send_ipi(hart_mask: HartMask) -> SbiRet {
     let (hart_mask, hart_mask_base) = hart_mask.into_inner();
     sbi_call_2(EID_SPI, SEND_IPI, hart_mask, hart_mask_base)

--- a/library/sbi-rt/src/srst.rs
+++ b/library/sbi-rt/src/srst.rs
@@ -31,6 +31,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 10.1.
 #[inline]
+#[doc(alias = "sbi_system_reset")]
 pub fn system_reset<T, R>(reset_type: T, reset_reason: R) -> SbiRet
 where
     T: ResetType,

--- a/library/sbi-rt/src/sta.rs
+++ b/library/sbi-rt/src/sta.rs
@@ -56,6 +56,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 16.1.
 #[inline]
+#[doc(alias = "sbi_sta_set_shmem")]
 pub fn sta_set_shmem(shmem: SharedPtr<[u8; 64]>, flags: usize) -> SbiRet {
     sbi_call_3(
         EID_STA,

--- a/library/sbi-rt/src/susp.rs
+++ b/library/sbi-rt/src/susp.rs
@@ -41,6 +41,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 13.1.
 #[inline]
+#[doc(alias = "sbi_system_suspend")]
 pub fn system_suspend<T>(sleep_type: T, resume_addr: usize, opaque: usize) -> SbiRet
 where
     T: SleepType,

--- a/library/sbi-rt/src/time.rs
+++ b/library/sbi-rt/src/time.rs
@@ -16,6 +16,7 @@ use sbi_spec::{
 ///
 /// This function is defined in RISC-V SBI Specification chapter 6.1.
 #[inline]
+#[doc(alias = "sbi_set_timer")]
 pub fn set_timer(stime_value: u64) -> SbiRet {
     match () {
         #[cfg(target_pointer_width = "32")]

--- a/library/sbi-spec/CHANGELOG.md
+++ b/library/sbi-spec/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - base: refactor `SbiRet` to be generic of registers and introduce the `SbiRegister` trait
 - base: implement `SbiRegister` for `i32`, `i64`, `i128` and `isize` primitive types
 - base: make HartMask and CounterMask generic over SBI registers
+- Add C language naming alias tags to all constants in the sbi-spec package
 
 ### Fixed
 

--- a/library/sbi-spec/src/base.rs
+++ b/library/sbi-spec/src/base.rs
@@ -1,6 +1,7 @@
 //! Chapter 4. Base Extension (EID #0x10).
 
 /// Extension ID for RISC-V SBI Base extension.
+#[doc(alias = "SBI_EXT_BASE")]
 pub const EID_BASE: usize = 0x10;
 pub use fid::*;
 
@@ -74,30 +75,37 @@ mod fid {
     /// Function ID to get the current SBI specification version.
     ///
     /// Declared in §4.1.
+    #[doc(alias = "SBI_EXT_BASE_GET_SPEC_VERSION")]
     pub const GET_SBI_SPEC_VERSION: usize = 0x0;
     /// Function ID to get the current SBI implementation ID.
     ///
     /// Declared in §4.2.
+    #[doc(alias = "SBI_EXT_BASE_GET_IMP_ID")]
     pub const GET_SBI_IMPL_ID: usize = 0x1;
     /// Function ID to get the current SBI implementation version.
     ///
     /// Declared in §4.3.
+    #[doc(alias = "SBI_EXT_BASE_GET_IMP_VERSION")]
     pub const GET_SBI_IMPL_VERSION: usize = 0x2;
     /// Function ID to probe information about one SBI extension from the current environment.
     ///
     /// Declared in §4.4.
+    #[doc(alias = "SBI_EXT_BASE_PROBE_EXT")]
     pub const PROBE_EXTENSION: usize = 0x3;
     /// Function ID to get the value of `mvendorid` register in the current environment.
     ///
     /// Declared in §4.5.
+    #[doc(alias = "SBI_EXT_BASE_GET_MVENDORID")]
     pub const GET_MVENDORID: usize = 0x4;
     /// Function ID to get the value of `marchid` register in the current environment.
     ///
     /// Declared in §4.6.
+    #[doc(alias = "SBI_EXT_BASE_GET_MARCHID")]
     pub const GET_MARCHID: usize = 0x5;
     /// Function ID to get the value of `mimpid` register in the current environment.
     ///
     /// Declared in §4.7.
+    #[doc(alias = "SBI_EXT_BASE_GET_MIMPID")]
     pub const GET_MIMPID: usize = 0x6;
 }
 

--- a/library/sbi-spec/src/binary.rs
+++ b/library/sbi-spec/src/binary.rs
@@ -22,32 +22,46 @@ pub struct SbiRet<T = usize> {
 }
 
 /// SBI success state return value.
+#[doc(alias = "SBI_SUCCESS")]
 pub const RET_SUCCESS: usize = <usize as SbiRegister>::RET_SUCCESS;
 /// Error for SBI call failed for unknown reasons.
+#[doc(alias = "SBI_ERR_FAILED")]
 pub const RET_ERR_FAILED: usize = <usize as SbiRegister>::RET_ERR_FAILED;
 /// Error for target operation not supported.
+#[doc(alias = "SBI_ERR_NOT_SUPPORTED")]
 pub const RET_ERR_NOT_SUPPORTED: usize = <usize as SbiRegister>::RET_ERR_NOT_SUPPORTED;
 /// Error for invalid parameter.
+#[doc(alias = "SBI_ERR_INVALID_PARAM")]
 pub const RET_ERR_INVALID_PARAM: usize = <usize as SbiRegister>::RET_ERR_INVALID_PARAM;
 /// Error for denied.
+#[doc(alias = "SBI_ERR_DENIED")]
 pub const RET_ERR_DENIED: usize = <usize as SbiRegister>::RET_ERR_DENIED;
 /// Error for invalid address.
+#[doc(alias = "SBI_ERR_INVALID_ADDRESS")]
 pub const RET_ERR_INVALID_ADDRESS: usize = <usize as SbiRegister>::RET_ERR_INVALID_ADDRESS;
 /// Error for resource already available.
+#[doc(alias = "SBI_ERR_ALREADY_AVAILABLE")]
 pub const RET_ERR_ALREADY_AVAILABLE: usize = <usize as SbiRegister>::RET_ERR_ALREADY_AVAILABLE;
 /// Error for resource already started.
+#[doc(alias = "SBI_ERR_ALREADY_STARTED")]
 pub const RET_ERR_ALREADY_STARTED: usize = <usize as SbiRegister>::RET_ERR_ALREADY_STARTED;
 /// Error for resource already stopped.
+#[doc(alias = "SBI_ERR_ALREADY_STOPPED")]
 pub const RET_ERR_ALREADY_STOPPED: usize = <usize as SbiRegister>::RET_ERR_ALREADY_STOPPED;
 /// Error for shared memory not available.
+#[doc(alias = "SBI_ERR_NO_SHMEM")]
 pub const RET_ERR_NO_SHMEM: usize = <usize as SbiRegister>::RET_ERR_NO_SHMEM;
 /// Error for invalid state.
+#[doc(alias = "SBI_ERR_INVALID_STATE")]
 pub const RET_ERR_INVALID_STATE: usize = <usize as SbiRegister>::RET_ERR_INVALID_STATE;
 /// Error for bad or invalid range.
+#[doc(alias = "SBI_ERR_BAD_RANGE")]
 pub const RET_ERR_BAD_RANGE: usize = <usize as SbiRegister>::RET_ERR_BAD_RANGE;
 /// Error for failed due to timeout.
+#[doc(alias = "SBI_ERR_TIMEOUT")]
 pub const RET_ERR_TIMEOUT: usize = <usize as SbiRegister>::RET_ERR_TIMEOUT;
 /// Error for input or output error.
+#[doc(alias = "SBI_ERR_IO")]
 pub const RET_ERR_IO: usize = <usize as SbiRegister>::RET_ERR_IO;
 
 /// Data type of register that can be passed to the RISC-V SBI ABI.

--- a/library/sbi-spec/src/cppc.rs
+++ b/library/sbi-spec/src/cppc.rs
@@ -1,6 +1,7 @@
 //! Chapter 14. CPPC Extension (EID #0x43505043 "CPPC").
 
 /// Extension ID for CPPC Extension.
+#[doc(alias = "SBI_EXT_CPPC")]
 pub const EID_CPPC: usize = crate::eid_from_str("CPPC") as _;
 pub use fid::*;
 
@@ -9,17 +10,21 @@ mod fid {
     /// Function ID to probe a CPPC register.
     ///
     /// Declared in §14.1.
+    #[doc(alias = "SBI_EXT_CPPC_PROBE")]
     pub const PROBE: usize = 0;
     /// Function ID to read CPPC register bits.
     ///
     /// Declared in §14.2.
+    #[doc(alias = "SBI_EXT_CPPC_READ")]
     pub const READ: usize = 1;
     /// Function ID to read high bits of a CPPC register.
     ///
     /// Declared in §14.3.
+    #[doc(alias = "SBI_EXT_CPPC_READ_HI")]
     pub const READ_HI: usize = 2;
     /// Function ID to write to a CPPC register.
     ///
     /// Declared in §14.4.
+    #[doc(alias = "SBI_EXT_CPPC_WRITE")]
     pub const WRITE: usize = 3;
 }

--- a/library/sbi-spec/src/dbcn.rs
+++ b/library/sbi-spec/src/dbcn.rs
@@ -1,6 +1,7 @@
 //! Chapter 12. Debug Console Extension (EID #0x4442434E "DBCN").
 
 /// Extension ID for Debug Console Extension.
+#[doc(alias = "SBI_EXT_DBCN")]
 pub const EID_DBCN: usize = crate::eid_from_str("DBCN") as _;
 pub use fid::*;
 
@@ -9,13 +10,16 @@ mod fid {
     /// Function ID to write bytes to the debug console from input memory.
     ///
     /// Declared in §12.1.
+    #[doc(alias = "SBI_EXT_DBCN_CONSOLE_WRITE")]
     pub const CONSOLE_WRITE: usize = 0;
     /// Function ID to read bytes from the debug console into an output memory.
     ///
     /// Declared in §12.2.
+    #[doc(alias = "SBI_EXT_DBCN_CONSOLE_READ")]
     pub const CONSOLE_READ: usize = 1;
     /// Function ID to write a single byte to the debug console.
     ///
     /// Declared in §12.3.
+    #[doc(alias = "SBI_EXT_DBCN_CONSOLE_WRITE_BYTE")]
     pub const CONSOLE_WRITE_BYTE: usize = 2;
 }

--- a/library/sbi-spec/src/dbtr.rs
+++ b/library/sbi-spec/src/dbtr.rs
@@ -1,6 +1,7 @@
 //! Chapter 19. Debug Triggers Extension (EID #0x44425452 "DBTR")
 
 /// Extension ID for Debug Triggers Extension.
+#[doc(alias = "SBI_EXT_DBTR")]
 pub const EID_DBTR: usize = crate::eid_from_str("DBTR") as _;
 pub use fid::*;
 
@@ -9,33 +10,41 @@ mod fid {
     /// Function ID to get the number of debug triggers on the calling hart.
     ///
     /// Declared in §19.1.
+    #[doc(alias = "SBI_EXT_DBTR_NUM_TRIGGERS")]
     pub const NUM_TRIGGERS: usize = 0;
     /// Function ID to set and enable the shared memory for debug trigger configuration on the calling hart.
     ///
     /// Declared in §19.2.
+    #[doc(alias = "SBI_EXT_DBTR_SET_SHMEM")]
     pub const SET_SHMEM: usize = 1;
     /// Function ID to read the debug trigger state and configuration into shared memory.
     ///
     /// Declared in §19.3.
+    #[doc(alias = "SBI_EXT_DBTR_TRIGGER_READ")]
     pub const READ_TRIGGERS: usize = 2;
     /// Function ID to install debug triggers based on an array of trigger configurations.
     ///
     /// Declared in §19.4.
+    #[doc(alias = "SBI_EXT_DBTR_TRIGGER_INSTALL")]
     pub const INSTALL_TRIGGERS: usize = 3;
     /// Function ID to update already installed debug triggers based on a trigger configuration array.
     ///
     /// Declared in 19.5.
+    #[doc(alias = "SBI_EXT_DBTR_TRIGGER_UPDATE")]
     pub const UPDATE_TRIGGERS: usize = 4;
     /// Function ID to uninstall a set of debug triggers.
     ///
     /// Declared in 19.6.
+    #[doc(alias = "SBI_EXT_DBTR_TRIGGER_UNINSTALL")]
     pub const UNINSTALL_TRIGGERS: usize = 5;
     /// Function ID to enable a set of debug triggers.
     ///
     /// Declared in 19.7.
+    #[doc(alias = "SBI_EXT_DBTR_TRIGGER_ENABLE")]
     pub const ENABLE_TRIGGERS: usize = 6;
     /// Function ID to disable a set of debug triggers.
     ///
     /// Declared in 19.8.
+    #[doc(alias = "SBI_EXT_DBTR_TRIGGER_DISABLE")]
     pub const DISABLE_TRIGGERS: usize = 7;
 }

--- a/library/sbi-spec/src/fwft.rs
+++ b/library/sbi-spec/src/fwft.rs
@@ -1,6 +1,7 @@
 //! Chapter 18. Firmware Features Extension (EID #0x46574654 "FWFT").
 
 /// Extension ID for Firmware Features Extension.
+#[doc(alias = "SBI_EXT_FWFT")]
 pub const EID_FWFT: usize = crate::eid_from_str("FWFT") as _;
 pub use fid::*;
 
@@ -9,10 +10,12 @@ mod fid {
     /// Set the firmware function of the request based on Value and Flags parameters.
     ///
     /// Declared in §18.1.
+    #[doc(alias = "SBI_EXT_FWFT_SET")]
     pub const SET: usize = 0;
     /// Return to the firmware function configuration value.
     ///
     /// Declared in §18.2.
+    #[doc(alias = "SBI_EXT_FWFT_GET")]
     pub const GET: usize = 1;
 }
 

--- a/library/sbi-spec/src/hsm.rs
+++ b/library/sbi-spec/src/hsm.rs
@@ -1,6 +1,7 @@
 //! Chapter 9. Hart State Management Extension (EID #0x48534D "HSM").
 
 /// Extension ID for Hart State Management extension.
+#[doc(alias = "SBI_EXT_HSM")]
 pub const EID_HSM: usize = crate::eid_from_str("HSM") as _;
 pub use fid::*;
 
@@ -9,43 +10,52 @@ pub use fid::*;
 /// Declared in Table 1 at §9.
 pub mod hart_state {
     /// The hart is physically powered-up and executing normally.
+    #[doc(alias = "SBI_HSM_STATE_STARTED")]
     pub const STARTED: usize = 0;
     /// The hart is not executing in supervisor-mode or any lower privilege mode.
     ///
     /// It is probably powered-down by the SBI implementation if the underlying platform
     /// has a mechanism to physically power-down harts.
+    #[doc(alias = "SBI_HSM_STATE_STOPPED")]
     pub const STOPPED: usize = 1;
     /// The hart is pending before being started
     ///
     /// Some other hart has requested to start (or power-up) the hart from the STOPPED state,
     /// and the SBI implementation is still working to get the hart in the STARTED state.
+    #[doc(alias = "SBI_HSM_STATE_START_PENDING")]
     pub const START_PENDING: usize = 2;
     /// The hart is pending before being stopped.
     ///
     /// The hart has requested to stop (or power-down) itself from the STARTED state,
     /// and the SBI implementation is still working to get the hart in the STOPPED state.
+    #[doc(alias = "SBI_HSM_STATE_STOP_PENDING")]
     pub const STOP_PENDING: usize = 3;
     /// The hart is in a platform-specific suspend (or low-power) state.
+    #[doc(alias = "SBI_HSM_STATE_SUSPENDED")]
     pub const SUSPENDED: usize = 4;
     /// The hart is pending before being suspended.
     ///
     /// The hart has requested to put itself in a platform-specific low-power state
     /// from the STARTED state, and the SBI implementation is still working to get
     /// the hart in the platform-specific SUSPENDED state.
+    #[doc(alias = "SBI_HSM_STATE_SUSPEND_PENDING")]
     pub const SUSPEND_PENDING: usize = 5;
     /// The hart is pending before being resumed.
     ///
     /// An interrupt or platform specific hardware event has caused the hart to resume
     /// normal execution from the SUSPENDED state, and the SBI implementation is still
     /// working to get the hart in the STARTED state.
+    #[doc(alias = "SBI_HSM_STATE_RESUME_PENDING")]
     pub const RESUME_PENDING: usize = 6;
 }
 
 /// Hart suspend types.
 pub mod suspend_type {
     /// Default retentive hart suspend type.
+    #[doc(alias = "SBI_HSM_SUSPEND_RET_DEFAULT")]
     pub const RETENTIVE: u32 = 0;
     /// Default non-retentive hart suspend type.
+    #[doc(alias = "SBI_HSM_SUSP_NON_RET_BIT")]
     pub const NON_RETENTIVE: u32 = 0x8000_0000;
 }
 
@@ -54,17 +64,21 @@ mod fid {
     /// Function ID to start executing the given hart at specified address in supervisor-mode.
     ///
     /// Declared in §9.1.
+    #[doc(alias = "SBI_EXT_HSM_HART_START")]
     pub const HART_START: usize = 0;
     /// Function ID to stop executing the calling hart in supervisor-mode.
     ///
     /// Declared in §9.2.
+    #[doc(alias = "SBI_EXT_HSM_HART_STOP")]
     pub const HART_STOP: usize = 1;
     /// Function ID to get the current status (or HSM state id) of the given hart.
     ///
     /// Declared in §9.3.
+    #[doc(alias = "SBI_EXT_HSM_HART_GET_STATUS")]
     pub const HART_GET_STATUS: usize = 2;
     /// Function ID to put the calling hart into suspend or platform-specific lower power states.
     ///
     /// Declared in §9.4.
+    #[doc(alias = "SBI_EXT_HSM_HART_SUSPEND")]
     pub const HART_SUSPEND: usize = 3;
 }

--- a/library/sbi-spec/src/lib.rs
+++ b/library/sbi-spec/src/lib.rs
@@ -386,12 +386,13 @@ mod tests {
     fn test_mpxy() {
         use crate::mpxy::*;
         const_assert_eq!(0x4D505859, EID_MPXY);
-        const_assert_eq!(0, SET_SHMEM);
-        const_assert_eq!(1, GET_CHANNEL_IDS);
-        const_assert_eq!(2, READ_ATTRIBUTE);
-        const_assert_eq!(3, WRITE_ATTRIBUTE);
-        const_assert_eq!(4, SEND_MESSAGE_WITH_RESPONSE);
-        const_assert_eq!(5, SEND_MESSAGE_WITHOUT_RESPONSE);
-        const_assert_eq!(6, GET_NOTIFICATION_EVENTS);
+        const_assert_eq!(0, GET_SHMEM_SIZE);
+        const_assert_eq!(1, SET_SHMEM);
+        const_assert_eq!(2, GET_CHANNEL_IDS);
+        const_assert_eq!(3, READ_ATTRIBUTE);
+        const_assert_eq!(4, WRITE_ATTRIBUTE);
+        const_assert_eq!(5, SEND_MESSAGE_WITH_RESPONSE);
+        const_assert_eq!(6, SEND_MESSAGE_WITHOUT_RESPONSE);
+        const_assert_eq!(7, GET_NOTIFICATION_EVENTS);
     }
 }

--- a/library/sbi-spec/src/mpxy.rs
+++ b/library/sbi-spec/src/mpxy.rs
@@ -7,32 +7,44 @@ pub use fid::*;
 
 /// Declared in §20.12.
 mod fid {
-    /// Function ID to set the shared memory for sending and receiving messages on the calling hart.
+    /// Function ID to get the version of the message proxy extension.
     ///
     /// Declared in §20.5.
-    pub const SET_SHMEM: usize = 0;
-    /// Function ID to get channel ids of the message channels accessible to the supervisor software in the shared memory of the calling hart.
+    #[doc(alias = "SBI_EXT_MPXY_GET_SHMEM_SIZE")]
+    pub const GET_SHMEM_SIZE: usize = 0;
+    /// Function ID to set the shared memory for sending and receiving messages on the calling hart.
     ///
     /// Declared in §20.6.
-    pub const GET_CHANNEL_IDS: usize = 1;
-    /// Function ID to read message channel attributes.
+    #[doc(alias = "SBI_EXT_MPXY_SET_SHMEM")]
+    pub const SET_SHMEM: usize = 1;
+    /// Function ID to get channel ids of the message channels accessible to the supervisor software in the shared memory of the calling hart.
     ///
     /// Declared in §20.7.
-    pub const READ_ATTRIBUTE: usize = 2;
-    /// Function ID to write message channel attributes.
+    #[doc(alias = "SBI_EXT_MPXY_GET_CHANNEL_IDS")]
+    pub const GET_CHANNEL_IDS: usize = 2;
+    /// Function ID to read message channel attributes.
     ///
     /// Declared in §20.8.
-    pub const WRITE_ATTRIBUTE: usize = 3;
+    #[doc(alias = "SBI_EXT_MPXY_READ_ATTRS")]
+    pub const READ_ATTRIBUTE: usize = 3;
+    /// Function ID to write message channel attributes.
+    ///
+    /// Declared in §20.9.
+    #[doc(alias = "SBI_EXT_MPXY_WRITE_ATTRS")]
+    pub const WRITE_ATTRIBUTE: usize = 4;
     /// Function ID to send a message to the mpxy channel and waits for sbi implementation for the message response.
     ///
-    /// Declared in 20.9.
-    pub const SEND_MESSAGE_WITH_RESPONSE: usize = 4;
+    /// Declared in 20.10.
+    #[doc(alias = "SBI_EXT_MPXY_SEND_MSG_WITH_RESP")]
+    pub const SEND_MESSAGE_WITH_RESPONSE: usize = 5;
     /// Function ID to send a message to the mpxy channel and does not waits for response.
     ///
-    /// Declared in 20.10.
-    pub const SEND_MESSAGE_WITHOUT_RESPONSE: usize = 5;
+    /// Declared in 20.11.
+    #[doc(alias = "SBI_EXT_MPXY_SEND_MSG_WITHOUT_RESP")]
+    pub const SEND_MESSAGE_WITHOUT_RESPONSE: usize = 6;
     /// Function ID to get the message protocol specific notification events on the mpxy channel.
     ///
-    /// Declared in 20.11.
-    pub const GET_NOTIFICATION_EVENTS: usize = 6;
+    /// Declared in 20.12.
+    #[doc(alias = "SBI_EXT_MPXY_GET_NOTIFICATION_EVENTS")]
+    pub const GET_NOTIFICATION_EVENTS: usize = 7;
 }

--- a/library/sbi-spec/src/mpxy.rs
+++ b/library/sbi-spec/src/mpxy.rs
@@ -1,6 +1,7 @@
 //! Chapter 20. Message Proxy Extension (EID #0x4D505859 "MPXY")
 
 /// Extension ID for Message Proxy Extension.
+#[doc(alias = "SBI_EXT_MPXY")]
 pub const EID_MPXY: usize = crate::eid_from_str("MPXY") as _;
 pub use fid::*;
 

--- a/library/sbi-spec/src/pmu.rs
+++ b/library/sbi-spec/src/pmu.rs
@@ -1,6 +1,7 @@
 //! Chapter 11. Performance Monitoring Unit Extension (EID #0x504D55 "PMU").
 
 /// Extension ID for Performance Monitoring Unit extension.
+#[doc(alias = "SBI_EXT_PMU")]
 pub const EID_PMU: usize = crate::eid_from_str("PMU") as _;
 pub use fid::*;
 
@@ -9,38 +10,47 @@ mod fid {
     /// Function ID to get the number of counters, both hardware and firmware.
     ///
     /// Declared in §11.6.
+    #[doc(alias = "SBI_EXT_PMU_NUM_COUNTERS")]
     pub const NUM_COUNTERS: usize = 0;
     /// Function ID to get details about the specified counter.
     ///
     /// Declared in §11.7.
+    #[doc(alias = "SBI_EXT_PMU_COUNTER_GET_INFO")]
     pub const COUNTER_GET_INFO: usize = 1;
     /// Function ID to find and configure a counter from a set of counters.
     ///
     /// Declared in §11.8.
+    #[doc(alias = "SBI_EXT_PMU_COUNTER_CFG_MATCH")]
     pub const COUNTER_CONFIG_MATCHING: usize = 2;
     /// Function ID to start or enable a set of counters on the calling hart with the specified initial value.
     ///
     /// Declared in §11.9.
+    #[doc(alias = "SBI_EXT_PMU_COUNTER_START")]
     pub const COUNTER_START: usize = 3;
     /// Function ID to stop or disable a set of counters on the calling hart.
     ///
     /// Declared in §11.10.
+    #[doc(alias = "SBI_EXT_PMU_COUNTER_STOP")]
     pub const COUNTER_STOP: usize = 4;
     /// Function ID to provide the current value of a firmware counter.
     ///
     /// Declared in §11.11.
+    #[doc(alias = "SBI_EXT_PMU_COUNTER_FW_READ")]
     pub const COUNTER_FW_READ: usize = 5;
     /// Function ID to provide the upper 32 bits from the value of the current firmware counter.
     ///
     /// Declared in §11.12.
+    #[doc(alias = "SBI_EXT_PMU_COUNTER_FW_READ_HI")]
     pub const COUNTER_FW_READ_HI: usize = 6;
     /// Function ID to set and enable the PMU snapshot shared memory.
     ///
     /// Declared in §11.13.
+    #[doc(alias = "SBI_EXT_PMU_SNAPSHOT_SET_SHMEM")]
     pub const SNAPSHOT_SET_SHMEM: usize = 7;
     /// Function ID to get details about any PMU event via shared memory.
     ///
     /// Declared in §11.14.
+    #[doc(alias = "SBI_EXT_PMU_EVENT_GET_INFO")]
     pub const EVENT_GET_INFO: usize = 8;
 }
 

--- a/library/sbi-spec/src/rfnc.rs
+++ b/library/sbi-spec/src/rfnc.rs
@@ -1,6 +1,7 @@
 //! Chapter 8. RFENCE Extension (EID #0x52464E43 "RFNC").
 
 /// Extension ID for Remote Fence extension.
+#[doc(alias = "SBI_EXT_RFENCE")]
 pub const EID_RFNC: usize = crate::eid_from_str("RFNC") as _;
 pub use fid::*;
 
@@ -9,29 +10,36 @@ mod fid {
     /// Function ID to `FENCE.I` instruction on remote harts.
     ///
     /// Declared in §8.1.
+    #[doc(alias = "SBI_EXT_RFENCE_REMOTE_FENCE_I")]
     pub const REMOTE_FENCE_I: usize = 0;
     /// Function ID to `SFENCE.VMA` for all address spaces on remote harts.
     ///
     /// Declared in §8.2.
+    #[doc(alias = "SBI_EXT_RFENCE_REMOTE_SFENCE_VMA")]
     pub const REMOTE_SFENCE_VMA: usize = 1;
     /// Function ID to address space based `SFENCE.VMA` on remote harts.
     ///
     /// Declared in §8.3.
+    #[doc(alias = "SBI_EXT_RFENCE_REMOTE_SFENCE_VMA_ASID")]
     pub const REMOTE_SFENCE_VMA_ASID: usize = 2;
     /// Function ID to virtual machine id based `HFENCE.GVMA` on remote harts.
     ///
     /// Declared in §8.4.
+    #[doc(alias = "SBI_EXT_RFENCE_REMOTE_HFENCE_GVMA_VMID")]
     pub const REMOTE_HFENCE_GVMA_VMID: usize = 3;
     /// Function ID to `HFENCE.GVMA` for all virtual machines on remote harts.
     ///
     /// Declared in §8.5.
+    #[doc(alias = "SBI_EXT_RFENCE_REMOTE_HFENCE_GVMA")]
     pub const REMOTE_HFENCE_GVMA: usize = 4;
     /// Function ID to address space based `HFENCE.VVMA` for current virtual machine on remote harts.
     ///
     /// Declared in §8.6.
+    #[doc(alias = "SBI_EXT_RFENCE_REMOTE_HFENCE_VVMA_ASID")]
     pub const REMOTE_HFENCE_VVMA_ASID: usize = 5;
     /// Function ID to `HFENCE.VVMA` for all address spaces in the current virtual machine on remote harts.
     ///
     /// Declared in §8.7.
+    #[doc(alias = "SBI_EXT_RFENCE_REMOTE_HFENCE_VVMA")]
     pub const REMOTE_HFENCE_VVMA: usize = 6;
 }

--- a/library/sbi-spec/src/spi.rs
+++ b/library/sbi-spec/src/spi.rs
@@ -1,6 +1,7 @@
 ﻿//! Chapter 7. IPI Extension (EID #0x735049 "sPI: s-mode IPI").
 
 /// Extension ID for Inter-processor Interrupt extension.
+#[doc(alias = "SBI_EXT_IPI")]
 pub const EID_SPI: usize = crate::eid_from_str("sPI") as _;
 pub use fid::*;
 
@@ -9,5 +10,6 @@ mod fid {
     /// Function ID to send an inter-processor interrupt to all harts defined in hart mask.
     ///
     /// Declared in §7.1.
+    #[doc(alias = "SBI_EXT_IPI_SEND_IPI")]
     pub const SEND_IPI: usize = 0;
 }

--- a/library/sbi-spec/src/srst.rs
+++ b/library/sbi-spec/src/srst.rs
@@ -1,19 +1,25 @@
 //! Chapter 10. System Reset Extension (EID #0x53525354 "SRST").
 
 /// Extension ID for System Reset extension.
+#[doc(alias = "SBI_EXT_SRST")]
 pub const EID_SRST: usize = crate::eid_from_str("SRST") as _;
 pub use fid::*;
 
 /// Shutdown as a reset type.
+#[doc(alias = "SBI_SRST_RESET_TYPE_SHUTDOWN")]
 pub const RESET_TYPE_SHUTDOWN: u32 = 0;
 /// Cold Reboot as a reset type.
+#[doc(alias = "SBI_SRST_RESET_TYPE_COLD_REBOOT")]
 pub const RESET_TYPE_COLD_REBOOT: u32 = 1;
 /// Warm Reboot as a reset type.
+#[doc(alias = "SBI_SRST_RESET_TYPE_WARM_REBOOT")]
 pub const RESET_TYPE_WARM_REBOOT: u32 = 2;
 
 /// No Reason as reset reason.
+#[doc(alias = "SBI_SRST_RESET_REASON_NONE")]
 pub const RESET_REASON_NO_REASON: u32 = 0;
 /// System Failure as reset reason.
+#[doc(alias = "SBI_SRST_RESET_REASON_SYSFAIL")]
 pub const RESET_REASON_SYSTEM_FAILURE: u32 = 1;
 
 /// Declared in §10.2.
@@ -21,5 +27,6 @@ mod fid {
     /// Function ID to reset the system based on provided reset type and reason.
     ///
     /// Declared in §10.1.
+    #[doc(alias = "SBI_EXT_SRST_RESET")]
     pub const SYSTEM_RESET: usize = 0;
 }

--- a/library/sbi-spec/src/sse.rs
+++ b/library/sbi-spec/src/sse.rs
@@ -1,6 +1,7 @@
 //! Chapter 17. Supervisor Software Events Extension (EID #0x535345 "SSE").
 
 /// Extension ID for Supervisor Software Events Extension.
+#[doc(alias = "SBI_EXT_SSE")]
 pub const EID_SSE: usize = crate::eid_from_str("SSE") as _;
 pub use fid::*;
 
@@ -9,41 +10,51 @@ mod fid {
     /// Function ID to read software event attributes.
     ///
     /// Declared in §17.7
+    #[doc(alias = "SBI_EXT_SSE_READ_ATTR")]
     pub const READ_ATTRS: usize = 0;
     /// Function ID to write software event attributes.
     ///
     /// Declared in §17.8
+    #[doc(alias = "SBI_EXT_SSE_WRITE_ATTR")]
     pub const WRITE_ATTRS: usize = 1;
     /// Function ID to register a software event.
     ///
     /// Declared in §17.9.
+    #[doc(alias = "SBI_EXT_SSE_REGISTER")]
     pub const REGISTER: usize = 2;
     /// Function ID to unregister a software event.
     ///
     /// Declared in §17.10.
+    #[doc(alias = "SBI_EXT_SSE_UNREGISTER")]
     pub const UNREGISTER: usize = 3;
     /// Function ID to enable a software event.
     ///
     /// Declared in §17.11.
+    #[doc(alias = "SBI_EXT_SSE_ENABLE")]
     pub const ENABLE: usize = 4;
     /// Function ID to disable a software event.
     ///
     /// Declared in §17.12.
+    #[doc(alias = "SBI_EXT_SSE_DISABLE")]
     pub const DISABLE: usize = 5;
     /// Function ID to complete software event handling.
     ///
     /// Declared in §17.13.
+    #[doc(alias = "SBI_EXT_SSE_COMPLETE")]
     pub const COMPLETE: usize = 6;
     /// Function ID to inject a software event.
     ///
     /// Declared in §17.14.
+    #[doc(alias = "SBI_EXT_SSE_INJECT")]
     pub const INJECT: usize = 7;
     /// Function ID to unmask software events on the calling hart.
     ///
     /// Declared in §17.15.
+    #[doc(alias = "SBI_EXT_SSE_HART_UNMASK")]
     pub const HART_UNMASK: usize = 8;
     /// Function ID to mask software events on the calling hart.
     ///
     /// Declared in §17.16.
+    #[doc(alias = "SBI_EXT_SSE_HART_MASK")]
     pub const HART_MASK: usize = 9;
 }

--- a/library/sbi-spec/src/susp.rs
+++ b/library/sbi-spec/src/susp.rs
@@ -1,6 +1,7 @@
 //! Chapter 13. System Suspend Extension (EID #0x53555350 "SUSP").
 
 /// Extension ID for System Suspend Extension.
+#[doc(alias = "SBI_EXT_SUSP")]
 pub const EID_SUSP: usize = crate::eid_from_str("SUSP") as _;
 pub use fid::*;
 
@@ -9,5 +10,6 @@ mod fid {
     /// Function ID to suspend under system-level sleep states.
     ///
     /// Declared in §13.1.
+    #[doc(alias = "SBI_EXT_SUSP_SUSPEND")]
     pub const SUSPEND: usize = 0;
 }

--- a/library/sbi-spec/src/time.rs
+++ b/library/sbi-spec/src/time.rs
@@ -1,6 +1,7 @@
 //! Chapter 6. Timer Extension (EID #0x54494D45 "TIME").
 
 /// Extension ID for Timer extension.
+#[doc(alias = "SBI_EXT_TIME")]
 pub const EID_TIME: usize = crate::eid_from_str("TIME") as _;
 pub use fid::*;
 
@@ -9,5 +10,6 @@ mod fid {
     /// Function ID to program the clock for the next event after an absolute time.
     ///
     /// Declared in §6.1.
+    #[doc(alias = "SBI_EXT_TIME_SET_TIMER")]
     pub const SET_TIMER: usize = 0;
 }


### PR DESCRIPTION
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

This PR mainly completed the following work：
1.  add C language naming alias tags to all functions of the sbi-rt library
2.  add C language naming alias tags to all constants in the sbi-spec package
3. fix the problem that MPXY extension support does not comply with SBI standard


The following is the test effect of the document alias：
![image](https://github.com/user-attachments/assets/0f6c1a90-2754-464e-beaa-120834d24876)


![image](https://github.com/user-attachments/assets/79c4de09-22ca-4a7b-a3c9-da0612dfae41)

Add C language naming alias tags for all constants in the sbi-spec package, referring to the naming of opensbi.
Other documents that reference the SBI standard https://github.com/riscv-non-isa/riscv-sbi-doc
