### PR TITLE
feat(prototyper): auto add reversed-memory device tree node

### DIFF
--- a/prototyper/prototyper/Cargo.toml
+++ b/prototyper/prototyper/Cargo.toml
@@ -24,7 +24,7 @@ sbi-spec = { version = "0.0.8", features = [
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 aclint = { git = "https://github.com/rustsbi/aclint", rev = "b2136a66" }
 fast-trap = { git = "https://github.com/rustsbi/fast-trap", rev = "8d855afa", features = ["riscv-m"] }
-serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", rev = "2a5d6ab7", default-features = false }
+serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", rev = "805718b", default-features = false, features = ["ser"] }
 uart_xilinx = { git = "https://github.com/duskmoon314/uart-rs/", rev = "12be9142" }
 xuantie-riscv = { git = "https://github.com/rustsbi/xuantie", rev = "7a521c04" }
 bouffalo-hal = { git = "https://github.com/rustsbi/bouffalo-hal", rev = "968b949", features = [

--- a/prototyper/prototyper/build.rs
+++ b/prototyper/prototyper/build.rs
@@ -77,11 +77,12 @@ SECTIONS {
     }
 
     . = ALIGN(0x1000);
-    sbi_end = .;
 
     .text : ALIGN(0x1000) {
         *(.fdt)
+        *(.patched_fdt)
     }
+    sbi_end = .;
 
     .text 0x80200000 : ALIGN(0x1000) {
         *(.payload)

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -96,7 +96,7 @@ pub fn patch_device_tree(device_tree_ptr: usize) -> usize {
     let tree: Node = root.deserialize();
 
     #[derive(Serialize)]
-    struct ReversedMemory {
+    struct ReservedMemory {
         #[serde(rename = "#address-cells")]
         pub address_cell: u32,
         #[serde(rename = "#size-cells")]
@@ -104,33 +104,33 @@ pub fn patch_device_tree(device_tree_ptr: usize) -> usize {
         pub ranges: (),
     }
     #[derive(Serialize)]
-    struct ReversedMemoryItem {
+    struct ReservedMemoryItem {
         pub reg: [u32; 4],
         #[serde(rename = "no-map")]
         pub no_map: (),
     }
-    // Make patch list and generate reversed-memory node.
+    // Make patch list and generate reserved-memory node.
     let sbi_length: u32 = (sbi_end - sbi_start) as u32;
-    let new_base = ReversedMemory {
+    let new_base = ReservedMemory {
         address_cell: 2,
         size_cell: 2,
         ranges: (),
     };
-    let new_base_2 = ReversedMemoryItem {
-        reg: [(sbi_end >> 32) as u32, sbi_end as u32, 0, sbi_length],
+    let new_base_2 = ReservedMemoryItem {
+        reg: [(sbi_start >> 32) as u32, sbi_start as u32, 0, sbi_length],
         no_map: (),
     };
     let patch1 = serde_device_tree::ser::patch::Patch::new(
-        "/reversed-memory",
+        "/reserved-memory",
         &new_base as _,
         ValueType::Node,
     );
-    let path_name = format!("/reversed-memory/mmode_resv1@{:x}", sbi_start);
+    let path_name = format!("/reserved-memory/mmode_resv1@{:x}", sbi_start);
     let patch2 =
         serde_device_tree::ser::patch::Patch::new(&path_name, &new_base_2 as _, ValueType::Node);
     let raw_list = [patch1, patch2];
-    // Only patch `reversed-memory` when it not exists.
-    let list = if tree.find("/reversed-memory").is_some() {
+    // Only patch `reserved-memory` when it not exists.
+    let list = if tree.find("/reserved-memory").is_some() {
         &raw_list[1..]
     } else {
         &raw_list[..]

--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -78,6 +78,8 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
             PLATFORM.print_board_info();
         }
 
+        let fdt_address = firmware::patch_device_tree(fdt_address);
+
         firmware::set_pmp(unsafe { PLATFORM.info.memory_range.as_ref().unwrap() });
         firmware::log_pmp_cfg(unsafe { PLATFORM.info.memory_range.as_ref().unwrap() });
 


### PR DESCRIPTION
As [docs](https://github.com/rustsbi/rustsbi/blob/main/prototyper/docs/booting-archlinux-in-qemu-using-edk2-and-rustsbi.md) said, prototyper will not add `reversed-memory` node automatically and may cause problem.

This pull request done the following jobs:

- Auto add `reversed-memory` node and protect sbi memory by it.

Wait for https://github.com/rustsbi/serde-device-tree/pull/17 for unit serialize support.