### PR TITLE
fix: hsm should return invalid when hartid is invalid

### DIFF
--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -20,6 +20,7 @@ mod sbi;
 
 use core::arch::{asm, naked_asm};
 
+use crate::platform::CPU_ENABLED;
 use crate::platform::PLATFORM;
 use crate::riscv::csr::menvcfg;
 use crate::riscv::current_hartid;
@@ -36,9 +37,6 @@ use crate::sbi::trap;
 use crate::sbi::trap_stack;
 
 pub const R_RISCV_RELATIVE: usize = 3;
-
-use crate::cfg::NUM_HART_MAX;
-static mut ENABLED: [bool; NUM_HART_MAX] = [false; NUM_HART_MAX];
 
 #[unsafe(no_mangle)]
 extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
@@ -58,7 +56,7 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
                 fail::stop();
             } else {
                 unsafe {
-                    ENABLED[current_hartid()] = true;
+                    CPU_ENABLED[current_hartid()] = true;
                 }
             }
         }
@@ -67,7 +65,7 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
                 fail::stop();
             } else {
                 unsafe {
-                    ENABLED[current_hartid()] = true;
+                    CPU_ENABLED[current_hartid()] = true;
                 }
             }
         }

--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -37,6 +37,9 @@ use crate::sbi::trap_stack;
 
 pub const R_RISCV_RELATIVE: usize = 3;
 
+use crate::cfg::NUM_HART_MAX;
+static mut ENABLED: [bool; NUM_HART_MAX] = [false; NUM_HART_MAX];
+
 #[unsafe(no_mangle)]
 extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
     // Track whether SBI is initialized and ready.
@@ -53,11 +56,19 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
         MPP::Supervisor => {
             if !misa::read().unwrap().has_extension('S') {
                 fail::stop();
+            } else {
+                unsafe {
+                    ENABLED[current_hartid()] = true;
+                }
             }
         }
         MPP::User => {
             if !misa::read().unwrap().has_extension('U') {
                 fail::stop();
+            } else {
+                unsafe {
+                    ENABLED[current_hartid()] = true;
+                }
             }
         }
         _ => {}

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -264,7 +264,9 @@ impl Platform {
             let cpu = cpu_iter.deserialize::<Cpu>();
             let hart_id = cpu.reg.iter().next().unwrap().0.start;
             if let Some(x) = cpu_list.get_mut(hart_id) {
-                *x = true;
+                unsafe {
+                    *x = crate::ENABLED[hart_id];
+                }
             } else {
                 error!(
                     "The maximum supported hart id is {}, but the hart id {} was obtained. Please check the config!",

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -36,6 +36,7 @@ use crate::sbi::suspend::SbiSuspend;
 mod clint;
 mod console;
 mod reset;
+pub static mut CPU_ENABLED: [bool; NUM_HART_MAX] = [false; NUM_HART_MAX];
 
 type BaseAddress = usize;
 
@@ -265,7 +266,7 @@ impl Platform {
             let hart_id = cpu.reg.iter().next().unwrap().0.start;
             if let Some(x) = cpu_list.get_mut(hart_id) {
                 unsafe {
-                    *x = crate::ENABLED[hart_id];
+                    *x = CPU_ENABLED[hart_id];
                 }
             } else {
                 error!(

--- a/prototyper/prototyper/src/sbi/hsm.rs
+++ b/prototyper/prototyper/src/sbi/hsm.rs
@@ -205,10 +205,9 @@ pub(crate) struct SbiHsm;
 impl rustsbi::Hsm for SbiHsm {
     /// Starts execution on a stopped hart.
     fn hart_start(&self, hartid: usize, start_addr: usize, opaque: usize) -> SbiRet {
-        let hart_num = unsafe { PLATFORM.info.cpu_num.unwrap() };
         let hart_enable = unsafe { PLATFORM.info.cpu_enabled.unwrap() };
         let enabled = hart_enable.get(hartid).copied().unwrap_or(false);
-        if hartid >= hart_num || !enabled {
+        if !enabled {
             return SbiRet::invalid_param();
         }
 
@@ -245,10 +244,9 @@ impl rustsbi::Hsm for SbiHsm {
     /// Gets the current state of a hart.
     #[inline]
     fn hart_get_status(&self, hartid: usize) -> SbiRet {
-        let hart_num = unsafe { PLATFORM.info.cpu_num.unwrap() };
         let hart_enable = unsafe { PLATFORM.info.cpu_enabled.unwrap() };
         let enabled = hart_enable.get(hartid).copied().unwrap_or(false);
-        if hartid >= hart_num || !enabled {
+        if !enabled {
             return SbiRet::invalid_param();
         }
 


### PR DESCRIPTION
hsm call should not return success when the hart is disabled
