### PR TITLE
feat(prototyper): split boot hart to init hart and boot hart

### DIFF
--- a/prototyper/prototyper/src/fail.rs
+++ b/prototyper/prototyper/src/fail.rs
@@ -56,9 +56,7 @@ pub fn stop() -> ! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "payload")] {
-    } else if #[cfg(feature = "jump")] {
-    } else {
+    if #[cfg(not(any(feature = "payload", feature = "jump")))] {
         use crate::firmware::dynamic;
         use crate::sbi::reset;
         use riscv::register::mstatus;
@@ -118,6 +116,7 @@ cfg_if::cfg_if! {
         ///
         /// Used when dynamic info read fails but execution should continue.
         #[cold]
+        #[allow(unused)]
         pub fn use_lottery(_err: dynamic::DynamicReadError) -> dynamic::DynamicInfo {
             dynamic::DynamicInfo {
                 magic: 0,

--- a/prototyper/prototyper/src/firmware/dynamic.rs
+++ b/prototyper/prototyper/src/firmware/dynamic.rs
@@ -1,32 +1,11 @@
 //! Frequently used first boot stage dynamic information on RISC-V.
 
 use core::ops::Range;
-use core::sync::atomic::{AtomicBool, Ordering};
 
 use super::BootInfo;
 use crate::fail;
-use crate::riscv::current_hartid;
 
 use riscv::register::mstatus;
-
-/// Determine whether the current hart is boot hart.
-///
-/// Return true if the current hart is boot hart.
-pub fn is_boot_hart(nonstandard_a2: usize) -> bool {
-    // Track whether this is the first hart to boot
-    static GENESIS: AtomicBool = AtomicBool::new(true);
-
-    let info = read_paddr(nonstandard_a2).unwrap_or_else(fail::use_lottery);
-
-    // Determine if this is the boot hart based on hart ID
-    if info.boot_hart == usize::MAX {
-        // If boot_hart is MAX, use atomic bool to determine first hart
-        GENESIS.swap(false, Ordering::AcqRel)
-    } else {
-        // Otherwise check if current hart matches designated boot hart
-        current_hartid() == info.boot_hart
-    }
-}
 
 /// Gets boot information from nonstandard_a2 parameter.
 ///

--- a/prototyper/prototyper/src/firmware/jump.rs
+++ b/prototyper/prototyper/src/firmware/jump.rs
@@ -1,16 +1,7 @@
-use core::sync::atomic::{AtomicBool, Ordering};
 use riscv::register::mstatus;
 
 use super::BootInfo;
 use crate::cfg::JUMP_ADDRESS;
-
-/// Determine whether the current hart is boot hart.
-///
-/// Return true if the current hart is boot hart.
-pub fn is_boot_hart(_nonstandard_a2: usize) -> bool {
-    static GENESIS: AtomicBool = AtomicBool::new(true);
-    GENESIS.swap(false, Ordering::AcqRel)
-}
 
 pub fn get_boot_info(_nonstandard_a2: usize) -> BootInfo {
     BootInfo {

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -11,7 +11,7 @@ cfg_if::cfg_if! {
     }
 }
 
-use crate::current_hartid;
+use crate::riscv::current_hartid;
 
 /// Get work hart, for both steps.
 ///

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -1,13 +1,55 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "payload")] {
         pub mod payload;
-        pub use payload::{get_boot_info, is_boot_hart};
+        pub use payload::{get_boot_info};
     } else if #[cfg(feature = "jump")] {
         pub mod jump;
-        pub use jump::{get_boot_info, is_boot_hart};
+        pub use jump::{get_boot_info};
     } else {
         pub mod dynamic;
-        pub use dynamic::{get_boot_info, is_boot_hart};
+        pub use dynamic::{get_boot_info, read_paddr};
+    }
+}
+
+use crate::current_hartid;
+
+/// Get work hart, for both steps.
+///
+/// Init hart can be random choose when DynamicInfo can not be read.
+pub fn is_work_hart(nonstandard_a2: usize, boot: bool) -> bool {
+    use core::sync::atomic::{AtomicBool, Ordering};
+    // Track whether this is the first hart to boot
+    static GENESIS_INIT: AtomicBool = AtomicBool::new(true);
+    static GENESIS_BOOT: AtomicBool = AtomicBool::new(true);
+
+    cfg_if::cfg_if! {
+        if #[cfg(any(feature = "payload", feature = "jump"))] {
+            let info: _ = None;
+        }
+        else {
+            let info = read_paddr(nonstandard_a2).ok().and_then(|x| Some(x.boot_hart));
+        }
+    }
+
+    let race_boot_hart = move || match boot {
+        true => GENESIS_BOOT.swap(false, Ordering::AcqRel),
+        false => GENESIS_INIT.swap(false, Ordering::AcqRel),
+    };
+
+    // Determine if this is the boot hart based on hart ID
+    match info {
+        Some(info) => {
+            if info == usize::MAX {
+                // If boot_hart is MAX, use atomic bool to determine first hart
+                race_boot_hart()
+            } else {
+                // Otherwise check if current hart matches designated boot hart
+                current_hartid() == info
+            }
+        }
+        // If can not load DynamicInfo, just race a boot hart, this error will
+        // be occurred after board init.
+        None => race_boot_hart(),
     }
 }
 
@@ -48,9 +90,12 @@ fn get_fdt_address() -> usize {
 /// Gets boot hart information based on opaque and nonstandard_a2 parameters.
 ///
 /// Returns a BootHart struct containing FDT address and whether this is the boot hart.
+///
+/// The boot flow is splitted into two steps, first init all devices,
+/// second the really boot stage. When in second step, boot flag should be true.
 #[allow(unused_mut, unused_assignments)]
-pub fn get_boot_hart(opaque: usize, nonstandard_a2: usize) -> BootHart {
-    let is_boot_hart = is_boot_hart(nonstandard_a2);
+pub fn get_work_hart(opaque: usize, nonstandard_a2: usize, boot: bool) -> BootHart {
+    let is_boot_hart = is_work_hart(nonstandard_a2, boot);
 
     let mut fdt_address = opaque;
 

--- a/prototyper/prototyper/src/firmware/payload.rs
+++ b/prototyper/prototyper/src/firmware/payload.rs
@@ -1,16 +1,7 @@
 use core::arch::naked_asm;
-use core::sync::atomic::{AtomicBool, Ordering};
 use riscv::register::mstatus;
 
 use super::BootInfo;
-
-/// Determine whether the current hart is boot hart.
-///
-/// Return true if the current hart is boot hart.
-pub fn is_boot_hart(_nonstandard_a2: usize) -> bool {
-    static GENESIS: AtomicBool = AtomicBool::new(true);
-    GENESIS.swap(false, Ordering::AcqRel)
-}
 
 pub fn get_boot_info(_nonstandard_a2: usize) -> BootInfo {
     BootInfo {

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -36,7 +36,7 @@ use crate::sbi::suspend::SbiSuspend;
 mod clint;
 mod console;
 mod reset;
-pub static mut CPU_ENABLED: [bool; NUM_HART_MAX] = [false; NUM_HART_MAX];
+pub static mut CPU_PRIVILEGED_ENABLED: [bool; NUM_HART_MAX] = [false; NUM_HART_MAX];
 
 type BaseAddress = usize;
 
@@ -266,7 +266,7 @@ impl Platform {
             let hart_id = cpu.reg.iter().next().unwrap().0.start;
             if let Some(x) = cpu_list.get_mut(hart_id) {
                 unsafe {
-                    *x = CPU_ENABLED[hart_id];
+                    *x = CPU_PRIVILEGED_ENABLED[hart_id];
                 }
             } else {
                 error!(


### PR DESCRIPTION
To make sbi can normal output when start with wrong params, like invalid `DynamicInfo`, this pull request split boot hart to init and boot hart.