### PR TITLE
fix(prototyper): the clippy check failed due to target uninstalled.

### DIFF
--- a/.github/workflows/prototyper.yml
+++ b/.github/workflows/prototyper.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
 
+      - name: Install required target
+        run: rustup target add riscv64imac-unknown-none-elf
+
       - name: Run rust-clippy
         run: |
           cargo clippy -p rustsbi-prototyper --target riscv64imac-unknown-none-elf  --message-format=json  | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt

--- a/.github/workflows/prototyper.yml
+++ b/.github/workflows/prototyper.yml
@@ -34,7 +34,7 @@ jobs:
             cargo test -p rustsbi-prototyper
 
       - name: Install required cargo
-        run: cargo install clippy-sarif sarif-fmt
+        run: cargo install clippy-sarif sarif-fmt cargo-binutils
 
       - name: Install required target
         run: rustup target add riscv64imac-unknown-none-elf

--- a/.github/workflows/prototyper.yml
+++ b/.github/workflows/prototyper.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install required target
         run: rustup target add riscv64imac-unknown-none-elf
       
-      # Build the prototyper is needded before running cargo clippy for it, as the build is dependent on some logic controlled by xtask.
+      # Build the prototyper is needed before running cargo clippy for it, as the build is dependent on some logic controlled by xtask.
       - name: Build cargo prototyper
         run: cargo prototyper
 

--- a/.github/workflows/prototyper.yml
+++ b/.github/workflows/prototyper.yml
@@ -38,6 +38,10 @@ jobs:
 
       - name: Install required target
         run: rustup target add riscv64imac-unknown-none-elf
+      
+      # Build the prototyper is needded before running cargo clippy for it, as the build is dependent on some logic controlled by xtask.
+      - name: Build cargo prototyper
+        run: cargo prototyper
 
       - name: Run rust-clippy
         run: |


### PR DESCRIPTION
Install the riscv4imac-unknown-none-elf target.

The original fault in [action](https://github.com/rustsbi/rustsbi/actions/runs/17512475914/job/49745910560):
<img width="1223" height="388" alt="图片" src="https://github.com/user-attachments/assets/0c42ca91-ce6a-4c7e-82a2-5df515bb5c6e" />


<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
