### PR TITLE
feat(prototyper): make the valid next_addr address range configurable.

### DIFF
--- a/prototyper/prototyper/config/default.toml
+++ b/prototyper/prototyper/config/default.toml
@@ -5,5 +5,7 @@ page_size = 4096
 log_level = "INFO"
 jump_address = 0x80200000
 tlb_flush_limit = 16384 # page_size * 4
-valid_next_addr_start = 0x80000000
-valid_next_addr_end = 0x90000000
+
+[[next_addr]]
+start = 0x80000000
+end = 0x90000000

--- a/prototyper/prototyper/config/default.toml
+++ b/prototyper/prototyper/config/default.toml
@@ -5,3 +5,5 @@ page_size = 4096
 log_level = "INFO"
 jump_address = 0x80200000
 tlb_flush_limit = 16384 # page_size * 4
+valid_next_addr_start = 0x80000000
+valid_next_addr_end = 0x90000000

--- a/prototyper/prototyper/config/sipeed_m1s_dock.toml
+++ b/prototyper/prototyper/config/sipeed_m1s_dock.toml
@@ -5,3 +5,7 @@ page_size = 4096
 log_level = "INFO"
 jump_address = 0x50000000
 tlb_flush_limit = 16384 # page_size * 4
+
+[[next_addr]]
+start = 0x80000000
+end = 0x90000000

--- a/prototyper/prototyper/src/cfg.rs
+++ b/prototyper/prototyper/src/cfg.rs
@@ -23,3 +23,9 @@ pub const JUMP_ADDRESS: usize = CONFIG.jump_address as usize;
 /// TLB_FLUSH_LIMIT defines the TLB refresh range limit.
 /// If the TLB refresh range is greater than TLB_FLUSH_LIMIT, the entire TLB is refreshed.
 pub const TLB_FLUSH_LIMIT: usize = CONFIG.tlb_flush_limit as usize;
+
+/// The dynamic valid next address range start.
+pub const VALID_NEXT_ADDR_START: usize = CONFIG.valid_next_addr_start as usize;
+
+/// The dynamic valid next address range end.
+pub const VALID_NEXT_ADDR_END: usize = CONFIG.valid_next_addr_end as usize;

--- a/prototyper/prototyper/src/cfg.rs
+++ b/prototyper/prototyper/src/cfg.rs
@@ -7,6 +7,8 @@ static_toml! {
     const CONFIG = include_toml!("../../target/config.toml");
 }
 
+pub type NextAddr = crate::cfg::config::next_addr::NextAddr;
+
 /// Maximum number of supported harts.
 pub const NUM_HART_MAX: usize = CONFIG.num_hart_max as usize;
 /// Stack size per hart (hardware thread) in bytes.
@@ -24,8 +26,5 @@ pub const JUMP_ADDRESS: usize = CONFIG.jump_address as usize;
 /// If the TLB refresh range is greater than TLB_FLUSH_LIMIT, the entire TLB is refreshed.
 pub const TLB_FLUSH_LIMIT: usize = CONFIG.tlb_flush_limit as usize;
 
-/// The dynamic valid next address range start.
-pub const VALID_NEXT_ADDR_START: usize = CONFIG.valid_next_addr_start as usize;
-
-/// The dynamic valid next address range end.
-pub const VALID_NEXT_ADDR_END: usize = CONFIG.valid_next_addr_end as usize;
+/// The dynamic valid next addr ranges.
+pub const DYNAMIC_NEXT_ADDR_RANGE: &NextAddr = &CONFIG.next_addr;

--- a/prototyper/prototyper/src/firmware/dynamic.rs
+++ b/prototyper/prototyper/src/firmware/dynamic.rs
@@ -62,11 +62,8 @@ pub struct DynamicInfo {
 // https://github.com/riscv-software-src/opensbi/blob/019a8e69a1dc0c0f011fabd0372e1ba80e40dd7c/include/sbi/fw_dynamic.h#L75
 
 const DYNAMIC_INFO_INVALID_ADDRESSES: usize = 0x00000000;
-const NEXT_ADDR_VALID_ADDRESSES: [Range<usize>; 2] = [
-    // Qemu Virt pflash address
-    0x20000000..0x22000000,
-    0x80000000..0x90000000,
-];
+const NEXT_ADDR_VALID_ADDRESSES: [Range<usize>; 1] =
+    [crate::cfg::VALID_NEXT_ADDR_START..crate::cfg::VALID_NEXT_ADDR_END];
 pub(crate) const MAGIC: usize = 0x4942534f;
 const SUPPORTED_VERSION: Range<usize> = 0..3;
 

--- a/prototyper/prototyper/src/firmware/dynamic.rs
+++ b/prototyper/prototyper/src/firmware/dynamic.rs
@@ -62,8 +62,6 @@ pub struct DynamicInfo {
 // https://github.com/riscv-software-src/opensbi/blob/019a8e69a1dc0c0f011fabd0372e1ba80e40dd7c/include/sbi/fw_dynamic.h#L75
 
 const DYNAMIC_INFO_INVALID_ADDRESSES: usize = 0x00000000;
-const NEXT_ADDR_VALID_ADDRESSES: [Range<usize>; 1] =
-    [crate::cfg::VALID_NEXT_ADDR_START..crate::cfg::VALID_NEXT_ADDR_END];
 pub(crate) const MAGIC: usize = 0x4942534f;
 const SUPPORTED_VERSION: Range<usize> = 0..3;
 
@@ -122,9 +120,9 @@ pub fn mpp_next_addr(info: &DynamicInfo) -> Result<(mstatus::MPP, usize), Dynami
     };
 
     // fail safe, errors will be aggregated after whole checking process.
-    let next_addr_valid = NEXT_ADDR_VALID_ADDRESSES
+    let next_addr_valid = crate::cfg::DYNAMIC_NEXT_ADDR_RANGE
         .iter()
-        .any(|x| x.contains(&info.next_addr));
+        .any(|r| info.next_addr >= r.start as usize && info.next_addr < r.end as usize);
     let mpp_valid = matches!(info.next_mode, 0 | 1 | 3);
 
     if !next_addr_valid {


### PR DESCRIPTION
Previously, the dynamic `next_addr` address range is coded as `0x8000000..0x90000000`.

In #139, to support boot from pflash in the QEMU, the addresses range `0x20000000..0x22000000` is added.

With the increase of target device, the hard code addresses range is not suitable, so in this PR, I add the feature to configure the `next_addr` range in the configuration file.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
