### PR TITLE
feat(cove): (1/n) add COVH riscv-cove-rt CoVE S-mode runtime module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "library/sbi-testing",
     "library/rustsbi",
     "library/riscv-cove",
+    "library/riscv-cove-rt",
     "library/penglai",
     "prototyper/prototyper",
     "prototyper/bench-kernel",

--- a/library/riscv-cove-rt/Cargo.toml
+++ b/library/riscv-cove-rt/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "riscv-cove-rt"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+riscv-cove = { version = "0.0.0", path = "../riscv-cove" }
+sbi-spec = { version = "0.0.8", path = "../sbi-spec" }
+sbi-rt = { version = "0.0.3", path = "../sbi-rt" }

--- a/library/riscv-cove-rt/src/host.rs
+++ b/library/riscv-cove-rt/src/host.rs
@@ -1,0 +1,13 @@
+//! Chapter 10, COVE Host Extension (EID #0x434F5648 "COVH").
+use riscv_cove::host::{EID_COVH, GET_TSM_INFO, TsmInfo};
+use sbi_spec::binary::{Physical, SbiRet};
+
+/// Reads the current TSM state, its configuration and supported features.
+#[inline]
+#[doc(alias = "sbi_covh_get_tsm_info")]
+pub fn covh_get_tsm_info(mem: Physical<&mut TsmInfo>) -> SbiRet {
+    // TODO mem.phys_addr_hi should be used.
+    unsafe { sbi_rt::raw::sbi_call_2(EID_COVH, GET_TSM_INFO, mem.phys_addr_lo(), mem.num_bytes()) }
+}
+
+// TODO other functions

--- a/library/riscv-cove-rt/src/host.rs
+++ b/library/riscv-cove-rt/src/host.rs
@@ -6,7 +6,7 @@ use sbi_spec::binary::{Physical, SbiRet};
 #[inline]
 #[doc(alias = "sbi_covh_get_tsm_info")]
 pub fn covh_get_tsm_info(mem: Physical<&mut TsmInfo>) -> SbiRet {
-    // TODO mem.phys_addr_hi should be used.
+    // TODO mem.phys_addr_hi should be used. The physical memory parameter should be parsed in `_hi` and `_lo` pairs, ref: https://lists.riscv.org/g/tech-ap-tee/topic/114646239#msg207 .
     unsafe { sbi_rt::raw::sbi_call_2(EID_COVH, GET_TSM_INFO, mem.phys_addr_lo(), mem.num_bytes()) }
 }
 

--- a/library/riscv-cove-rt/src/lib.rs
+++ b/library/riscv-cove-rt/src/lib.rs
@@ -1,0 +1,10 @@
+// TODO crate level descriptions.
+#![no_std]
+
+mod host;
+// TODO mod guest;
+// TODO mod interrupt;
+
+pub use host::*;
+// TODO pub use guest::*;
+// TODO pub use interrupt::*;

--- a/library/riscv-cove/src/host.rs
+++ b/library/riscv-cove/src/host.rs
@@ -108,3 +108,60 @@ mod fid {
     #[doc(alias = "SBI_EXT_COVH_TVM_REMOVE_PAGES")]
     pub const TVM_REMOVE_PAGES: usize = 19;
 }
+
+/// Possible state of a TEE Security Manager (TSM).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u32)]
+pub enum TsmState {
+    /// TSM has not been loaded on this platform.
+    NotLoaded = 0,
+    /// TSM has been loaded, but has not yet been initialized.
+    Loaded = 1,
+    /// TSM has been loaded & initialized, and is ready to accept ECALLs.
+    Ready = 2,
+}
+
+// TODO generic type of T replacing `usize`s, see sbi_spec::binary::SbiRet
+/// Information structure of a TEE Security Manager (TSM).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(C)]
+pub struct TsmInfo {
+    /// The raw current state of the TSM.
+    ///
+    /// If the state is not [`Ready`], the remanining fields are invalid
+    /// and will be initialized to zero.
+    ///
+    /// [`Ready`]: struct.TsmState.html#Ready
+    pub tsm_state: u32,
+    /// Identifier of the TSM implementation.
+    ///
+    /// This identifier is intended to distinguish among different TSM
+    /// implementations, potentially managed by different organizations,
+    /// that might target different deployment models and, thus,
+    /// implement subset of CoVE specification.
+    pub tsm_impl_id: u32,
+    /// Version number of the running TSM.
+    pub tsm_version: u32,
+    /// A bit mask of CoVE features supported by the running TSM.
+    ///
+    /// Every bit in this field corresponds to a capability defined by
+    /// constants. Presense of bit `i` indicates that both the TSM and
+    /// hardware support the corresponding capability.
+    pub tsm_capabilities: usize,
+    /// The number of 4-KiB pages which must be donated to the TSM for
+    /// storing TVM state in `covh_create_tvm_vcpu`.
+    ///
+    /// `0` if the TSM does not support the dynamic memory allocation
+    /// capability.
+    pub tvm_state_pages: usize,
+    /// The maximum number of vCPUs a TVM can support.
+    pub tvm_max_vcpus: usize,
+    /// The number of 4-KiB pages which must be donated to the TSM when
+    /// creating a new vCPU.
+    ///
+    /// `0` if the TSM does not support the dynamic memory allocation
+    /// capability.
+    pub tvm_vcpu_state_pages: usize,
+}
+
+// TODO unit tests on offsets of TsmInfo.

--- a/library/sbi-rt/CHANGELOG.md
+++ b/library/sbi-rt/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - rt: add structure for SSE, FWFT, DBTR, and MPXY extensions
 - rt: add SSE extension support to SBI implementation.
 - feat(rt): add MPXY extension support to SBI runtime library.
+- lib: add `raw` module for raw SBI calls; they may be used in runtime libraries for custom SBI extensions.
 
 ### Modified
 

--- a/library/sbi-rt/src/lib.rs
+++ b/library/sbi-rt/src/lib.rs
@@ -76,8 +76,8 @@ pub use time::*;
 
 /// Raw RISC-V SBI calls.
 ///
-/// This module is not intended for direct use; it should be used by other SBI runtime libraries
-/// to wrap SBI `ecall` instruction into Rust friendly functions.
+/// This module is not intended for direct use; it should be used by runtime libraries for custom
+/// SBI extensions, to wrap SBI `ecall` instruction into Rust friendly functions.
 ///
 /// SBI runtime users should use functions from root of this library, or functions from other SBI
 /// runtime libraries.

--- a/library/sbi-rt/src/lib.rs
+++ b/library/sbi-rt/src/lib.rs
@@ -73,3 +73,34 @@ pub use sse::*;
 pub use sta::*;
 pub use susp::*;
 pub use time::*;
+
+/// Raw RISC-V SBI calls.
+///
+/// This module is not intended for direct use; it should be used by other SBI runtime libraries
+/// to wrap SBI `ecall` instruction into Rust friendly functions.
+///
+/// SBI runtime users should use functions from root of this library, or functions from other SBI
+/// runtime libraries.
+pub mod raw {
+    use sbi_spec::binary::SbiRet;
+
+    /// Raw SBI call with 0 parameters.
+    #[inline(always)]
+    pub unsafe fn sbi_call_0(eid: usize, fid: usize) -> SbiRet {
+        super::binary::sbi_call_0(eid, fid)
+    }
+
+    /// Raw SBI call with 1 parameter.
+    #[inline(always)]
+    pub unsafe fn sbi_call_1(eid: usize, fid: usize, arg0: usize) -> SbiRet {
+        super::binary::sbi_call_1(eid, fid, arg0)
+    }
+
+    /// Raw SBI call with 2 parameters.
+    #[inline(always)]
+    pub unsafe fn sbi_call_2(eid: usize, fid: usize, arg0: usize, arg1: usize) -> SbiRet {
+        super::binary::sbi_call_2(eid, fid, arg0, arg1)
+    }
+
+    // TODO sbi_call_3, ..., sbi_call_6
+}


### PR DESCRIPTION
Ref: https://github.com/rivosinc/sbi-rs/blob/main/src/cove_host.rs

TODO: The physical memory parameter should be parsed in `_hi` and `_lo` pairs, ref: https://lists.riscv.org/g/tech-ap-tee/topic/114646239#msg207 .