### PR TITLE
fix(prototyper): remove a semicolon in `boot` function

### DIFF
--- a/prototyper/prototyper/src/sbi/trap/boot.rs
+++ b/prototyper/prototyper/src/sbi/trap/boot.rs
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn boot() -> ! {
         "mret",
         locate_stack = sym trap_stack::locate,
         boot_handler = sym boot_handler,
-    );
+    )
 }
 
 /// Boot Handler.


### PR DESCRIPTION
RustRover 2025.2.2 suggests that there is a type mismathcing: a redundant semicolon returns () type which does not match ! type stipulated in the signature of the function.

The original error messages are as follows:

```
Type mismatch [E0308]
Expected: !
Found: ()
```

<img width="384" height="170" alt="image" src="https://github.com/user-attachments/assets/c5298baa-ca07-4e5f-9c93-80a5999c5b6d" />