### PR TITLE
feat(prototyper): allocate the patched fdt on the heap.

### DIFF
--- a/prototyper/prototyper/Cargo.toml
+++ b/prototyper/prototyper/Cargo.toml
@@ -24,7 +24,7 @@ sbi-spec = { version = "0.0.8", features = [
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 aclint = { git = "https://github.com/rustsbi/aclint", rev = "b2136a66" }
 fast-trap = { git = "https://github.com/rustsbi/fast-trap", rev = "8d855afa", features = ["riscv-m"] }
-serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", rev = "805718b", default-features = false, features = ["ser"] }
+serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", rev = "f051687", default-features = false, features = ["ser"] }
 uart_xilinx = { git = "https://github.com/duskmoon314/uart-rs/", rev = "12be9142" }
 xuantie-riscv = { git = "https://github.com/rustsbi/xuantie", rev = "7a521c04" }
 bouffalo-hal = { git = "https://github.com/rustsbi/bouffalo-hal", rev = "968b949", features = [

--- a/prototyper/prototyper/build.rs
+++ b/prototyper/prototyper/build.rs
@@ -80,7 +80,6 @@ SECTIONS {
 
     .text : ALIGN(0x1000) {
         *(.fdt)
-        *(.patched_fdt)
     }
     sbi_end = .;
 

--- a/prototyper/prototyper/config/default.toml
+++ b/prototyper/prototyper/config/default.toml
@@ -1,6 +1,6 @@
 num_hart_max = 8
 stack_size_per_hart = 16384 # 16 * 1024
-heap_size = 131072 # 128 * 1024
+heap_size = 1048576 # 1024 * 1024
 page_size = 4096
 log_level = "INFO"
 jump_address = 0x80200000

--- a/prototyper/prototyper/config/default.toml
+++ b/prototyper/prototyper/config/default.toml
@@ -1,6 +1,6 @@
 num_hart_max = 8
 stack_size_per_hart = 16384 # 16 * 1024
-heap_size = 32768 # 32 * 1024
+heap_size = 131072 # 128 * 1024
 page_size = 4096
 log_level = "INFO"
 jump_address = 0x80200000

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -131,6 +131,10 @@ pub fn patch_device_tree(device_tree_ptr: usize) -> usize {
 
     // Firstly, allocate a temporary buffer to store the fdt and get the real total size of the patched fdt.
     // TODO: The serde_device_tree can provide a function to calculate the accuracy size of patched fdt.
+    debug!(
+        "Allocate temporary DTB buffer with length 0x{:x}.",
+        original_length + 2048
+    );
     let mut temporary_buffer = vec![0u8; original_length + 2048];
     serde_device_tree::ser::to_dtb(&tree, &list, &mut temporary_buffer).unwrap();
     let Ok(patched_dtb_ptr) = DtbPtr::from_raw(temporary_buffer.as_mut_ptr()) else {

--- a/prototyper/prototyper/src/sbi/heap.rs
+++ b/prototyper/prototyper/src/sbi/heap.rs
@@ -4,8 +4,9 @@ use buddy_system_allocator::LockedHeap;
 #[unsafe(link_section = ".bss.heap")]
 static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 
+const BUDDY_MAX_ORDER: usize = 17;
 #[global_allocator]
-static HEAP_ALLOCATOR: LockedHeap<15> = LockedHeap::<15>::empty();
+static HEAP_ALLOCATOR: LockedHeap<BUDDY_MAX_ORDER> = LockedHeap::<BUDDY_MAX_ORDER>::empty();
 
 pub fn sbi_heap_init() {
     unsafe {
@@ -17,5 +18,16 @@ pub fn sbi_heap_init() {
 
 #[alloc_error_handler]
 pub fn handle_alloc_error(layout: core::alloc::Layout) -> ! {
+    error!("Heap stats:");
+    {
+        let heap = HEAP_ALLOCATOR.lock();
+        error!("\tTotal size: {}", heap.stats_total_bytes());
+        error!("\tRequested size: {}", heap.stats_alloc_user());
+        error!("\tAllocated size: {}", heap.stats_alloc_actual());
+        error!(
+            "Currently the heap only support allocate buffer with max length {} bytes.",
+            1 << (BUDDY_MAX_ORDER - 1)
+        );
+    }
     panic!("Heap allocation error, layout = {:?}", layout);
 }

--- a/prototyper/prototyper/src/sbi/heap.rs
+++ b/prototyper/prototyper/src/sbi/heap.rs
@@ -4,7 +4,7 @@ use buddy_system_allocator::LockedHeap;
 #[unsafe(link_section = ".bss.heap")]
 static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 
-const BUDDY_MAX_ORDER: usize = 17;
+const BUDDY_MAX_ORDER: usize = 20;
 #[global_allocator]
 static HEAP_ALLOCATOR: LockedHeap<BUDDY_MAX_ORDER> = LockedHeap::<BUDDY_MAX_ORDER>::empty();
 


### PR DESCRIPTION
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

The main questions in allocating the patched `fdt` on the heap are:
- How to get the actual length of patched `fdt`?
- Is the heap supported to allocate such long buffer?

In this pr,
- The length of patched `fdt` is acquired by writing twice strategy.
- The heap is adjusted to allocate buffer with max length 65536 bytes. 

> The `serde_device_tree` crate may provide a function to acquire the actual length of patched `fdt`.