### PR TITLE
feat(spec): add spec for penglai pmp extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "library/sbi-spec",
     "library/sbi-testing",
     "library/rustsbi",
+    "library/penglai",
     "prototyper/prototyper",
     "prototyper/bench-kernel",
     "prototyper/test-kernel",

--- a/library/penglai/Cargo.toml
+++ b/library/penglai/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "penglai"
+description = "Definitions and constants in the Penglai PMP extension"
+version = "0.0.0"
+authors = ["Char <jinzhe.oerv@isrc.iscas.ac.cn>", "Luo Jia <me@luojia.cc>"]
+documentation = "https://docs.rs/penglai"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords = ["riscv", "sbi", "rustsbi", "penglai", "tee"]
+categories = ["os", "embedded", "hardware-support", "no-std"]
+
+[dev-dependencies]
+static_assertions = "1.1.0"

--- a/library/penglai/src/enclave.rs
+++ b/library/penglai/src/enclave.rs
@@ -1,0 +1,26 @@
+//! Penglai PMP enclave-side extension (Penglai Enclave extension) spec.
+
+/// Extension ID for Penglai Host extension.
+///
+/// Penglai Enclave extension isn't a standard extension. The currently used extension ID is temporary.
+pub const EID_PENGLAI_ENCLAVE: usize = 0x100101;
+pub use fid::*;
+
+mod fid {
+    /// Feature ID for enclave exit.
+    #[doc(alias = "SBI_EXIT_ENCLAVE")]
+    pub const ENCLAVE_EXIT: usize = 99;
+    /// Feature ID for request service from host.
+    #[doc(alias = "SBI_ENCLAVE_OCALL")]
+    pub const ENCLAVE_OCALL: usize = 98;
+    /// Feature ID for get key from secure monitor.
+    #[doc(alias = "SBI_GET_KEY")]
+    pub const GET_KEY: usize = 88;
+}
+
+pub mod ocall_type {
+    /// ocall for request host for print.
+    pub const OCALL_SYS_WRITE: usize = 3;
+    /// ocall reserved for user defined.
+    pub const OCALL_USER_DEFINED: usize = 9;
+}

--- a/library/penglai/src/host.rs
+++ b/library/penglai/src/host.rs
@@ -1,0 +1,56 @@
+//! Penglai PMP host-side extension (Penglai Host extension) spec.
+
+/// Extension ID for Penglai Host extension.
+///
+/// Penglai Host extension isn't a standard extension. The currently used extension ID is temporary.
+pub const EID_PENGLAI_HOST: usize = 0x100100;
+pub use fid::*;
+
+mod fid {
+    /// Feature ID for init secure memory management.
+    #[doc(alias = "SBI_MM_INIT")]
+    pub const MM_INIT: usize = 100;
+    /// Feature ID for create an enclave.
+    #[doc(alias = "SBI_CREATE_ENCLAVE")]
+    pub const CREATE_ENCLAVE: usize = 99;
+    /// Feature ID for attest enclave and generate attest report.
+    #[doc(alias = "SBI_ATTEST_ENCLAVE")]
+    pub const ATTEST_ENCLAVE: usize = 98;
+    /// Feature ID for running enclave on current hart.
+    #[doc(alias = "SBI_RUN_ENCLAVE")]
+    pub const RUN_ENCLAVE: usize = 97;
+    /// Feature ID for stoping enclave.
+    #[doc(alias = "SBI_STOP_ENCLAVE")]
+    pub const STOP_ENCLAVE: usize = 96;
+    /// Feature ID for resume enclave.
+    #[doc(alias = "SBI_RESUME_ENCLAVE")]
+    pub const RESUME_ENCLAVE: usize = 95;
+    /// Feature ID for destory enclave.
+    #[doc(alias = "SBI_DESTROY_ENCLAVE")]
+    pub const DESTROY_ENCLAVE: usize = 94;
+    /// Feature ID for allocate secure memory from secure monitor.
+    #[doc(alias = "SBI_ALLOC_ENCLAVE_MM")]
+    pub const ALLOC_ENCLAVE_MM: usize = 93;
+    /// Feature ID for extend secure memory.
+    #[doc(alias = "SBI_MEMORY_EXTEND")]
+    pub const MEMORY_EXTEND: usize = 92;
+    /// Feature ID for reclaim secure memory from secure monitor.
+    #[doc(alias = "SBI_MEMORY_RECLAIM")]
+    pub const MEMORY_RECLAIM: usize = 91;
+    /// Feature ID for free secure memory used by enclave.
+    #[doc(alias = "SBI_FREE_ENCLAVE_MEM")]
+    pub const FREE_ENCLAVE_MEM: usize = 90;
+    /// Feature ID for print debug information.
+    #[doc(alias = "SBI_DEBUG_PRINT")]
+    pub const DEBUG_PRINT: usize = 88;
+}
+
+/// Enclave resume status.
+pub mod resume_status {
+    /// Resume enclave from the timer interrupt.
+    pub const RESUME_FROM_TIMER_IRQ: usize = 2000;
+    /// Resume enclave from enclave stopped.
+    pub const RESUME_FROM_STOP: usize = 2003;
+    /// Resume enclave from an ocall.
+    pub const RESUME_FROM_OCALL: usize = 2;
+}

--- a/library/penglai/src/lib.rs
+++ b/library/penglai/src/lib.rs
@@ -1,0 +1,52 @@
+//! Penglai PMP Extension structure and constant definitions.
+//!
+//! Penglai PMP Extension is a lightweight TEE solution built on RISC-V’s PMP feature.
+//! This crate provides the SBI structures and constant definitions required by
+//! the Penglai PMP extension.
+//!
+//! This crate can be integrated as part of RustSBI and used in Prototyper,
+//! or included as a component of Rust-based bare-metal applications or operating systems
+//! to facilitate invoking services provided by the Penglai PMP extension.
+#![no_std]
+
+pub mod enclave;
+pub mod host;
+
+#[cfg(test)]
+mod tests {
+    use static_assertions::const_assert_eq;
+
+    #[test]
+    fn test_penglai_host() {
+        use crate::host::*;
+        const_assert_eq!(0x100100, EID_PENGLAI_HOST);
+        const_assert_eq!(100, MM_INIT);
+        const_assert_eq!(99, CREATE_ENCLAVE);
+        const_assert_eq!(98, ATTEST_ENCLAVE);
+        const_assert_eq!(97, RUN_ENCLAVE);
+        const_assert_eq!(96, STOP_ENCLAVE);
+        const_assert_eq!(95, RESUME_ENCLAVE);
+        const_assert_eq!(94, DESTROY_ENCLAVE);
+        const_assert_eq!(93, ALLOC_ENCLAVE_MM);
+        const_assert_eq!(92, MEMORY_EXTEND);
+        const_assert_eq!(91, MEMORY_RECLAIM);
+        const_assert_eq!(90, FREE_ENCLAVE_MEM);
+        const_assert_eq!(88, DEBUG_PRINT);
+
+        const_assert_eq!(2, resume_status::RESUME_FROM_OCALL);
+        const_assert_eq!(2003, resume_status::RESUME_FROM_STOP);
+        const_assert_eq!(2000, resume_status::RESUME_FROM_TIMER_IRQ);
+    }
+
+    #[test]
+    fn test_penglai_enclave() {
+        use crate::enclave::*;
+        const_assert_eq!(0x100101, EID_PENGLAI_ENCLAVE);
+        const_assert_eq!(99, ENCLAVE_EXIT);
+        const_assert_eq!(98, ENCLAVE_OCALL);
+        const_assert_eq!(88, GET_KEY);
+
+        const_assert_eq!(3, ocall_type::OCALL_SYS_WRITE);
+        const_assert_eq!(9, ocall_type::OCALL_USER_DEFINED);
+    }
+}


### PR DESCRIPTION
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

1. This commit defines the Penglai PMP extension specification in Rust, serves as a prerequisite for introducing the Penglai PMP extension into the RustSBI prototyper. 
3. It can be used either as part of RustSBI or independently, helping operating systems and applications access the Penglai Secure Monitor services.
4. Since the Penglai PMP extension is not part of the standard extensions, it is managed as a crate at the same level as sbi-spec.
5. Constants and their meanings should refer to the accompanying [document](https://penglai-doc.readthedocs.io/en/latest/Penglai-manual/Penglai-Opensbi-Extension-API.html); when adopting them, consistency with the OpenSBI-based Penglai PMP extension is ensured to maintain compatibility.