### PR TITLE
fix(prototyper): fix incorrect mip setting when time interrupt processing

### DIFF
--- a/prototyper/prototyper/src/sbi/trap/mod.rs
+++ b/prototyper/prototyper/src/sbi/trap/mod.rs
@@ -42,7 +42,7 @@ pub extern "C" fn fast_handler(
 
                     ipi::clear_mtime();
                     unsafe {
-                        mip::clear_stimer();
+                        mip::set_stimer();
                     }
                     save_regs(&mut ctx);
                     ctx.restore()


### PR DESCRIPTION
In the previous trap refactoring, the `STIP` setting of the `mip` in the time interrupt handler was mistakenly implemented as clearing.