### PR TITLE
refactor(prototyper): refactor fast handler for trap handle

### DIFF
--- a/prototyper/prototyper/src/sbi/trap/mod.rs
+++ b/prototyper/prototyper/src/sbi/trap/mod.rs
@@ -2,6 +2,7 @@ pub mod boot;
 pub mod handler;
 
 mod helper;
+
 use super::pmu::pmu_firmware_counter_increment;
 use crate::fail::unsupported_trap;
 
@@ -27,59 +28,99 @@ pub extern "C" fn fast_handler(
     // Save mepc into context
     ctx.regs().pc = mepc::read();
 
+    let cause = match mcause::read().cause().try_into() {
+        Ok(cause) => cause,
+        Err(err) => {
+            error!("Failed to parse mcause: {:?}", err);
+            unsupported_trap(None)
+        }
+    };
+
+    // Fast path for SBI calls
+    if let Trap::Exception(Exception::SupervisorEnvCall) = cause {
+        return handler::sbi_call_handler(ctx, a1, a2, a3, a4, a5, a6, a7);
+    }
+
+    // Save registers for other traps
     let save_regs = |ctx: &mut FastContext| {
         ctx.regs().a = [ctx.a0(), a1, a2, a3, a4, a5, a6, a7];
     };
 
-    match mcause::read().cause().try_into() {
-        Ok(cause) => {
-            match cause {
-                // Handle Msoft
-                Trap::Interrupt(Interrupt::MachineSoft) => {
-                    save_regs(&mut ctx);
-                    handler::msoft_handler(ctx)
-                }
-                // Handle MTimer
-                Trap::Interrupt(Interrupt::MachineTimer) => {
-                    use crate::sbi::ipi;
+    match cause {
+        Trap::Interrupt(interrupt) => handle_interrupt(ctx, interrupt, save_regs),
+        Trap::Exception(exception) => handle_exception(ctx, exception, save_regs),
+    }
+}
 
-                    ipi::clear_mtime();
-                    unsafe {
-                        mip::set_stimer();
-                    }
-                    save_regs(&mut ctx);
-                    ctx.restore()
-                }
-                // Handle SBI calls
-                Trap::Exception(Exception::SupervisorEnvCall) => {
-                    handler::sbi_call_handler(ctx, a1, a2, a3, a4, a5, a6, a7)
-                }
-                // Handle illegal instructions
-                Trap::Exception(Exception::IllegalInstruction) => {
-                    pmu_firmware_counter_increment(firmware_event::ILLEGAL_INSN);
-                    if mstatus::read().mpp() == mstatus::MPP::Machine {
-                        panic!("Cannot handle illegal instruction exception from M-MODE");
-                    }
-                    save_regs(&mut ctx);
-                    ctx.continue_with(handler::illegal_instruction_handler, ())
-                }
-                Trap::Exception(Exception::LoadMisaligned) => {
-                    pmu_firmware_counter_increment(firmware_event::MISALIGNED_LOAD);
-                    save_regs(&mut ctx);
-                    ctx.continue_with(handler::load_misaligned_handler, ())
-                }
-                Trap::Exception(Exception::StoreMisaligned) => {
-                    pmu_firmware_counter_increment(firmware_event::MISALIGNED_STORE);
-                    save_regs(&mut ctx);
-                    ctx.continue_with(handler::store_misaligned_handler, ())
-                }
-                // Handle other traps
-                trap => unsupported_trap(Some(trap)),
-            }
+fn handle_interrupt(
+    mut ctx: FastContext,
+    interrupt: Interrupt,
+    save_regs: impl Fn(&mut FastContext),
+) -> FastResult {
+    match interrupt {
+        Interrupt::MachineSoft => {
+            save_regs(&mut ctx);
+            handler::msoft_handler(ctx)
         }
-        Err(err) => {
-            error!("Failed to parse mcause: {:?}", err);
-            unsupported_trap(None);
+        Interrupt::MachineTimer => {
+            use crate::sbi::ipi;
+
+            ipi::clear_mtime();
+            unsafe {
+                mip::set_stimer();
+            }
+            save_regs(&mut ctx);
+            ctx.restore()
+        }
+        // TODO: Handle MachineExternal
+        Interrupt::MachineExternal => {
+            error!("TODO: Unhandled MachineExternal interrupt");
+            unsupported_trap(Some(Trap::Interrupt(interrupt)))
+        }
+        _ => {
+            error!("Unhandled interrupt: {:?}", interrupt);
+            unsupported_trap(Some(Trap::Interrupt(interrupt)))
+        }
+    }
+}
+
+fn handle_exception(
+    mut ctx: FastContext,
+    exception: Exception,
+    save_regs: impl Fn(&mut FastContext),
+) -> FastResult {
+    match exception {
+        // TODO: Handle InstructionMisaligned
+        Exception::InstructionMisaligned => {
+            error!("TODO: Unhandled InstructionMisaligned exception");
+            unsupported_trap(Some(Trap::Exception(exception)))
+        }
+        Exception::IllegalInstruction => {
+            pmu_firmware_counter_increment(firmware_event::ILLEGAL_INSN);
+            if mstatus::read().mpp() == mstatus::MPP::Machine {
+                panic!("Cannot handle illegal instruction exception from M-MODE");
+            }
+            save_regs(&mut ctx);
+            ctx.continue_with(handler::illegal_instruction_handler, ())
+        }
+        // TODO: Handle Breakpoint
+        Exception::Breakpoint => {
+            error!("TODO: Unhandled Breakpoint exception");
+            unsupported_trap(Some(Trap::Exception(exception)))
+        }
+        Exception::LoadMisaligned => {
+            pmu_firmware_counter_increment(firmware_event::MISALIGNED_LOAD);
+            save_regs(&mut ctx);
+            ctx.continue_with(handler::load_misaligned_handler, ())
+        }
+        Exception::StoreMisaligned => {
+            pmu_firmware_counter_increment(firmware_event::MISALIGNED_STORE);
+            save_regs(&mut ctx);
+            ctx.continue_with(handler::store_misaligned_handler, ())
+        }
+        _ => {
+            error!("Unhandled exception: {:?}", exception);
+            unsupported_trap(Some(Trap::Exception(exception)))
         }
     }
 }


### PR DESCRIPTION
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

### Motivation
1. In prototyper trap handler, all handle have been dealt with one big match,  match logic nesting two layers has led to a decrease in readability.
2. For the already implemented match branch, comments are useless. However, for the hander that must be supported but is not supported, there are no todo comments, such as handling M mode external interrupt, etc.
3. Interrupt and exception are obviously two different ways of handling, so they should not be placed in one big match.

### What did this PR do
1. Reducing the number of nested layers improves readability.
2. Handle interrupts and exceptions separately and output the complete error message.
3. Add comments for TODO handler.