### PR TITLE
docs(prototyper): correct the comments of pmp setting

### DIFF
--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -206,9 +206,9 @@ pub fn set_pmp(memory_range: &Range<usize>) {
     unsafe {
         // [0..memory_range.start] RWX
         // [memory_range.start..sbi_start] RWX
-        // [sbi_start..sbi_rodata_start] NONE
+        // [sbi_start..sbi_rodata_start] R
         // [sbi_rodata_start..sbi_rodata_end] NONE
-        // [sbi_rodata_end..sbi_end] NONE
+        // [sbi_rodata_end..sbi_end] R
         // [sbi_end..memory_range.end] RWX
         // [memory_range.end..INF] RWX
         use riscv::register::*;


### PR DESCRIPTION
According to the following code, the permission of segment `[sbi_start..sbi_rodata_start]` is `R`, while the another one `[sbi_rodata_end..sbi_end]` is same as above.

<img width="1025" height="214" alt="image" src="https://github.com/user-attachments/assets/30438126-79d0-4f20-b184-29d759ff51de" />
