### PR TITLE
feat(prototyper): add Penglai/Keystone style PMP management for prototyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "library/rustsbi",
     "library/riscv-cove",
     "library/penglai",
+    "library/pmpm",
     "prototyper/prototyper",
     "prototyper/bench-kernel",
     "prototyper/test-kernel",
@@ -20,6 +21,7 @@ default-members = [
     "library/rustsbi",
     "library/riscv-cove",
     "library/penglai",
+    "library/pmpm"
 ]
 
 [workspace.package]

--- a/library/pmpm/CHANGELOG.md
+++ b/library/pmpm/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/library/pmpm/Cargo.toml
+++ b/library/pmpm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pmpm"
+description = "penglai/Keystone style PMP management"
+version = "0.0.0"
+authors = ["Char <jinzhe.oerv@isrc.iscas.ac.cn>", "Luo Jia <me@luojia.cc>"]
+documentation = "https://docs.rs/penglai"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords = ["riscv", "sbi", "rustsbi", "tee"]
+categories = ["os", "embedded", "hardware-support", "no-std"]
+
+[dependencies]
+riscv = "0.12.1"
+
+[dev-dependencies]
+static_assertions = "1.1.0"

--- a/library/pmpm/src/lib.rs
+++ b/library/pmpm/src/lib.rs
@@ -1,0 +1,250 @@
+//! PMP slot management.
+//!
+//! A PMP slot refers to the collection of PMP entries that correspond to the same index
+//! across all harts, used to provide a unified memory isolation view for all harts in Penglai/Keystone.
+//! The module consists of two parts: bitmap-based PMP slot management and software interrupt-based
+//! PMP synchronization implementation.
+#![no_std]
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+use riscv::register::{
+    Permission, Pmp, Range, pmpaddr0, pmpaddr1, pmpaddr2, pmpaddr3, pmpaddr4, pmpaddr5, pmpaddr6,
+    pmpaddr7, pmpaddr8, pmpaddr9, pmpaddr10, pmpaddr11, pmpaddr12, pmpaddr13, pmpaddr14, pmpaddr15,
+    pmpcfg0, pmpcfg2,
+};
+
+// PMP management bitmap, for alloc/free PMP slot in Penglai/Keystone. A bitmap
+// can describe a segment of consecutive PMP entries.
+pub struct PmpBitmap {
+    map: AtomicUsize,
+    start: u8,
+    end: u8,
+}
+
+#[allow(unused)]
+impl PmpBitmap {
+    pub const fn new(pmp_start: u8, pmp_end: u8, mask: usize) -> Self {
+        Self {
+            map: (AtomicUsize::new(mask)),
+            start: (pmp_start),
+            end: (pmp_end),
+        }
+    }
+    pub fn alloc(&self) -> Option<u8> {
+        let mut cur_map = self.map.load(Ordering::Acquire);
+        loop {
+            // Find idx of first free slot in current PMP area and set to used.
+            // Beware that reserved PMP slot will set to used when TEE init.
+            let first_free = match (self.start..self.end).find(|&i| cur_map & (1 << i) == 0) {
+                Some(bit) => bit,
+                None => return None,
+            };
+            let new_map = cur_map | (1 << first_free);
+
+            // Try to update bitmap by CAS. If update successfully, then return idx.
+            match self.map.compare_exchange_weak(
+                cur_map,
+                new_map,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return Some(first_free),
+                Err(actual) => cur_map = actual,
+            }
+        }
+    }
+    pub fn free(&self, idx: u8, mask: usize) {
+        self.map.fetch_and(!((1 << idx) & mask), Ordering::SeqCst);
+    }
+    pub fn region(&self) -> (u8, u8) {
+        (self.start, self.end)
+    }
+    pub fn get(&self) -> usize {
+        self.map.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PmpSlice {
+    num_bytes: usize,
+    pa_lo: usize,
+    pa_hi: usize,
+}
+
+impl PmpSlice {
+    pub fn new(num_bytes: usize, pa_lo: usize, pa_hi: usize) -> Self {
+        PmpSlice {
+            num_bytes: (num_bytes),
+            pa_lo: (pa_lo),
+            pa_hi: (pa_hi),
+        }
+    }
+    #[inline]
+    pub fn size(&self) -> usize {
+        self.num_bytes
+    }
+    pub fn lo(&self) -> usize {
+        self.pa_lo
+    }
+    pub fn hi(&self) -> usize {
+        self.pa_hi
+    }
+}
+
+#[inline]
+fn check_pmp_region(slice: PmpSlice) -> bool {
+    let len = slice.num_bytes;
+    let addr = slice.pa_lo;
+    // len must be power of 2 and no less than 4, addr must be aligned to len
+    if len < 4 || len & (len - 1) != 0 || addr & (len - 1) != 0 {
+        return false;
+    }
+    true
+}
+
+// TODO: Under 32-bit architecture, both length and address may overflow and need to be fixed
+// Encode addr to PMP addr.
+pub fn encode_pmp_addr(slice: PmpSlice, mode: Range) -> Option<usize> {
+    let addr = slice.pa_lo;
+    let len = slice.num_bytes;
+    match mode {
+        Range::NAPOT => {
+            if check_pmp_region(slice) {
+                Some((addr | ((len >> 1) - 1)) >> 2)
+            } else {
+                None
+            }
+        }
+        Range::NA4 => return Some(addr >> 2),
+        Range::TOR => return Some(addr >> 2),
+        Range::OFF => return Some(0),
+    }
+}
+// TODO: Under 32-bit architecture, both length and address may overflow and need to be fixed
+// Decode addr from PMP addr.
+pub fn decode_pmp_addr(pmp_addr: usize, mode: Range) -> PmpSlice {
+    let mut addr = pmp_addr;
+    match mode {
+        Range::NAPOT => {
+            let order = addr.trailing_ones();
+            addr &= !((1 << (order + 1)) - 1);
+            PmpSlice {
+                pa_lo: addr << 2,
+                pa_hi: addr.rotate_left(2) & 0b11,
+                num_bytes: 1 << (order + 3),
+            }
+        }
+        Range::NA4 => PmpSlice::new(4, pmp_addr << 2, pmp_addr.rotate_left(2) & 0b11),
+        Range::TOR => PmpSlice::new(0, pmp_addr << 2, pmp_addr.rotate_left(2) & 0b11),
+        Range::OFF => PmpSlice::new(0, 0, 0),
+    }
+}
+
+#[allow(unused)]
+#[inline]
+/// Get PMP entry @idx on local hart.
+pub fn get_pmp_entry(idx: u8) -> (PmpSlice, Pmp) {
+    let (pmp_addr, pmp_config) = get_pmp_reg(idx);
+    (decode_pmp_addr(pmp_addr, pmp_config.range), pmp_config)
+}
+
+#[allow(unused)]
+#[inline]
+/// Set PMP entry @idx on local hart.
+pub fn set_pmp_entry(idx: u8, slice: PmpSlice, mode: Range, perm: Permission) {
+    if let Some(pmp_addr) = encode_pmp_addr(slice, mode) {
+        set_pmp_reg(idx, pmp_addr, mode, perm)
+    }
+}
+
+fn set_pmp_reg(idx: u8, pmp_addr: usize, mode: Range, perm: Permission) {
+    unsafe {
+        match idx {
+            0 => {
+                pmpaddr0::write(pmp_addr);
+                pmpcfg0::set_pmp(0, mode, perm, false);
+            }
+            1 => {
+                pmpaddr1::write(pmp_addr);
+                pmpcfg0::set_pmp(1, mode, perm, false);
+            }
+            2 => {
+                pmpaddr2::write(pmp_addr);
+                pmpcfg0::set_pmp(2, mode, perm, false);
+            }
+            3 => {
+                pmpaddr3::write(pmp_addr);
+                pmpcfg0::set_pmp(3, mode, perm, false);
+            }
+            4 => {
+                pmpaddr4::write(pmp_addr);
+                pmpcfg0::set_pmp(4, mode, perm, false);
+            }
+            5 => {
+                pmpaddr5::write(pmp_addr);
+                pmpcfg0::set_pmp(5, mode, perm, false);
+            }
+            6 => {
+                pmpaddr6::write(pmp_addr);
+                pmpcfg0::set_pmp(6, mode, perm, false);
+            }
+            7 => {
+                pmpaddr7::write(pmp_addr);
+                pmpcfg0::set_pmp(7, mode, perm, false);
+            }
+            8 => {
+                pmpaddr8::write(pmp_addr);
+                pmpcfg2::set_pmp(0, mode, perm, false);
+            }
+            9 => {
+                pmpaddr9::write(pmp_addr);
+                pmpcfg2::set_pmp(1, mode, perm, false);
+            }
+            10 => {
+                pmpaddr10::write(pmp_addr);
+                pmpcfg2::set_pmp(2, mode, perm, false);
+            }
+            11 => {
+                pmpaddr11::write(pmp_addr);
+                pmpcfg2::set_pmp(3, mode, perm, false);
+            }
+            12 => {
+                pmpaddr12::write(pmp_addr);
+                pmpcfg2::set_pmp(4, mode, perm, false);
+            }
+            13 => {
+                pmpaddr13::write(pmp_addr);
+                pmpcfg2::set_pmp(5, mode, perm, false);
+            }
+            14 => {
+                pmpaddr14::write(pmp_addr);
+                pmpcfg2::set_pmp(6, mode, perm, false);
+            }
+            _ => {
+                pmpaddr15::write(pmp_addr);
+                pmpcfg2::set_pmp(7, mode, perm, false);
+            }
+        }
+    }
+}
+
+fn get_pmp_reg(idx: u8) -> (usize, Pmp) {
+    match idx {
+        0 => (pmpaddr0::read(), pmpcfg0::read().into_config(0)),
+        1 => (pmpaddr1::read(), pmpcfg0::read().into_config(1)),
+        2 => (pmpaddr2::read(), pmpcfg0::read().into_config(2)),
+        3 => (pmpaddr3::read(), pmpcfg0::read().into_config(3)),
+        4 => (pmpaddr4::read(), pmpcfg0::read().into_config(4)),
+        5 => (pmpaddr5::read(), pmpcfg0::read().into_config(5)),
+        6 => (pmpaddr6::read(), pmpcfg0::read().into_config(6)),
+        7 => (pmpaddr7::read(), pmpcfg0::read().into_config(7)),
+        8 => (pmpaddr8::read(), pmpcfg2::read().into_config(0)),
+        9 => (pmpaddr9::read(), pmpcfg2::read().into_config(1)),
+        10 => (pmpaddr10::read(), pmpcfg2::read().into_config(2)),
+        11 => (pmpaddr11::read(), pmpcfg2::read().into_config(3)),
+        12 => (pmpaddr12::read(), pmpcfg2::read().into_config(4)),
+        13 => (pmpaddr13::read(), pmpcfg2::read().into_config(5)),
+        14 => (pmpaddr14::read(), pmpcfg2::read().into_config(6)),
+        _ => (pmpaddr15::read(), pmpcfg2::read().into_config(7)),
+    }
+}

--- a/prototyper/prototyper/Cargo.toml
+++ b/prototyper/prototyper/Cargo.toml
@@ -21,6 +21,7 @@ rustsbi = { version = "0.4.0", features = [
 sbi-spec = { version = "0.0.8", features = [
     "legacy",
 ], path = "../../library/sbi-spec" }
+pmpm = { version = "0.0.0", path = "../../library/pmpm" }
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 aclint = { git = "https://github.com/rustsbi/aclint", rev = "b2136a66" }
 fast-trap = { git = "https://github.com/rustsbi/fast-trap", rev = "8d855afa", features = ["riscv-m"] }

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -13,8 +13,10 @@ cfg_if::cfg_if! {
 
 #[allow(unused)]
 use core::arch::{asm, naked_asm};
-use core::ops::Range;
+use core::{ops::Range, usize};
 use riscv::register::mstatus;
+
+use pmpm::{PmpSlice, get_pmp_entry, set_pmp_entry};
 
 pub struct BootInfo {
     pub next_address: usize,
@@ -88,58 +90,92 @@ pub fn set_pmp(memory_range: &Range<usize>) {
         assert_eq!(RODATA_START_ADDRESS & 0x3, 0);
         assert_eq!(RODATA_END_ADDRESS & 0x3, 0);
 
-        pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
-        pmpaddr0::write(0);
-        pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
-        pmpaddr1::write(memory_range.start >> 2);
-        pmpcfg0::set_pmp(2, Range::TOR, Permission::RWX, false);
-        pmpaddr2::write(SBI_START_ADDRESS >> 2);
-        pmpcfg0::set_pmp(3, Range::TOR, Permission::NONE, false);
-        pmpaddr3::write(RODATA_START_ADDRESS >> 2);
-        pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
-        pmpaddr4::write(RODATA_END_ADDRESS >> 2);
-        pmpcfg0::set_pmp(5, Range::TOR, Permission::NONE, false);
-        pmpaddr5::write(SBI_END_ADDRESS >> 2);
-        pmpcfg0::set_pmp(6, Range::TOR, Permission::RWX, false);
-        pmpaddr6::write(memory_range.end >> 2);
-        pmpcfg0::set_pmp(7, Range::TOR, Permission::RWX, false);
-        pmpaddr7::write(usize::MAX >> 2);
+        // pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
+        // pmpaddr0::write(0);
+        // pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
+        // pmpaddr1::write(memory_range.start >> 2);
+        // pmpcfg0::set_pmp(2, Range::TOR, Permission::RWX, false);
+        // pmpaddr2::write(SBI_START_ADDRESS >> 2);
+        // pmpcfg0::set_pmp(3, Range::TOR, Permission::NONE, false);
+        // pmpaddr3::write(RODATA_START_ADDRESS >> 2);
+        // pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
+        // pmpaddr4::write(RODATA_END_ADDRESS >> 2);
+        // pmpcfg0::set_pmp(5, Range::TOR, Permission::NONE, false);
+        // pmpaddr5::write(SBI_END_ADDRESS >> 2);
+        // pmpcfg0::set_pmp(6, Range::TOR, Permission::RWX, false);
+        // pmpaddr6::write(memory_range.end >> 2);
+        // pmpcfg0::set_pmp(7, Range::TOR, Permission::RWX, false);
+        // pmpaddr7::write(usize::MAX >> 2);
+        set_pmp_entry(0, PmpSlice::new(0, 0, 0), Range::OFF, Permission::NONE);
+
+        set_pmp_entry(
+            1,
+            PmpSlice::new(0, memory_range.start, 0),
+            Range::TOR,
+            Permission::RWX,
+        );
+
+        set_pmp_entry(
+            2,
+            PmpSlice::new(0, SBI_START_ADDRESS, 0),
+            Range::TOR,
+            Permission::RWX,
+        );
+        set_pmp_entry(
+            3,
+            PmpSlice::new(0, RODATA_START_ADDRESS, 0),
+            Range::TOR,
+            Permission::NONE,
+        );
+        set_pmp_entry(
+            4,
+            PmpSlice::new(0, RODATA_END_ADDRESS, 0),
+            Range::TOR,
+            Permission::NONE,
+        );
+        set_pmp_entry(
+            5,
+            PmpSlice::new(0, SBI_END_ADDRESS, 0),
+            Range::TOR,
+            Permission::NONE,
+        );
+        set_pmp_entry(
+            6,
+            PmpSlice::new(0, memory_range.end, 0),
+            Range::TOR,
+            Permission::RWX,
+        );
+        set_pmp_entry(
+            7,
+            PmpSlice::new(0, usize::MAX, 0),
+            Range::TOR,
+            Permission::RWX,
+        );
+
+        set_pmp_entry(
+            8,
+            PmpSlice::new(memory_range.end - memory_range.start, memory_range.start, 0),
+            Range::NAPOT,
+            Permission::RWX,
+        );
     }
 }
 
 pub fn log_pmp_cfg(memory_range: &Range<usize>) {
-    unsafe {
-        info!("PMP Configuration");
-
+    info!("PMP Configuration");
+    info!(
+        "{:<10} {:<10} {:<15} {:<30}",
+        "PMP", "Range", "Permission", "Address"
+    );
+    for i in 0..16 {
+        let (slice, config) = get_pmp_entry(i);
         info!(
-            "{:<10} {:<10} {:<15} {:<30}",
-            "PMP", "Range", "Permission", "Address"
-        );
-
-        info!("{:<10} {:<10} {:<15} 0x{:08x}", "PMP 0:", "OFF", "NONE", 0);
-        info!(
-            "{:<10} {:<10} {:<15} 0x{:08x} - 0x{:08x}",
-            "PMP 1-2:", "TOR", "RWX/RWX", memory_range.start, SBI_START_ADDRESS
-        );
-        info!(
-            "{:<10} {:<10} {:<15} 0x{:08x} - 0x{:08x} - 0x{:08x}",
-            "PMP 3-5:",
-            "TOR",
-            "NONE/NONE",
-            RODATA_START_ADDRESS,
-            RODATA_END_ADDRESS,
-            SBI_END_ADDRESS
-        );
-        info!(
-            "{:<10} {:<10} {:<15} 0x{:08x}",
-            "PMP 6:", "TOR", "RWX", memory_range.end
-        );
-        info!(
-            "{:<10} {:<10} {:<15} 0x{:08x}",
-            "PMP 7:",
-            "TOR",
-            "RWX",
-            usize::MAX
+            "{:<10} 0x{:<10b} 0x{:<15b} 0x{:08x}+0x{:08x}",
+            format_args!("PMP {}", i),
+            config.range as u8,
+            config.permission as u8,
+            slice.lo(),
+            slice.size()
         );
     }
 }

--- a/prototyper/prototyper/src/sbi/fifo.rs
+++ b/prototyper/prototyper/src/sbi/fifo.rs
@@ -19,7 +19,7 @@ pub struct Fifo<T: Copy + Clone> {
 
 impl<T: Copy + Clone> Fifo<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         // Initialize array with uninitialized values
         let data = [MaybeUninit::uninit(); FIFO_SIZE];
         Self {

--- a/prototyper/prototyper/src/sbi/hart_context.rs
+++ b/prototyper/prototyper/src/sbi/hart_context.rs
@@ -1,6 +1,7 @@
 use crate::sbi::features::HartFeatures;
 use crate::sbi::features::PrivilegedVersion;
 use crate::sbi::hsm::HsmCell;
+use crate::sbi::pmpm::PmpSyncCell;
 use crate::sbi::rfence::RFenceCell;
 use core::ptr::NonNull;
 use core::sync::atomic::AtomicU8;
@@ -18,6 +19,8 @@ pub(crate) struct HartContext {
     pub hsm: HsmCell<NextStage>,
     /// Remote fence synchronization cell.
     pub rfence: RFenceCell,
+    /// PMP synchronization cell.
+    pub pmpsync: PmpSyncCell,
     /// Type of inter-processor interrupt pending.
     pub ipi_type: AtomicU8,
     /// Supported hart features.

--- a/prototyper/prototyper/src/sbi/mod.rs
+++ b/prototyper/prototyper/src/sbi/mod.rs
@@ -14,6 +14,7 @@ pub mod fifo;
 pub mod hart_context;
 pub mod heap;
 pub mod logger;
+pub mod pmpm;
 pub mod trap;
 pub mod trap_stack;
 

--- a/prototyper/prototyper/src/sbi/pmpm.rs
+++ b/prototyper/prototyper/src/sbi/pmpm.rs
@@ -1,0 +1,178 @@
+use crate::platform::PLATFORM;
+use crate::riscv::current_hartid;
+use crate::sbi::fifo::{Fifo, FifoError};
+use crate::sbi::trap_stack::ROOT_STACK;
+use core::sync::atomic::{AtomicU32, Ordering};
+use pmpm::{PmpSlice, set_pmp_entry};
+use riscv::register::{Permission, Range};
+use rustsbi::SbiRet;
+use spin::mutex::Mutex;
+/// Context information for a PMP sync operation.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct PmpSyncContext {
+    /// PMP addr info.
+    slice: PmpSlice,
+    /// PMP addr range mode.
+    mode: Range,
+    /// Permission for PMP entry, R/W/X/N
+    perm: Permission,
+    /// Index of PMP entry.
+    idx: u8,
+}
+
+/// Cell for managing PMP sync operations between harts.
+pub(crate) struct PmpSyncCell {
+    // Queue of PMP operations.
+    mailbox: Mutex<Fifo<(PmpSyncContext, usize)>>,
+    // Wait for other cores complete.
+    wait_sync_count: AtomicU32,
+}
+
+// Mark PmpSyncCell as safe to share between threads
+unsafe impl Sync for PmpSyncCell {}
+unsafe impl Send for PmpSyncCell {}
+
+impl PmpSyncCell {
+    #[allow(unused)]
+    pub const fn new() -> Self {
+        Self {
+            mailbox: Mutex::new(Fifo::new()),
+            wait_sync_count: AtomicU32::new(0),
+        }
+    }
+    /// Gets a local view of this fence cell for the current hart.
+    #[inline]
+    pub fn local(&self) -> LocalPmpSyncCell<'_> {
+        LocalPmpSyncCell(self)
+    }
+    /// Gets a remote view of this fence cell for accessing from other harts.
+    #[inline]
+    pub fn remote(&self) -> RemotePmpSyncCell<'_> {
+        RemotePmpSyncCell(self)
+    }
+}
+
+/// View of PmpSyncCell for operations on the current hart.
+pub struct LocalPmpSyncCell<'a>(&'a PmpSyncCell);
+/// View of PmpSyncCell for operations from other harts.
+pub struct RemotePmpSyncCell<'a>(&'a PmpSyncCell);
+
+impl LocalPmpSyncCell<'_> {
+    /// Checks if all synchronization operations are complete.
+    #[inline]
+    pub fn is_sync(&self) -> bool {
+        self.0.wait_sync_count.load(Ordering::Relaxed) == 0
+    }
+
+    /// Increments the synchronization counter.
+    #[inline]
+    pub fn add(&self) {
+        self.0.wait_sync_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Checks if the PMP sync queue is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.mailbox.lock().is_empty()
+    }
+
+    /// Gets the next PMP sync operation from the queue of current hart.
+    #[inline]
+    pub fn get(&self) -> Option<(PmpSyncContext, usize)> {
+        self.0.mailbox.lock().pop().ok()
+    }
+
+    /// Adds a PMP sync operation to the queue of current hart.
+    #[allow(unused)]
+    pub fn set(&self, ctx: PmpSyncContext) -> bool {
+        loop {
+            let mut mailbox = self.0.mailbox.lock();
+            match mailbox.push((ctx, current_hartid())) {
+                Ok(_) => return true,
+                Err(FifoError::Full) => return false,
+                Err(_) => panic!("Unable to push PMP sync ops to fifo"),
+            }
+        }
+    }
+}
+
+#[allow(unused)]
+impl RemotePmpSyncCell<'_> {
+    /// Adds a PMP sync operation to the queue of a remote hart.
+    pub fn set(&self, ctx: PmpSyncContext) -> bool {
+        loop {
+            let mut mailbox = self.0.mailbox.lock();
+            match mailbox.push((ctx, current_hartid())) {
+                Ok(_) => return true,
+                Err(FifoError::Full) => return false,
+                Err(_) => panic!("Unable to push PMP sync ops to fifo"),
+            }
+        }
+    }
+
+    /// Decrements the synchronization counter.
+    pub fn sub(&self) {
+        self.0.wait_sync_count.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Gets the local PMP sync queue for the current hart.
+#[inline]
+pub(crate) fn local_pmpctx() -> Option<LocalPmpSyncCell<'static>> {
+    unsafe {
+        ROOT_STACK
+            .get_mut(current_hartid())
+            .map(|x| x.hart_context().pmpsync.local())
+    }
+}
+
+/// Gets the remote PMP sync context for a specific hart.
+#[inline]
+pub(crate) fn remote_pmpctx(hart_id: usize) -> Option<RemotePmpSyncCell<'static>> {
+    unsafe {
+        ROOT_STACK
+            .get_mut(hart_id)
+            .map(|x| x.hart_context().pmpsync.remote())
+    }
+}
+
+#[inline]
+pub(crate) fn pmpsync_handler() {
+    let receiver = local_pmpctx().unwrap();
+    while !receiver.is_empty() {
+        if let Some(config) = receiver.get() {
+            // Set local PMP entry.
+            set_pmp_entry(config.0.idx, config.0.slice, config.0.mode, config.0.perm);
+            // Notify sender process complete.
+            if let Some(sender) = remote_pmpctx(config.1) {
+                sender.sub();
+            }
+        }
+    }
+}
+
+#[allow(unused)]
+#[inline]
+/// Set PMP entry @idx on every hart.
+pub fn set_pmp_slot(idx: u8, slice: PmpSlice, mode: Range, perm: Permission) -> SbiRet {
+    // Set other harts first.
+    let sbi_ret = unsafe { PLATFORM.sbi.ipi.as_ref() }
+        .unwrap()
+        .send_ipi_by_pmpsync(PmpSyncContext {
+            slice: slice,
+            mode: (mode),
+            perm: (perm),
+            idx: (idx),
+        });
+    // If configure other harts successfully, then configure local PMP.
+    set_pmp_entry(idx, slice, mode, perm);
+    sbi_ret
+}
+
+#[allow(unused)]
+#[inline]
+/// Clean PMP entry @idx on every hart.
+pub fn clean_pmp_slot(idx: u8) -> SbiRet {
+    set_pmp_slot(idx, PmpSlice::new(0, 0, 0), Range::OFF, Permission::NONE)
+}

--- a/prototyper/prototyper/src/sbi/trap/handler.rs
+++ b/prototyper/prototyper/src/sbi/trap/handler.rs
@@ -10,6 +10,7 @@ use crate::riscv::current_hartid;
 use crate::sbi::console;
 use crate::sbi::hsm::local_hsm;
 use crate::sbi::ipi;
+use crate::sbi::pmpm;
 use crate::sbi::pmu::pmu_firmware_counter_increment;
 use crate::sbi::rfence;
 
@@ -44,6 +45,10 @@ pub fn msoft_ipi_handler() {
     // Handle fence operation
     if (ipi_type & ipi::IPI_TYPE_FENCE) != 0 {
         rfence::rfence_handler();
+    }
+    // Handle PMP synchronous operation.
+    if (ipi_type & ipi::IPI_TYPE_PMP) != 0 {
+        pmpm::pmpsync_handler();
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Mechanicu <jinzhe.oerv@isrc.iscas.ac.cn>

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

This commit includes the following work:

- Introduced a new PMP management library to provide structures and interfaces for managing PMP slots.

- A new PMP management module has been introduced in the prototyper to support IPI-based PMP entry synchronization across harts.