### PR TITLE
fix(prototyper): use rustc_align attribute on function.

### DIFF
--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -28,7 +28,7 @@ pub struct BootHart {
 
 #[unsafe(naked)]
 #[unsafe(link_section = ".fdt")]
-#[repr(align(16))]
+#[rustc_align(16)]
 #[cfg(feature = "fdt")]
 pub extern "C" fn raw_fdt() {
     naked_asm!(concat!(".incbin \"", env!("PROTOTYPER_FDT_PATH"), "\""),)

--- a/prototyper/prototyper/src/sbi/early_trap.rs
+++ b/prototyper/prototyper/src/sbi/early_trap.rs
@@ -8,7 +8,7 @@ use riscv::register::mtvec;
 /// This function will change a0 and a1 and will NOT change them back.
 // TODO: Support save trap info.
 #[unsafe(naked)]
-#[repr(align(16))]
+#[rustc_align(16)]
 pub(crate) unsafe extern "C" fn light_expected_trap() {
     naked_asm!(
         "add a0, zero, zero",
@@ -39,7 +39,7 @@ impl Default for TrapInfo {
 }
 
 #[unsafe(naked)]
-#[repr(align(16))]
+#[rustc_align(16)]
 pub(crate) unsafe extern "C" fn expected_trap() {
     naked_asm!(
         "csrr a4, mepc",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly"
+channel = "nightly-2025-08-01"
 components = ["rustfmt", "clippy", "llvm-tools-preview", "rust-src"]


### PR DESCRIPTION
The upstream is trying to stablize the `align` attribute on the function, which leading to regression. So in the [pr](https://github.com/rust-lang/rust/pull/144080), the upstream renames the `align` to `rustc_align` to fix the regression.

Fix the toolchain to nightly-2025-08-01 to prevent the upstream update breaking rustsbi. I would love to suggest that update the toolchain manually once or twice one mouth.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
