### PR TITLE
fix(prototyper) add `"starfive,jh7110-clint", "sifive,clint0"` to `SIFIVE_CLINT_COMPATIBLE`

### DIFF
--- a/prototyper/prototyper/src/platform/clint.rs
+++ b/prototyper/prototyper/src/platform/clint.rs
@@ -3,7 +3,8 @@ use core::arch::asm;
 use xuantie_riscv::peripheral::clint::THeadClint;
 
 use crate::sbi::ipi::IpiDevice;
-pub(crate) const SIFIVE_CLINT_COMPATIBLE: [&str; 1] = ["riscv,clint0"];
+pub(crate) const SIFIVE_CLINT_COMPATIBLE: [&str; 3] =
+    ["riscv,clint0", "starfive,jh7110-clint", "sifive,clint0"];
 pub(crate) const THEAD_CLINT_COMPATIBLE: [&str; 1] = ["thead,c900-clint"];
 
 #[doc(hidden)]


### PR DESCRIPTION
add `"starfive,jh7110-clint", "sifive,clint0"` to `SIFIVE_CLINT_COMPATIBLE`
Solve the problem that the IPI of jh7110 cannot be initialized when using the device tree in the mainline u-boot