### PR TITLE
docs(prototyper): refine csr group comments

### DIFF
--- a/prototyper/CHANGELOG.md
+++ b/prototyper/CHANGELOG.md
@@ -9,5 +9,6 @@ All notable changes to this project will be documented in this file. See [conven
 ### Added
 
 ### Modified
+- Refine CSR group comments.
 
 ### Removed

--- a/prototyper/prototyper/src/riscv/csr.rs
+++ b/prototyper/prototyper/src/riscv/csr.rs
@@ -3,30 +3,14 @@
 use pastey::paste;
 use seq_macro::seq;
 
-/// CSR addresses
+// Supervisor Timer Register (Sstc extension)
 pub const CSR_STIMECMP: u16 = 0x14D;
+
+// Machine Counter-Enable and Environment Configuration
 pub const CSR_MCOUNTEREN: u16 = 0x306;
 pub const CSR_MENVCFG: u16 = 0x30a;
-pub const CSR_MCYCLE: u16 = 0xb00;
-pub const CSR_MINSTRET: u16 = 0xb02;
-seq!(N in 3..32 {
-    pub const CSR_MHPMCOUNTER~N: u16 = 0xb00 + N;
-});
-pub const CSR_MCYCLEH: u16 = 0xb80;
-pub const CSR_MINSTRETH: u16 = 0xb82;
-seq!(N in 3..32 {
-    paste! {
-        pub const [<CSR_MHPMCOUNTER ~N H>]: u16 = 0xb80 + N;
-    }
-});
-/* User Counters/Timers */
-pub const CSR_CYCLE: u16 = 0xc00;
-pub const CSR_TIME: u16 = 0xc01;
-pub const CSR_INSTRET: u16 = 0xc02;
-seq!(N in 3..32 {
-    pub const CSR_HPMCOUNTER~N: u16 = 0xc00 + N;
-});
-/// MHPMEVENT
+
+// Machine Counter Setup (Inhibit, Privilege Filtering and Event Selection)
 pub const CSR_MCOUNTINHIBIT: u16 = 0x320;
 pub const CSR_MCYCLECFG: u16 = 0x321;
 pub const CSR_MINSTRETCFG: u16 = 0x322;
@@ -34,7 +18,31 @@ seq!(N in 3..32 {
     pub const CSR_MHPMEVENT~N: u16 = 0x320 + N;
 });
 
-// For RV32
+// Machine Counter/Timers
+pub const CSR_MCYCLE: u16 = 0xb00;
+pub const CSR_MINSTRET: u16 = 0xb02;
+seq!(N in 3..32 {
+    pub const CSR_MHPMCOUNTER~N: u16 = 0xb00 + N;
+});
+
+// Upper 32 bits of Machine Counter/Timers (RV32)
+pub const CSR_MCYCLEH: u16 = 0xb80;
+pub const CSR_MINSTRETH: u16 = 0xb82;
+seq!(N in 3..32 {
+    paste! {
+        pub const [<CSR_MHPMCOUNTER ~N H>]: u16 = 0xb80 + N;
+    }
+});
+
+// User Counter/Timers (Read-only shadows of Machine counters)
+pub const CSR_CYCLE: u16 = 0xc00;
+pub const CSR_TIME: u16 = 0xc01;
+pub const CSR_INSTRET: u16 = 0xc02;
+seq!(N in 3..32 {
+    pub const CSR_HPMCOUNTER~N: u16 = 0xc00 + N;
+});
+
+// Upper 32 bits of User Counter/Timers (RV32)
 pub const CSR_CYCLEH: u16 = 0xc80;
 pub const CSR_TIMEH: u16 = 0xc81;
 pub const CSR_INSTRETH: u16 = 0xc82;


### PR DESCRIPTION
## What
Refine comments for csr group constants in prototyper and add a changelog entry.

## Why
The previous CSR group comments were inconsistent and slightly verbose. This change improves readability
and keeps comment style consistent across the prototyper codebase, with no functional impact.

## How
- Use line comments (`//`) for CSR group headings in `prototyper/prototyper/src/riscv/csr.rs`.
- Regroup the comments and add detailed information.
- Add an Unreleased entry in `prototyper/CHANGELOG.md`.

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo clippy` (existing warnings only)
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
