### PR TITLE
fix(prototyper): move device tree out of pmu protect

### DIFF
--- a/prototyper/prototyper/build.rs
+++ b/prototyper/prototyper/build.rs
@@ -17,15 +17,17 @@ SECTIONS {
     . = 0x80000000;
 
     . = ALIGN(0x1000); /* Need this to create proper sections */
-
     sbi_start = .;
+
     .text : ALIGN(0x1000) { 
         *(.text.entry)
         *(.text .text.*)
     }
 
+    . = ALIGN(0x1000);
+    sbi_rodata_start = .;
+
     .rodata : ALIGN(0x1000) { 
-        sbi_rodata_start = .;
         *(.rodata .rodata.*)
         *(.srodata .srodata.*)
         . = ALIGN(0x1000);  
@@ -41,14 +43,15 @@ SECTIONS {
         __rel_dyn_end = .;
     }
 
+    . = ALIGN(0x1000);
     sbi_rodata_end = .;
 
 	/*
 	 * PMP regions must be to be power-of-2. RX/RW will have separate
 	 * regions, so ensure that the split is power-of-2.
 	 */
-	. = ALIGN(1 << LOG2CEIL((SIZEOF(.rodata) + SIZEOF(.text)
-				+ SIZEOF(.dynsym) + SIZEOF(.rela.dyn))));
+	/* . = ALIGN(1 << LOG2CEIL((SIZEOF(.rodata) + SIZEOF(.text)
+				+ SIZEOF(.dynsym) + SIZEOF(.rela.dyn)))); */
 
     .data : ALIGN(0x1000) { 
         sbi_data_start = .;
@@ -73,8 +76,12 @@ SECTIONS {
         *(.eh_frame)
     }
 
-	. = ALIGN(0x1000); /* Need this to create proper sections */
+    . = ALIGN(0x1000);
     sbi_end = .;
+
+    .text : ALIGN(0x1000) {
+        *(.fdt)
+    }
 
     .text 0x80200000 : ALIGN(0x1000) {
         *(.payload)

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -27,7 +27,7 @@ pub struct BootHart {
 }
 
 #[naked]
-#[unsafe(link_section = ".rodata.fdt")]
+#[unsafe(link_section = ".fdt")]
 #[repr(align(16))]
 #[cfg(feature = "fdt")]
 pub extern "C" fn raw_fdt() {
@@ -67,13 +67,13 @@ static mut RODATA_END_ADDRESS: usize = 0;
 
 pub fn set_pmp(memory_range: &Range<usize>) {
     unsafe {
-        // [0..memory_range.start] RW
+        // [0..memory_range.start] RWX
         // [memory_range.start..sbi_start] RWX
         // [sbi_start..sbi_rodata_start] NONE
         // [sbi_rodata_start..sbi_rodata_end] NONE
         // [sbi_rodata_end..sbi_end] NONE
         // [sbi_end..memory_range.end] RWX
-        // [memory_range.end..INF] RW
+        // [memory_range.end..INF] RWX
         use riscv::register::*;
 
         asm!("la {}, sbi_start", out(reg) SBI_START_ADDRESS, options(nomem));
@@ -138,7 +138,7 @@ pub fn log_pmp_cfg(memory_range: &Range<usize>) {
             "{:<10} {:<10} {:<15} 0x{:08x}",
             "PMP 7:",
             "TOR",
-            "RW",
+            "RWX",
             usize::MAX
         );
     }


### PR DESCRIPTION
This pull request do the following fix:

- Move device tree out of pmu protect
- Make sure pmu section aligned with 4k