### PR TITLE
fix(prototyper): skip non rela item in rela.dyn

### DIFF
--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -234,8 +234,8 @@ unsafe extern "C" fn relocation_update() {
         "   add t4, t4, t2", // Add load offset to offset add append
         "   add t5, t5, t2",
         "   sd t5, 0(t4)", // Update address
-        "   addi t0, t0, 24", // Get next rela item
         "2:",
+        "   addi t0, t0, 24", // Get next rela item
         "   blt t0, t1, 1b",
         "   fence.i",
 


### PR DESCRIPTION
when meet a non-relative item in rela.dyn, relocation_update will loop infinitely now. so maybe we should skip this rela item and go to next instead?

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
