### PR TITLE
fix(prototyper): specify `serde-device-tree` commit id to resolve prototyper compilation error

### DIFF
--- a/prototyper/bench-kernel/Cargo.toml
+++ b/prototyper/bench-kernel/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 sbi-testing = { path = "../../library/sbi-testing", features = ["log"] }
 sbi-spec = { version = "0.0.8", path = "../../library/sbi-spec" }
-serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", default-features = false }
+serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", rev= "e7f9404f", default-features = false }
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 log = "0.4"
 riscv = "0.12.1"

--- a/prototyper/prototyper/Cargo.toml
+++ b/prototyper/prototyper/Cargo.toml
@@ -20,7 +20,7 @@ rustsbi = { version = "0.4.0", features = ["machine"], path = "../../library/rus
 sbi-spec = { version = "0.0.8", features = ["legacy"], path = "../../library/sbi-spec" }
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 fast-trap = { version = "0.1.0",  features = ["riscv-m"] }
-serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", default-features = false }
+serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", rev = "e7f9404f",  default-features = false }
 uart_xilinx = { git = "https://github.com/duskmoon314/uart-rs/" }
 xuantie-riscv = { git= "https://github.com/rustsbi/xuantie" }
 bouffalo-hal = { git = "https://github.com/rustsbi/bouffalo-hal", rev = "968b949", features = ["bl808"] }


### PR DESCRIPTION
Due to the break change of `serde-device-tree#4cff697c`, the prototyper has a compilation error. Therefore, specify the commit id of serde-device-tree in `Cargo.toml` as `e7f9404f` to solve the above error.
