### PR TITLE
feat: bump `riscv` crate to version 0.16.0, set `riscv` to workspace level dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,7 @@ repository = "https://github.com/rustsbi/rustsbi"
 [profile.release]
 debug = true
 
+[workspace.dependencies]
+riscv = { version = "0.16.0", default-features = false }
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/library/pmpm/Cargo.toml
+++ b/library/pmpm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["riscv", "sbi", "rustsbi", "pmp", "tee"]
 categories = ["os", "embedded", "hardware-support", "no-std"]
 
 [dependencies]
-riscv = "0.12.1"
+riscv = { workspace = true }
 
 [dev-dependencies]
 static_assertions = "1.1.0"

--- a/library/pmpm/src/lib.rs
+++ b/library/pmpm/src/lib.rs
@@ -140,25 +140,27 @@ pub fn set_pmp_cfg(idx: u32, config: &PmpConfig) {
     }
 }
 
-fn _set_pmp_addr(idx: u32, addr: usize) {
-    match idx {
-        0 => pmpaddr0::write(addr),
-        1 => pmpaddr1::write(addr),
-        2 => pmpaddr2::write(addr),
-        3 => pmpaddr3::write(addr),
-        4 => pmpaddr4::write(addr),
-        5 => pmpaddr5::write(addr),
-        6 => pmpaddr6::write(addr),
-        7 => pmpaddr7::write(addr),
-        8 => pmpaddr8::write(addr),
-        9 => pmpaddr9::write(addr),
-        10 => pmpaddr10::write(addr),
-        11 => pmpaddr11::write(addr),
-        12 => pmpaddr12::write(addr),
-        13 => pmpaddr13::write(addr),
-        14 => pmpaddr14::write(addr),
-        15 => pmpaddr15::write(addr),
-        _ => panic!("Invalid PMP index for addr"),
+unsafe fn _set_pmp_addr(idx: u32, addr: usize) {
+    unsafe {
+        match idx {
+            0 => pmpaddr0::write(addr),
+            1 => pmpaddr1::write(addr),
+            2 => pmpaddr2::write(addr),
+            3 => pmpaddr3::write(addr),
+            4 => pmpaddr4::write(addr),
+            5 => pmpaddr5::write(addr),
+            6 => pmpaddr6::write(addr),
+            7 => pmpaddr7::write(addr),
+            8 => pmpaddr8::write(addr),
+            9 => pmpaddr9::write(addr),
+            10 => pmpaddr10::write(addr),
+            11 => pmpaddr11::write(addr),
+            12 => pmpaddr12::write(addr),
+            13 => pmpaddr13::write(addr),
+            14 => pmpaddr14::write(addr),
+            15 => pmpaddr15::write(addr),
+            _ => panic!("Invalid PMP index for addr"),
+        }
     }
 }
 
@@ -178,8 +180,10 @@ pub fn set_pmp_entry(idx: u32, addr: usize, len: usize, config: &PmpConfig) -> b
         addr,
         0,
     );
-    _set_pmp_addr(idx, encode_pmp_addr(&slice, config.range));
-    set_pmp_cfg(idx, config);
+    unsafe {
+        _set_pmp_addr(idx, encode_pmp_addr(&slice, config.range));
+        set_pmp_cfg(idx, config);
+    }
     true
 }
 
@@ -194,7 +198,9 @@ pub fn set_pmp_addr(idx: u32, addr: usize, len: usize, range: Range) -> bool {
         addr,
         0,
     );
-    _set_pmp_addr(idx, encode_pmp_addr(&slice, range));
+    unsafe {
+        _set_pmp_addr(idx, encode_pmp_addr(&slice, range));
+    }
     true
 }
 

--- a/library/riscv-aia/Cargo.toml
+++ b/library/riscv-aia/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["riscv", "aia"]
 categories = ["os", "embedded", "hardware-support", "no-std"]
 
 [dependencies]
-riscv = "0.12.1"
+riscv = { workspace = true }
 volatile-register = "0.2.2"
 
 [dev-dependencies]

--- a/library/riscv-aia/src/register/mtopei.rs
+++ b/library/riscv-aia/src/register/mtopei.rs
@@ -1,5 +1,4 @@
 //! Machine-level top external interrupt register (only with an IMSIC).
-//! Machine-level top external interrupt register (only with an IMSIC).
 //!
 //! CSR `mtopei` reports the highest-priority external interrupt that is
 //! pending and enabled for machine-level when an IMSIC is present. Provide a

--- a/library/rustsbi/CHANGELOG.md
+++ b/library/rustsbi/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Modified
 
 - Migrate sbi-rt crate to Rust 2024 edition.
+- Upgrade dependency `riscv` to 0.16.0.
 - susp: amend documentation on `system_suspend` function.
 - lib: replace map+unwrap_or with Option::map_or in impls
 - doc: lib: alter link to Prototyper firmware in documentation.

--- a/library/rustsbi/Cargo.toml
+++ b/library/rustsbi/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["os", "embedded", "hardware-support", "no-std"]
 
 [dependencies]
 sbi-spec = { version = "0.0.8", path = "../sbi-spec" }
-riscv = { version = "0.12.0", optional = true, default-features = false }
+riscv = { workspace = true, optional = true }
 sbi-rt = { version = "0.0.3", features = ["integer-impls"], optional = true, path = "../sbi-rt" }
 rustsbi-macros = { version = "0.0.2", path = "../macros" }
 

--- a/library/rustsbi/src/traits.rs
+++ b/library/rustsbi/src/traits.rs
@@ -65,9 +65,9 @@ pub fn _rustsbi_base_bare<U: _ExtensionProbe>(
         spec::base::GET_SBI_IMPL_ID => crate::IMPL_ID_RUSTSBI,
         spec::base::GET_SBI_IMPL_VERSION => crate::RUSTSBI_VERSION,
         spec::base::PROBE_EXTENSION => probe.probe_extension(param0),
-        spec::base::GET_MVENDORID => mvendorid::read().map(|r| r.bits()).unwrap_or(0),
-        spec::base::GET_MARCHID => marchid::read().map(|r| r.bits()).unwrap_or(0),
-        spec::base::GET_MIMPID => mimpid::read().map(|r| r.bits()).unwrap_or(0),
+        spec::base::GET_MVENDORID => mvendorid::read().bits(),
+        spec::base::GET_MARCHID => marchid::read().bits(),
+        spec::base::GET_MIMPID => mimpid::read().bits(),
         _ => return SbiRet::not_supported(),
     };
     SbiRet::success(value)

--- a/library/sbi-testing/CHANGELOG.md
+++ b/library/sbi-testing/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Migrate sbi-rt crate to Rust 2024 edition.
 - Update sbi-spec to version 0.0.7
 - Update sbi-rt to version 0.0.3
+- Upgrade dependency `riscv` to 0.16.0.
 - Rename `MArchId` and `MVendorId` into `MarchId` and `MvendorId` in `BaseCase`
 - Replace `#[naked]` with `#[unsafe(naked)]` attribute in sbi-testing module to support stable Rust
     - Modified files:

--- a/library/sbi-testing/Cargo.toml
+++ b/library/sbi-testing/Cargo.toml
@@ -20,7 +20,7 @@ targets = ["riscv32imac-unknown-none-elf", "riscv64imac-unknown-none-elf"]
 [dependencies]
 sbi-rt = { version = "0.0.3", path = "../sbi-rt" }
 sbi-spec = { version = "0.0.8", path = "../sbi-spec" }
-riscv = { version = "0.12.0", default-features = false }
+riscv = { workspace = true }
 log = { version = "0.4", package = "log", optional = true }
 
 [features]

--- a/library/smm/Cargo.toml
+++ b/library/smm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["riscv", "sbi", "rustsbi", "tee"]
 categories = ["os", "embedded", "hardware-support", "no-std"]
 
 [dependencies]
-riscv = "0.12.1"
+riscv = { workspace = true }
 buddy_system_allocator = "0.11.0"
 spin = "0.9"
 log = "0.4"

--- a/prototyper/bench-kernel/Cargo.toml
+++ b/prototyper/bench-kernel/Cargo.toml
@@ -14,7 +14,7 @@ sbi-spec = { version = "0.0.8", path = "../../library/sbi-spec" }
 serde-device-tree = { git = "https://github.com/rustsbi/serde-device-tree", rev= "e7f9404f", default-features = false }
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 log = "0.4"
-riscv = "0.12.1"
+riscv = { workspace = true }
 spin = "0.9"
 uart16550 = "0.0.1"
 rcore-console = "0.0.0"

--- a/prototyper/prototyper/Cargo.toml
+++ b/prototyper/prototyper/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 [dependencies]
 log = "0.4"
 panic-halt = "1.0.0"
-riscv = "0.12.1"
+riscv = { workspace = true }
 sifive-test-device = "0.0.0"
 spin = "0.9.8"
 uart16550 = "0.0.1"
@@ -35,6 +35,7 @@ seq-macro = "0.3.5"
 pastey = "0.1.0"
 uart_sifive = { git = "https://github.com/duskmoon314/uart-rs/" }
 arm-pl011-uart = "0.3.2"
+riscv-aia = { version = "0.0.0", path = "../../library/riscv-aia" }
 
 [[bin]]
 name = "rustsbi-prototyper"

--- a/prototyper/prototyper/src/macros.rs
+++ b/prototyper/prototyper/src/macros.rs
@@ -34,7 +34,7 @@ macro_rules! has_csr {
                 // Backup old mtvec
                 let mtvec = mtvec::read().bits();
                 // Write expected_trap
-                mtvec::write(light_expected_trap as _, mtvec::TrapMode::Direct);
+                mtvec::write(mtvec::Mtvec::new(light_expected_trap as *const () as _, mtvec::TrapMode::Direct));
                 asm!("addi a0, zero, 0",
                     "addi a1, zero, 0",
                     "csrr a2, {}",

--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -153,7 +153,11 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
             }
         }
         // Set up trap handling.
-        mtvec::write(fast_trap::trap_entry as _, mtvec::TrapMode::Direct);
+        let val = mtvec::Mtvec::new(
+            fast_trap::trap_entry as *const () as _,
+            mtvec::TrapMode::Direct,
+        );
+        mtvec::write(val);
     }
 }
 

--- a/prototyper/prototyper/src/sbi/early_trap.rs
+++ b/prototyper/prototyper/src/sbi/early_trap.rs
@@ -63,7 +63,10 @@ pub(crate) unsafe fn csr_read_allow<const CSR_NUM: u16>(trap_info: *mut TrapInfo
     unsafe {
         core::ptr::write_volatile(&mut (*trap_info).mcause, usize::MAX);
         // Write expected_trap
-        mtvec::write(expected_trap as _, mtvec::TrapMode::Direct);
+        mtvec::write(mtvec::Mtvec::new(
+            expected_trap as *const () as _,
+            mtvec::TrapMode::Direct,
+        ));
 
         asm!(
             "add a3, {tinfo}, zero",
@@ -86,7 +89,8 @@ pub(crate) unsafe fn csr_write_allow<const CSR_NUM: u16>(trap_info: *mut TrapInf
     unsafe {
         core::ptr::write_volatile(&mut (*trap_info).mcause, usize::MAX);
         // Write expected_trap
-        mtvec::write(expected_trap as _, mtvec::TrapMode::Direct);
+        let val = mtvec::Mtvec::new(expected_trap as *const () as _, mtvec::TrapMode::Direct);
+        mtvec::write(val);
 
         asm!(
             "add a3, {tinfo}, zero",

--- a/prototyper/prototyper/src/sbi/features.rs
+++ b/prototyper/prototyper/src/sbi/features.rs
@@ -37,6 +37,7 @@ pub enum PrivilegedVersion {
 pub enum Extension {
     Sstc = 0,
     Hypervisor = 1,
+    Smaia = 2,
 }
 
 impl Extension {
@@ -46,6 +47,7 @@ impl Extension {
         match self {
             Self::Sstc => "sstc",
             Self::Hypervisor => "h",
+            Self::Smaia => "smaia", // TODO verify with DTB standard
         }
     }
 
@@ -55,7 +57,7 @@ impl Extension {
     }
 
     pub fn iter() -> impl Iterator<Item = Self> {
-        [Self::Sstc, Self::Hypervisor].into_iter()
+        [Self::Sstc, Self::Hypervisor, Self::Smaia].into_iter()
     }
 }
 
@@ -94,7 +96,7 @@ pub fn extension_detection(cpus: &NodeSeq) {
             let dt_supported = check_extension_in_device_tree(ext_name, &cpu_data);
             extensions[ext_index] = match ext {
                 Extension::Hypervisor if hart_id == current_hartid() => {
-                    misa::read().unwrap().has_extension('H')
+                    misa::read().has_extension('H')
                 }
                 _ => dt_supported,
             };
@@ -198,7 +200,7 @@ pub fn hart_privileged_check(mpp: MPP) {
     let hart_id = current_hartid();
     match mpp {
         MPP::Supervisor => {
-            if !misa::read().unwrap().has_extension('S') {
+            if !misa::read().has_extension('S') {
                 warn!("Hart {} not support Supervisor mode", hart_id);
                 fail::stop();
             } else {
@@ -208,7 +210,7 @@ pub fn hart_privileged_check(mpp: MPP) {
             }
         }
         MPP::User => {
-            if !misa::read().unwrap().has_extension('U') {
+            if !misa::read().has_extension('U') {
                 warn!("Hart {} not support User mode", hart_id);
                 fail::stop();
             } else {

--- a/prototyper/prototyper/src/sbi/features.rs
+++ b/prototyper/prototyper/src/sbi/features.rs
@@ -38,10 +38,11 @@ pub enum Extension {
     Sstc = 0,
     Hypervisor = 1,
     Smaia = 2,
+    // Remember to increment `Extension::COUNT` while implementing new extensions.
 }
 
 impl Extension {
-    pub const COUNT: usize = 2;
+    pub const COUNT: usize = 3;
 
     pub const fn as_str(&self) -> &'static str {
         match self {

--- a/prototyper/prototyper/src/sbi/pmu.rs
+++ b/prototyper/prototyper/src/sbi/pmu.rs
@@ -755,7 +755,9 @@ fn write_mhpmevent(mhpm_offset: u16, mhpmevent_val: u64) {
         seq_macro::seq!(N in 3..=31 {
             match idx {
                 #(
-                    N => pastey::paste!{ [<mhpmevent ~N>]::write(mhpmevent_val as usize) },
+                    N => unsafe {
+                        pastey::paste!{ [<mhpmevent ~N>]::write(mhpmevent_val as usize) }
+                    },
                 )*
                 _ =>{}
             }
@@ -782,7 +784,9 @@ fn write_mhpmcounter(mhpm_offset: u16, mhpmcounter_val: u64) {
         seq_macro::seq!(N in 3..=31 {
             match counter_idx {
                 #(
-                    N => pastey::paste!{ [<mhpmcounter ~N>]::write(mhpmcounter_val as usize) },
+                    N => pastey::paste!{ unsafe {
+                        [<mhpmcounter ~N>]::write(mhpmcounter_val as usize) }
+                    },
                 )*
                 _ =>{}
             }

--- a/prototyper/prototyper/src/sbi/trap/boot.rs
+++ b/prototyper/prototyper/src/sbi/trap/boot.rs
@@ -43,7 +43,7 @@ pub extern "C" fn boot_handler(ctx: &mut BootContext) {
     fn boot(ctx: &mut BootContext, start_addr: usize, opaque: usize) {
         unsafe {
             sstatus::clear_sie();
-            satp::write(0);
+            satp::write(satp::Satp::from_bits(0));
         }
         ctx.a0 = current_hartid();
         ctx.a1 = opaque;

--- a/prototyper/prototyper/src/sbi/trap/helper.rs
+++ b/prototyper/prototyper/src/sbi/trap/helper.rs
@@ -43,10 +43,11 @@ pub fn get_unsigned_byte(addr: usize) -> u8 {
     let mut status: usize = 0;
     unsafe {
         let prev_mtvec = mtvec::read().bits();
-        mtvec::write(
-            crate::sbi::early_trap::expected_trap as _,
+        let val = mtvec::Mtvec::new(
+            crate::sbi::early_trap::expected_trap as *const () as _,
             mtvec::TrapMode::Direct,
         );
+        mtvec::write(val);
         asm!(
             "csrrs t3, mstatus, t3",
             "lbu t0, 0(t1)",
@@ -71,10 +72,11 @@ pub fn save_byte(addr: usize, data: usize) {
     unsafe {
         let prev_mtvec = mtvec::read().bits();
         let mut status: usize = 0;
-        mtvec::write(
-            crate::sbi::early_trap::expected_trap as _,
+        let val = mtvec::Mtvec::new(
+            crate::sbi::early_trap::expected_trap as *const () as _,
             mtvec::TrapMode::Direct,
         );
+        mtvec::write(val);
         asm!(
               "csrrs t3, mstatus, t3",
               "sb t0, 0(t1)",
@@ -119,7 +121,7 @@ pub fn save_reg_x(ctx: &mut EntireContextSeparated, reg_id: usize, data: usize) 
     match reg_id {
         00 => (),
         01 => ctx.regs().ra = data,
-        02 => sscratch::write(data),
+        02 => unsafe { sscratch::write(data) },
         03 => write_gp(data),
         04 => write_tp(data),
         05 => ctx.regs().t[0] = data,

--- a/prototyper/test-kernel/Cargo.toml
+++ b/prototyper/test-kernel/Cargo.toml
@@ -14,7 +14,7 @@ sbi-spec = { version = "0.0.8", features = [
     "legacy",
 ], path = "../../library/sbi-spec" }
 log = "0.4"
-riscv = "0.12.1"
+riscv = { workspace = true }
 spin = "0.9"
 uart16550 = "0.0.1"
 rcore-console = "0.0.0"


### PR DESCRIPTION
Upgrade `riscv` from `0.12.0` to `0.16.0`.

Download compilation result: [rustsbi-prototyper-dynamic.zip](https://github.com/user-attachments/files/25143307/rustsbi-prototyper-dynamic.zip)
