### PR TITLE
feat(prototyper): support boot from pflash on QEMU virt platform.

### DIFF
--- a/prototyper/prototyper/src/firmware/dynamic.rs
+++ b/prototyper/prototyper/src/firmware/dynamic.rs
@@ -62,7 +62,11 @@ pub struct DynamicInfo {
 // https://github.com/riscv-software-src/opensbi/blob/019a8e69a1dc0c0f011fabd0372e1ba80e40dd7c/include/sbi/fw_dynamic.h#L75
 
 const DYNAMIC_INFO_INVALID_ADDRESSES: usize = 0x00000000;
-const NEXT_ADDR_VALID_ADDRESSES: Range<usize> = 0x80000000..0x90000000;
+const NEXT_ADDR_VALID_ADDRESSES: [Range<usize>; 2] = [
+    // Qemu Virt pflash address
+    0x20000000..0x22000000,
+    0x80000000..0x90000000,
+];
 pub(crate) const MAGIC: usize = 0x4942534f;
 const SUPPORTED_VERSION: Range<usize> = 0..3;
 
@@ -121,7 +125,9 @@ pub fn mpp_next_addr(info: &DynamicInfo) -> Result<(mstatus::MPP, usize), Dynami
     };
 
     // fail safe, errors will be aggregated after whole checking process.
-    let next_addr_valid = NEXT_ADDR_VALID_ADDRESSES.contains(&info.next_addr);
+    let next_addr_valid = NEXT_ADDR_VALID_ADDRESSES
+        .iter()
+        .any(|x| x.contains(&info.next_addr));
     let mpp_valid = matches!(info.next_mode, 0 | 1 | 3);
 
     if !next_addr_valid {


### PR DESCRIPTION
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

In the UEFI boot process, the qemu `virt` platform will load the UEFI firmware from the pflash whose address is from `0x20000000` to `0x22000000`.

Currently, the constant value `NEXT_ADDR_VALID_ADDRESSES` restricts that the firmware must be load from DDR, so in this pr, I add a new range to allow boot from pflash.