### PR TITLE
fix(prototyper): the sbi_end symbol may not be aligned to 4 bytes.

### DIFF
--- a/prototyper/prototyper/build.rs
+++ b/prototyper/prototyper/build.rs
@@ -82,6 +82,7 @@ SECTIONS {
         *(.fdt)
         *(.patched_fdt)
     }
+    . = ALIGN(4);
     sbi_end = .;
 
     .text 0x80200000 : ALIGN(0x1000) {


### PR DESCRIPTION
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

When trying to boot Vision Five 2, the assertion 

https://github.com/rustsbi/rustsbi/blob/7754d4b33949141bef4da00f7ff74c75ea412f5c/prototyper/prototyper/src/firmware/mod.rs#L169

failed, so fix in the linker script.

<img width="2331" height="432" alt="image" src="https://github.com/user-attachments/assets/9b25e3a4-2ef9-48bf-b896-8223679d299c" />
