### PR TITLE
feat(prototyper): add support for ARM PL011 UART and update platform …

### DIFF
--- a/prototyper/prototyper/Cargo.toml
+++ b/prototyper/prototyper/Cargo.toml
@@ -34,6 +34,7 @@ static-toml = "1"
 seq-macro = "0.3.5"
 pastey = "0.1.0"
 uart_sifive = { git = "https://github.com/duskmoon314/uart-rs/" }
+arm-pl011-uart = "0.3.2"
 
 [[bin]]
 name = "rustsbi-prototyper"

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -15,10 +15,11 @@ use crate::fail;
 use crate::platform::clint::{MachineClintType, SIFIVE_CLINT_COMPATIBLE, THEAD_CLINT_COMPATIBLE};
 use crate::platform::console::Uart16550Wrap;
 use crate::platform::console::UartBflbWrap;
+use crate::platform::console::UartPl011Wrap;
 use crate::platform::console::UartSifiveWrap;
 use crate::platform::console::{
     MachineConsoleType, UART16650U8_COMPATIBLE, UART16650U32_COMPATIBLE, UARTAXILITE_COMPATIBLE,
-    UARTBFLB_COMPATIBLE, UARTSIFIVE_COMPATIBLE,
+    UARTBFLB_COMPATIBLE, UARTPL011_COMPATIBLE, UARTSIFIVE_COMPATIBLE,
 };
 use crate::platform::reset::SIFIVETEST_COMPATIBLE;
 use crate::sbi::SBI;
@@ -121,6 +122,9 @@ impl Platform {
                         }
                         if UARTSIFIVE_COMPATIBLE.contains(&device_id) {
                             self.info.console = Some((regs.start, MachineConsoleType::UartSifive));
+                        }
+                        if UARTPL011_COMPATIBLE.contains(&device_id) {
+                            self.info.console = Some((regs.start, MachineConsoleType::UartPl011));
                         }
                     }
                 }
@@ -289,6 +293,9 @@ impl Platform {
                 )))),
                 MachineConsoleType::UartSifive => Some(SbiConsole::new(Mutex::new(Box::new(
                     UartSifiveWrap::new(base),
+                )))),
+                MachineConsoleType::UartPl011 => Some(SbiConsole::new(Mutex::new(Box::new(
+                    UartPl011Wrap::new(base),
                 )))),
             };
         } else {


### PR DESCRIPTION
This pull request adds support for the PL011 UART device to the RustSBI prototyper platform. The main changes include introducing a wrapper for the PL011 UART, updating platform detection logic to recognize PL011-compatible devices, and integrating the new UART type into the console initialization flow.