### PR TITLE
feat: support sifive_u

### DIFF
--- a/library/rustsbi/CHANGELOG.md
+++ b/library/rustsbi/CHANGELOG.md
@@ -23,6 +23,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - lib: replace map+unwrap_or with Option::map_or in impls
 - doc: lib: alter link to Prototyper firmware in documentation.
 - doc: lib: clarify error codes in documents of SBI IPI and RFENCE extensions
+- doc: rustsbi: update `#[naked]` in docs to `#[unsafe(naked)]`
 
 ### Removed
 

--- a/library/rustsbi/src/lib.rs
+++ b/library/rustsbi/src/lib.rs
@@ -265,7 +265,7 @@
 //!
 //! ```no_run
 //! # #[cfg(nightly)] // disable checks
-//! #[naked]
+//! #[unsafe(naked)]
 //! #[link_section = ".text.entry"]
 //! #[export_name = "_start"]
 //! unsafe extern "C" fn entry() -> ! {

--- a/prototyper/bench-kernel/src/main.rs
+++ b/prototyper/bench-kernel/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(naked_functions)]
 #![allow(static_mut_refs)]
 
 #[macro_use]
@@ -30,31 +29,29 @@ const RISCV_IMAGE_MAGIC: u64 = 0x5643534952; /* Magic number, little endian, "RI
 const RISCV_IMAGE_MAGIC2: u32 = 0x05435352; /* Magic number 2, little endian, "RSC\x05" */
 
 /// boot header
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".head.text")]
 unsafe extern "C" fn _boot_header() -> ! {
-    unsafe {
-        naked_asm!(
-            "j _start",
-            ".word 0",
-            ".balign 8",
-            ".dword 0x200000",
-            ".dword iend - istart",
-            ".dword {RISCV_HEAD_FLAGS}",
-            ".word  {RISCV_HEADER_VERSION}",
-            ".word  0",
-            ".dword 0",
-            ".dword {RISCV_IMAGE_MAGIC}",
-            ".balign 4",
-            ".word  {RISCV_IMAGE_MAGIC2}",
-            ".word  0",
-            RISCV_HEAD_FLAGS = const RISCV_HEAD_FLAGS,
-            RISCV_HEADER_VERSION = const RISCV_HEADER_VERSION,
-            RISCV_IMAGE_MAGIC = const RISCV_IMAGE_MAGIC,
-            RISCV_IMAGE_MAGIC2 = const RISCV_IMAGE_MAGIC2,
-        );
-    }
+    naked_asm!(
+        "j _start",
+        ".word 0",
+        ".balign 8",
+        ".dword 0x200000",
+        ".dword iend - istart",
+        ".dword {RISCV_HEAD_FLAGS}",
+        ".word  {RISCV_HEADER_VERSION}",
+        ".word  0",
+        ".dword 0",
+        ".dword {RISCV_IMAGE_MAGIC}",
+        ".balign 4",
+        ".word  {RISCV_IMAGE_MAGIC2}",
+        ".word  0",
+        RISCV_HEAD_FLAGS = const RISCV_HEAD_FLAGS,
+        RISCV_HEADER_VERSION = const RISCV_HEADER_VERSION,
+        RISCV_IMAGE_MAGIC = const RISCV_IMAGE_MAGIC,
+        RISCV_IMAGE_MAGIC2 = const RISCV_IMAGE_MAGIC2,
+    );
 }
 
 const STACK_SIZE: usize = 512 * 1024; // 512 KiB
@@ -88,53 +85,47 @@ static mut BOOT_HART_ID: usize = 0;
 /// # Safety
 ///
 /// 裸函数。
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.entry")]
 unsafe extern "C" fn _start(hartid: usize, device_tree_paddr: usize) -> ! {
-    unsafe {
-        naked_asm!(
-            // clear bss segment
-            "   la      t0, sbss
+    naked_asm!(
+        // clear bss segment
+        "   la      t0, sbss
             la      t1, ebss
         1:  bgeu    t0, t1, 2f
             sd      zero, 0(t0)
             addi    t0, t0, 8
             j       1b",
-            "2:",
-            "   la sp, {stack} + {stack_size}",
-            "   j  {main}",
-            stack_size = const STACK_SIZE,
-            stack      =   sym STACK,
-            main       =   sym rust_main,
-        )
-    }
+        "2:",
+        "   la sp, {stack} + {stack_size}",
+        "   j  {main}",
+        stack_size = const STACK_SIZE,
+        stack      =   sym STACK,
+        main       =   sym rust_main,
+    )
 }
 
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 extern "C" fn init_hart(hartid: usize, opaque: usize) {
-    unsafe {
-        naked_asm!(
-            "add sp, a1, zero",
-            "csrw sscratch, sp",
-            "call {init_main}",
-            init_main = sym init_main,
-        )
-    }
+    naked_asm!(
+        "add sp, a1, zero",
+        "csrw sscratch, sp",
+        "call {init_main}",
+        init_main = sym init_main,
+    )
 }
 
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 extern "C" fn core_send_ipi(hartid: usize, opaque: usize) {
-    unsafe {
-        naked_asm!(
-            "add sp, a1, zero",
-            "csrw sscratch, sp",
-            "call {send_ipi}",
-            send_ipi = sym send_ipi,
-        )
-    }
+    naked_asm!(
+        "add sp, a1, zero",
+        "csrw sscratch, sp",
+        "call {send_ipi}",
+        send_ipi = sym send_ipi,
+    )
 }
 
 extern "C" fn send_ipi(hartid: usize) -> ! {

--- a/prototyper/prototyper/Cargo.toml
+++ b/prototyper/prototyper/Cargo.toml
@@ -33,6 +33,7 @@ bouffalo-hal = { git = "https://github.com/rustsbi/bouffalo-hal", rev = "968b949
 static-toml = "1"
 seq-macro = "0.3.5"
 pastey = "0.1.0"
+uart_sifive = { git = "https://github.com/duskmoon314/uart-rs/" }
 
 [[bin]]
 name = "rustsbi-prototyper"

--- a/prototyper/prototyper/src/fail.rs
+++ b/prototyper/prototyper/src/fail.rs
@@ -48,6 +48,13 @@ pub fn device_tree_deserialize_root<'a>(
     }
 }
 
+#[cold]
+pub fn stop() -> ! {
+    loop {
+        core::hint::spin_loop()
+    }
+}
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "payload")] {
     } else if #[cfg(feature = "jump")] {

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -26,7 +26,7 @@ pub struct BootHart {
     pub is_boot_hart: bool,
 }
 
-#[naked]
+#[unsafe(naked)]
 #[unsafe(link_section = ".fdt")]
 #[repr(align(16))]
 #[cfg(feature = "fdt")]

--- a/prototyper/prototyper/src/firmware/payload.rs
+++ b/prototyper/prototyper/src/firmware/payload.rs
@@ -19,10 +19,10 @@ pub fn get_boot_info(_nonstandard_a2: usize) -> BootInfo {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 #[unsafe(link_section = ".payload")]
 pub extern "C" fn payload_image() {
-    unsafe { naked_asm!(concat!(".incbin \"", env!("PROTOTYPER_PAYLOAD_PATH"), "\""),) }
+    naked_asm!(concat!(".incbin \"", env!("PROTOTYPER_PAYLOAD_PATH"), "\""),)
 }
 
 #[inline]

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -15,9 +15,10 @@ use crate::fail;
 use crate::platform::clint::{MachineClintType, SIFIVE_CLINT_COMPATIBLE, THEAD_CLINT_COMPATIBLE};
 use crate::platform::console::Uart16550Wrap;
 use crate::platform::console::UartBflbWrap;
+use crate::platform::console::UartSifiveWrap;
 use crate::platform::console::{
     MachineConsoleType, UART16650U8_COMPATIBLE, UART16650U32_COMPATIBLE, UARTAXILITE_COMPATIBLE,
-    UARTBFLB_COMPATIBLE,
+    UARTBFLB_COMPATIBLE, UARTSIFIVE_COMPATIBLE,
 };
 use crate::platform::reset::SIFIVETEST_COMPATIBLE;
 use crate::sbi::SBI;
@@ -117,6 +118,9 @@ impl Platform {
                         }
                         if UARTBFLB_COMPATIBLE.contains(&device_id) {
                             self.info.console = Some((regs.start, MachineConsoleType::UartBflb));
+                        }
+                        if UARTSIFIVE_COMPATIBLE.contains(&device_id) {
+                            self.info.console = Some((regs.start, MachineConsoleType::UartSifive));
                         }
                     }
                 }
@@ -282,6 +286,9 @@ impl Platform {
                 )))),
                 MachineConsoleType::UartBflb => Some(SbiConsole::new(Mutex::new(Box::new(
                     UartBflbWrap::new(base),
+                )))),
+                MachineConsoleType::UartSifive => Some(SbiConsole::new(Mutex::new(Box::new(
+                    UartSifiveWrap::new(base),
                 )))),
             };
         } else {


### PR DESCRIPTION
This pull request do the following jobs:

- Add `UartSifive` support
- Only choose current hart as boot hart if current hart support next_mode.
- Replace misa detection to `riscv` crate one.
- RustSBI Prototyper should work on qemu `sifive_u`.