### PR TITLE
fix(prototyper): use `x0` instead of `in(reg) 0` in sfence.vma for full address space flush

### DIFF
--- a/prototyper/prototyper/src/sbi/rfence.rs
+++ b/prototyper/prototyper/src/sbi/rfence.rs
@@ -304,7 +304,7 @@ pub fn rfence_single_handler() {
                     || (ctx.size > TLB_FLUSH_LIMIT)
                 {
                     unsafe {
-                        asm!("sfence.vma {}, {}", in(reg) 0, in(reg) asid);
+                        asm!("sfence.vma x0, {}", in(reg) asid);
                     }
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {


### PR DESCRIPTION
According to the [RISC-V Privileged Architecture Specification,](https://github.com/riscv/riscv-isa-manual) when the `remote_sfence_vma_asid` function needs to flush the entire address space, it must use the `x0` register. When `rs1 = x0`, it indicates that the instruction should flush all virtual address translations in the address space. This has a special semantic meaning that is different from using a general-purpose register that simply holds the value 0.

Without this fix, the compiler may select a non-x0 register to hold the immediate value 0, leading to incorrect behavior.

![image](https://github.com/user-attachments/assets/4f3d2819-b34b-45ec-9698-7bacbde2615b)


<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
