### PR TITLE
docs(prototyper): update rustsbi prototyper's upstream url

### DIFF
--- a/prototyper/docs/booting-fedora-in-qemu-using-uboot-and-rustsbi.md
+++ b/prototyper/docs/booting-fedora-in-qemu-using-uboot-and-rustsbi.md
@@ -11,28 +11,30 @@
 |  RustSBI Prototyper   |  0.0.0  |
 |        U-Boot         | 2024.04 |
 
-## 准备RustSBI Prototyper， U-Boot ，Fedora 
+## 准备RustSBI Prototyper， U-Boot ，Fedora
 
 创建工作目录并进入该目录
 
-``` shell
+```shell
 $ mkdir workshop && cd workshop
 ```
 
-### Clone RustSBI Prototyper
+### Clone RustSBI
 
-``` shell
-$ git clone https://github.com/rustsbi/prototyper.git && cd prototyper && git checkout main && cd ..
+```shell
+$ git clone -b main https://github.com/rustsbi/rustsbi.git
 ```
 
 ### Clone U-Boot
 
-``` shell
-$ git clone https://github.com/u-boot/u-boot.git && cd u-boot && git checkout v2024.04 && cd ..
+```shell
+$ git clone -b v2024.04 https://github.com/u-boot/u-boot.git
 ```
+
 ### 下载 Fedora 镜像文件
 
 下载链接：<https://dl.fedoraproject.org/pub/alt/risc-v/disk_images/Fedora-40/Fedora.riscv64-40-20240429.n.0.qcow2>
+
 ```shell
 $ mkdir -p fedora
 $ cd fedora
@@ -40,17 +42,17 @@ $ wget https://dl.fedoraproject.org/pub/alt/risc-v/disk_images/Fedora-40/Fedora.
 $ cd ..
 ```
 
-## 编译RustSBI  Prototyper
+## 编译RustSBI Prototyper
 
-进入prototyper目录
+进入rustsbi目录
 
-``` shell
-$ cd prototyper
+```shell
+$ cd rustsbi
 ```
 
-编译RustSBI  Prototyper
+编译RustSBI Prototyper
 
-``` shell
+```shell
 $ cargo prototyper
 ```
 
@@ -58,7 +60,7 @@ $ cargo prototyper
 
 进入U-Boot目录
 
-``` shell
+```shell
 $ cd u-boot
 ```
 
@@ -67,7 +69,7 @@ $ cd u-boot
 ```shell
 $ export ARCH=riscv
 $ export CROSS_COMPILE=riscv64-linux-gnu-
-$ export OPENSBI=../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin 
+$ export OPENSBI=../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin
 ```
 
 生成`.config`文件,编译U-Boot
@@ -103,13 +105,13 @@ genisoimage \
 
 进入`workshop`目录
 
-``` shell
+```shell
 $ cd workshop
 ```
 
 运行下面命令
 
-``` shell
+```shell
 $ qemu-system-riscv64 \
     -nographic -machine virt \
     -smp 4 -m 8G \

--- a/prototyper/docs/booting-freebsd-in-qemu-using-uboot-and-rustsbi.md
+++ b/prototyper/docs/booting-freebsd-in-qemu-using-uboot-and-rustsbi.md
@@ -14,7 +14,7 @@ RustSBI 原型系统提供动态固件，根据前一个阶段传入的信息动
 |  qemu-system-riscv64  |  9.1.1  |
 |  RustSBI Prototyper   |  0.0.0  |
 |        U-Boot         | 2024.04 |
-|       FreeBSD         |  14.1   |
+|        FreeBSD        |  14.1   |
 
 ## 环境配置
 
@@ -22,7 +22,7 @@ RustSBI 原型系统提供动态固件，根据前一个阶段传入的信息动
 
 For Arch Linux
 
-``` shell
+```shell
 $ sudo pacman -S git riscv64-linux-gnu-gcc qemu-system-riscv
 ```
 
@@ -30,7 +30,7 @@ $ sudo pacman -S git riscv64-linux-gnu-gcc qemu-system-riscv
 
 For riscv64-linux-gnu-gcc:
 
-``` shell
+```shell
 $ riscv64-linux-gnu-gcc --version
 ```
 
@@ -45,7 +45,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 For QEMU:
 
-``` shell
+```shell
 $ qemu-system-riscv64 --version
 ```
 
@@ -60,39 +60,39 @@ Copyright (c) 2003-2024 Fabrice Bellard and the QEMU Project developers
 
 创建工作目录并进入该目录
 
-``` shell
+```shell
 $ mkdir workshop && cd workshop
 ```
 
 Clone RustSBI Prototyper
 
-``` shell
-$ git clone https://github.com/rustsbi/prototyper.git && cd prototyper && git checkout main && cd ..
+```shell
+$ git clone -b main https://github.com/rustsbi/rustsbi.git
 ```
 
 Clone U-Boot
 
-``` shell
-$ git clone https://github.com/u-boot/u-boot.git && cd u-boot && git checkout v2024.04 && cd ..
+```shell
+$ git clone -b v2024.04 https://github.com/u-boot/u-boot.git
 ```
 
 Download FreeBSD
-``` shell
+
+```shell
 $ wget https://download.freebsd.org/releases/VM-IMAGES/14.1-RELEASE/riscv64/Latest/FreeBSD-14.1-RELEASE-riscv-riscv64.raw.xz && xz -d FreeBSD-14.1-RELEASE-riscv-riscv64.raw.xz
 ```
 
+## 编译RustSBI Prototyper
 
-## 编译RustSBI  Prototyper
+进入rustsbi目录
 
-进入prototyper目录
-
-``` shell
-$ cd prototyper
+```shell
+$ cd rustsbi
 ```
 
-编译RustSBI  Prototyper
+编译RustSBI Prototyper
 
-``` shell
+```shell
 $ cargo prototyper
 ```
 
@@ -100,28 +100,28 @@ $ cargo prototyper
 
 进入U-Boot目录
 
-``` shell
+```shell
 $ cd u-boot
 ```
 
 导出环境变量
 
-``` shell
+```shell
 $ export ARCH=riscv
 $ export CROSS_COMPILE=riscv64-linux-gnu-
-$ export OPENSBI=../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin
+$ export OPENSBI=../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin
 ```
 
 生成`.config`文件
 
-``` shell
+```shell
 # To generate .config file out of board configuration file
 $ make qemu-riscv64_spl_defconfig
 ```
 
 编译U-Boot
 
-``` shell
+```shell
 # To build U-Boot
 $ make -j$(nproc)
 ```
@@ -132,13 +132,13 @@ $ make -j$(nproc)
 
 进入`workshop`目录
 
-``` shell
+```shell
 $ cd workshop
 ```
 
 运行下面命令
 
-``` shell
+```shell
 $ qemu-system-riscv64 -M virt -smp 1 -m 256M -nographic \
           -bios ./u-boot/spl/u-boot-spl \
           -device loader,file=./u-boot/u-boot.itb,addr=0x80200000 \

--- a/prototyper/docs/booting-openEuler-23.09-in-qemu-using-uboot-and-rustsbi.md
+++ b/prototyper/docs/booting-openEuler-23.09-in-qemu-using-uboot-and-rustsbi.md
@@ -12,44 +12,47 @@
 |        U-Boot         | 2024.04 |
 
 ## 准备RustSBI Prototyper， U-Boot ，openEuler 23.09
+
 创建工作目录并进入该目录
 
-``` shell
+```shell
 $ mkdir workshop && cd workshop
 ```
 
 ### Clone RustSBI Prototyper
 
-``` shell
-$ git clone https://github.com/rustsbi/prototyper.git && cd prototyper && git checkout main && cd ..
+```shell
+$ git clone -b main https://github.com/rustsbi/rustsbi.git
 ```
 
 ### Clone U-Boot
 
-``` shell
-$ git clone https://github.com/u-boot/u-boot.git && cd u-boot && git checkout v2024.04 && cd ..
+```shell
+$ git clone -b v2024.04 https://github.com/u-boot/u-boot.git
 ```
+
 ### 下载openEuler 23.09 Qemu磁盘镜像文件
 
 下载链接：[openEuler 23.09](https://mirror.iscas.ac.cn/openeuler-sig-riscv/openEuler-RISC-V/preview/openEuler-23.09-V1-riscv64/QEMU/openEuler-23.09-V1-base-qemu-preview.qcow2.zst)
+
 ```shell
  $ unzstd openEuler-23.09-V1-base-qemu-preview.qcow2.zst
 ```
+
 - The password of user `root` is `openEuler12#$`.
 - The password of the default user `openeuler` is `openEuler12#$`.
 
+## 编译RustSBI Prototyper
 
-## 编译RustSBI  Prototyper
+进入rustsbi目录
 
-进入prototyper目录
-
-``` shell
-$ cd prototyper
+```shell
+$ cd rustsbi
 ```
 
-编译RustSBI  Prototyper
+编译RustSBI Prototyper
 
-``` shell
+```shell
 $ cargo prototyper
 ```
 
@@ -57,21 +60,21 @@ $ cargo prototyper
 
 进入U-Boot目录
 
-``` shell
+```shell
 $ cd u-boot
 ```
 
 导出环境变量
 
-``` shell
+```shell
 $ export ARCH=riscv
 $ export CROSS_COMPILE=riscv64-linux-gnu-
-$ export OPENSBI=../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin 
+$ export OPENSBI=../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin
 ```
 
 生成`.config`文件,编译U-Boot
 
-``` shell
+```shell
 # To generate .config file out of board configuration file
 $ make qemu-riscv64_spl_defconfig
 $ ./scripts/config -e CMD_BTRFS -e FS_BTRFS
@@ -84,13 +87,13 @@ $ make -j$(nproc)
 
 进入`workshop`目录
 
-``` shell
+```shell
 $ cd workshop
 ```
 
 运行下面命令
 
-``` shell
+```shell
 $ qemu-system-riscv64 \
     -nographic -machine virt \
     -smp 4 -m 8G \

--- a/prototyper/docs/booting-polyos-in-qemu-using-uboot-and-rustsbi.md
+++ b/prototyper/docs/booting-polyos-in-qemu-using-uboot-and-rustsbi.md
@@ -8,50 +8,49 @@
 
 ### Clone & Compile RustSBI Prototyper
 
-``` shell
+```shell
 $ cd $workdir
-$ git clone https://github.com/rustsbi/prototyper.git && cd prototyper && git checkout main && cd ..
+$ git clone -b main https://github.com/rustsbi/rustsbi.git
 ```
 
-``` shell
-$ cd prototyper
+```shell
+$ cd rustsbi
 ```
 
-编译RustSBI  Prototyper
+编译RustSBI Prototyper
 
-``` shell
+```shell
 $ cargo prototyper
 ```
 
 ### Clone & Compile U-Boot
 
-``` shell
+```shell
 $ cd $workdir
-$ git clone https://github.com/u-boot/u-boot.git && cd u-boot && git checkout v2024.04 && cd ..
+$ git clone -b v2024.04 https://github.com/u-boot/u-boot.git
 ```
 
 进入U-Boot目录
 
-``` shell
+```shell
 $ cd u-boot
 ```
 
 导出环境变量
 
-``` shell
+```shell
 $ export ARCH=riscv
 $ export CROSS_COMPILE=riscv64-linux-gnu-
-$ export OPENSBI=../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin 
+$ export OPENSBI=../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin
 ```
 
 生成`.config`文件,编译U-Boot
 
-``` shell
+```shell
 # To generate .config file out of board configuration file
 $ make qemu-riscv64_spl_defconfig
 $ make -j$(nproc)
 ```
-
 
 ### Download & Configure PolyOS
 
@@ -120,6 +119,7 @@ $ losetup -d /dev/loop1
 ### USE Qemu to bootup
 
 使用 qemu 启动：
+
 ```shell
 $ cd $workdir/image
 image_path=`pwd`

--- a/prototyper/docs/booting-test-kernel-in-qemu-using-uboot-and-rustsbi.md
+++ b/prototyper/docs/booting-test-kernel-in-qemu-using-uboot-and-rustsbi.md
@@ -3,6 +3,7 @@
 本教程给出了使用RustSBI和U-Boot在QEMU中启动Test Kernel的基本流程。
 
 其中启动流程分为两种类型：
+
 1. 只使用U-Boot SPL的启动流程
 2. 同时使用U-Boot SPL和U-Boot的启动流程。
 
@@ -31,13 +32,13 @@
 
 For Arch Linux:
 
-``` shell
+```shell
 $ sudo pacman -S git riscv64-linux-gnu-gcc qemu-system-riscv uboot-tools
 ```
 
 For Ubuntu:
 
-``` shell
+```shell
 $ sudo apt-get update && sudo apt-get upgrade
 $ sudo apt-get install git qemu-system-misc gcc-riscv64-linux-gnu u-boot-tools
 ```
@@ -46,7 +47,7 @@ $ sudo apt-get install git qemu-system-misc gcc-riscv64-linux-gnu u-boot-tools
 
 For riscv64-linux-gnu-gcc:
 
-``` shell
+```shell
 $ riscv64-linux-gnu-gcc --version
 ```
 
@@ -60,7 +61,7 @@ This is free software; see the source for copying conditions.  There is NO warra
 
 For QEMU:
 
-``` shell
+```shell
 $ qemu-system-riscv64 --version
 ```
 
@@ -75,59 +76,60 @@ Copyright (c) 2003-2024 Fabrice Bellard and the QEMU Project developers
 
 创建工作目录并进入该目录
 
-``` shell
+```shell
 $ mkdir workshop && cd workshop
 ```
 
 Clone RustSBI Prototyper
 
-``` shell
-$ git clone https://github.com/rustsbi/prototyper.git && cd prototyper && git checkout main && cd ..
+```shell
+$ git clone -b main https://github.com/rustsbi/rustsbi.git
 ```
 
 Clone U-Boot
 
-``` shell
-$ git clone https://github.com/u-boot/u-boot.git && cd u-boot && git checkout v2024.04 && cd ..
+```shell
+$ git clone -b v2024.04 https://github.com/u-boot/u-boot.git
 ```
 
 ## 使用U-Boot SPL启动Test Kernel
-### 编译RustSBI  Prototyper和Test Kernel
 
-进入prototyper目录
+### 编译RustSBI Prototyper和Test Kernel
 
-``` shell
-$ cd prototyper
+进入rustsbi目录
+
+```shell
+$ cd rustsbi
 ```
 
 编译RustSBI Prototyper和Test Kernel
 
-``` shell
+```shell
 $ cargo prototyper
 $ cargo test-kernel --pack
 ```
 
-本小节将使用二进制文件 `./target/riscv64imac-unknown-none-elf/release/rustsbi-test-kernel.itb`。
+本小节将使用二进制文件 `./target/riscv64gc-unknown-none-elf/release/rustsbi-test-kernel.itb`。
 
 ### 编译U-Boot SPL
 
 进入U-Boot目录
 
-``` shell
+```shell
 $ cd u-boot
 ```
 
 导出环境变量
 
-``` shell
+```shell
 $ export ARCH=riscv
 $ export CROSS_COMPILE=riscv64-linux-gnu-
-$ export OPENSBI=../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin
+$ export OPENSBI=../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin
 ```
 
 生成`.config`文件
 
-``` shell
+```shell
 # To generate .config file out of board configuration file
 $ make qemu-riscv64_spl_defconfig
 # add bootcmd value
@@ -136,7 +138,7 @@ $ make menuconfig
 
 编译U-Boot
 
-``` shell
+```shell
 # To build U-Boot
 $ make -j$(nproc)
 ```
@@ -147,54 +149,56 @@ $ make -j$(nproc)
 
 进入`workshop`目录
 
-``` shell
+```shell
 $ cd workshop
 ```
 
 运行下面命令
 
-``` shell
+```shell
 $ qemu-system-riscv64 -M virt -smp 1 -m 256M -nographic \
           -bios ./u-boot/spl/u-boot-spl \
-          -device loader,file=./prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-test-kernel.itb,addr=0x80200000
+          -device loader,file=./rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-test-kernel.itb,addr=0x80200000
 ```
 
 ## 使用U-Boot SPL和U-Boot启动Test Kernel
-### 编译RustSBI  Prototyper和Test Kernel
 
-进入prototyper目录
+### 编译RustSBI Prototyper和Test Kernel
 
-``` shell
-$ cd prototyper
+进入rustsbi目录
+
+```shell
+$ cd rustsbi
 ```
 
 编译RustSBI Prototyper和Test Kernel
 
-``` shell
-$ cargo make prototyper
-$ cargo make test-kernel
+```shell
+$ cargo prototyper
+$ cargo test-kernel
 ```
-本小节将使用二进制文件 `./target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin`和`./target/riscv64imac-unknown-none-elf/release/rustsbi-test-kernel.bin`。
+
+本小节将使用二进制文件 `./target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin`和`./target/riscv64gc-unknown-none-elf/release/rustsbi-test-kernel.bin`。
 
 ### 编译U-Boot SPL
 
 进入U-Boot目录
 
-``` shell
+```shell
 $ cd u-boot
 ```
 
 导出环境变量
 
-``` shell
+```shell
 $ export ARCH=riscv
 $ export CROSS_COMPILE=riscv64-linux-gnu-
-$ export OPENSBI=../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin
+$ export OPENSBI=../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin
 ```
 
 生成`.config`文件
 
-``` shell
+```shell
 # To generate .config file out of board configuration file
 $ make qemu-riscv64_spl_defconfig
 # add bootcmd value
@@ -209,7 +213,7 @@ ext4load virtio 0:1 84000000 rustsbi-test-kernel.bin; booti 0x84000000 - ${fdtco
 
 编译U-Boot
 
-``` shell
+```shell
 # To build U-Boot
 $ make -j$(nproc)
 ```
@@ -217,9 +221,10 @@ $ make -j$(nproc)
 本小节将使用二进制文件 `./spl/u-boot-spl`和`./u-boot.itb `。
 
 ### 创建启动盘
+
 在`workshop`目录运行以下命令来创建一个256 MB的磁盘镜像
 
-``` shell
+```shell
 # Create a 256 MB disk image
 $ qemu-img create test-kernel.img 256m
 ```
@@ -230,13 +235,13 @@ $ qemu-img create test-kernel.img 256m
 
 `parted`命令将用于在镜像`test-kernel.img`中创建分区。在镜像中创建分区表：
 
-``` shell
+```shell
 $ sudo parted test-kernel.img mklabel gpt
 ```
 
 现在`test-kernel.img`中有一个分区表。将`test-kernel.img`挂载为loop device，以便它可以用作块设备。将`test-kernel.img`挂载为块设备将允许在其中创建分区。
 
-``` shell
+```shell
 # Attach test-kernel.img with the first available loop device
 $ sudo losetup --find --show test-kernel.img
 ```
@@ -248,7 +253,7 @@ $ sudo losetup --find --show test-kernel.img
 
 对`/dev/loop0`分区
 
-``` shell
+```shell
 # Create a couple of primary partitions
 $ sudo parted --align minimal /dev/loop0 mkpart primary ext4 0 100%
 
@@ -259,7 +264,7 @@ $ sudo parted /dev/loop0 print
 
 通过以下命令查看分区：
 
-``` shell
+```shell
 $ ls -l /dev/loop0*
 ```
 
@@ -267,7 +272,7 @@ $ ls -l /dev/loop0*
 
 格式化分区并创建`ext4`文件系统，同时将分区设置为可引导分区。
 
-``` shell
+```shell
 $ sudo mkfs.ext4 /dev/loop0p1
 
 # Mark first partition as bootable
@@ -276,27 +281,29 @@ $ sudo parted /dev/loop0 set 1 boot on
 
 #### 将Linux Kernel和根文件系统拷贝进启动盘
 
-``` shell
+```shell
 # Mount the 1st partition
 $ sudo mkdir test-kernel
 $ sudo mount /dev/loop0p1 test-kernel
 $ cd test-kernel
 ```
+
 拷贝Linux Kernel镜像
-``` shell
-$ sudo cp ../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-test-kernel.bin .
+
+```shell
+$ sudo cp ../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-test-kernel.bin .
 ```
 
 卸载`test-kernel`
 
-``` shell
+```shell
 $ cd workshop
 $ sudo umount test-kernel
 ```
 
 将`/dev/loop0`分离
 
-``` shell
+```shell
 $ sudo losetup -d /dev/loop0
 ```
 
@@ -304,13 +311,13 @@ $ sudo losetup -d /dev/loop0
 
 进入`workshop`目录
 
-``` shell
+```shell
 $ cd workshop
 ```
 
 运行下面命令
 
-``` shell
+```shell
 $ qemu-system-riscv64 -M virt -smp 1 -m 256M -nographic \
           -bios ./u-boot/spl/u-boot-spl \
           -device loader,file=./u-boot/u-boot.itb,addr=0x80200000 \

--- a/prototyper/docs/booting-ubuntu-24.04.1-in-qemu-using-uboot-and-rustsbi.md
+++ b/prototyper/docs/booting-ubuntu-24.04.1-in-qemu-using-uboot-and-rustsbi.md
@@ -12,26 +12,29 @@
 |        U-Boot         | 2024.04 |
 
 ## 准备RustSBI Prototyper， U-Boot ，Ubuntu 24.04.1
+
 创建工作目录并进入该目录
 
-``` shell
+```shell
 $ mkdir workshop && cd workshop
 ```
 
 ### Clone RustSBI Prototyper
 
-``` shell
-$ git clone https://github.com/rustsbi/prototyper.git && cd prototyper && git checkout main && cd ..
+```shell
+$ git clone -b main https://github.com/rustsbi/rustsbi.git
 ```
 
 ### Clone U-Boot
 
-``` shell
-$ git clone https://github.com/u-boot/u-boot.git && cd u-boot && git checkout v2024.04 && cd ..
+```shell
+$ git clone -b v2024.04 https://github.com/u-boot/u-boot.git
 ```
+
 ### 下载并扩容 Ubuntu 24.04.1 磁盘镜像文件
 
 下载链接：[Ubuntu 24.04.1](https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04.1-preinstalled-server-riscv64.img.xz)
+
 ```shell
  $ unar ubuntu-24.04.1-preinstalled-server-riscv64.img.xz
  $ qemu-img resize -f raw ubuntu-24.04.1-preinstalled-server-riscv64.img +5G
@@ -41,18 +44,17 @@ $ git clone https://github.com/u-boot/u-boot.git && cd u-boot && git checkout v2
 - 登录后应会被要求更改登录密码。
 - 可以通过 `sudo` 更改 root 密码。
 
+## 编译RustSBI Prototyper
 
-## 编译RustSBI  Prototyper
+进入rustsbi目录
 
-进入prototyper目录
-
-``` shell
-$ cd prototyper
+```shell
+$ cd rustsbi
 ```
 
-编译RustSBI  Prototyper
+编译RustSBI Prototyper
 
-``` shell
+```shell
 $ cargo prototyper
 ```
 
@@ -60,21 +62,21 @@ $ cargo prototyper
 
 进入U-Boot目录
 
-``` shell
+```shell
 $ cd u-boot
 ```
 
 导出环境变量
 
-``` shell
+```shell
 $ export ARCH=riscv
 $ export CROSS_COMPILE=riscv64-linux-gnu-
-$ export OPENSBI=../prototyper/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper.bin 
+$ export OPENSBI=../rustsbi/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper.bin
 ```
 
 生成`.config`文件,编译U-Boot
 
-``` shell
+```shell
 # To generate .config file out of board configuration file
 $ make qemu-riscv64_spl_defconfig
 $ make -j$(nproc)
@@ -84,13 +86,13 @@ $ make -j$(nproc)
 
 进入`workshop`目录
 
-``` shell
+```shell
 $ cd workshop
 ```
 
 运行下面命令
 
-``` shell
+```shell
 $ qemu-system-riscv64 \
     -nographic -machine virt \
     -smp 4 -m 8G \


### PR DESCRIPTION
Since prototyper was merged into the rustsbi repository, the upstream urls in the documentation have become invalid. This PR updates those urls and fixes some outdated commands.
