### PR TITLE
fix(prototyper): validate pmu firmware counter index

### DIFF
--- a/prototyper/prototyper/src/sbi/pmu.rs
+++ b/prototyper/prototyper/src/sbi/pmu.rs
@@ -266,11 +266,10 @@ impl Pmu for SbiPmu {
             pmu_state.active_event[counter_idx] = event_idx;
         }
 
-        if configure_counter(pmu_state, counter_idx, event, flags) {
-            return SbiRet::success(counter_idx);
+        match configure_counter(pmu_state, counter_idx, event, flags) {
+            Ok(_) => SbiRet::success(counter_idx),
+            Err(e) => e,
         }
-
-        return SbiRet::not_supported();
     }
 
     /// Start one or more counters (FID #3)
@@ -627,11 +626,14 @@ fn configure_counter(
     counter_idx: usize,
     event: EventIdx,
     flags: flags::CounterCfgFlags,
-) -> bool {
+) -> Result<(), SbiRet> {
     let auto_start = flags.contains(flags::CounterCfgFlags::AUTO_START);
     let clear_value = flags.contains(flags::CounterCfgFlags::CLEAR_VALUE);
     if event.is_firmware_event() {
         let firmware_event_idx = counter_idx - pmu_state.hw_counters_num;
+        if firmware_event_idx >= PMU_FIRMWARE_COUNTER_MAX {
+            return Err(SbiRet::invalid_param());
+        }
         if clear_value {
             pmu_state.fw_counter[firmware_event_idx] = 0;
         }
@@ -644,10 +646,12 @@ fn configure_counter(
             write_mhpmcounter(mhpm_offset, 0);
         }
         if auto_start {
-            return start_hardware_counter(mhpm_offset, 0, false).is_ok();
+            if start_hardware_counter(mhpm_offset, 0, false).is_err() {
+                return Err(SbiRet::not_supported());
+            }
         }
     }
-    true
+    Ok(())
 }
 
 /// Get the offset of the mhpmcounter CSR corresponding to counter_idx relative to mcycle


### PR DESCRIPTION
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>

This pull request fix the issue #190. It add a new logic to validate the `firmware_event_idx` in pmu and return a `SbiRet`.
