### PR TITLE
fix(prototyper): validate DBCN console shared memory range

### DIFF
--- a/prototyper/CHANGELOG.md
+++ b/prototyper/CHANGELOG.md
@@ -11,5 +11,5 @@ All notable changes to this project will be documented in this file. See [conven
 ### Modified
 - Refine CSR group comments.
 - fix(prototyper): temporary PMU fix for possible S-mode DTB modification
-
+- fix(prototyper): validate DBCN console shared memory range
 ### Removed

--- a/prototyper/prototyper/src/sbi/console.rs
+++ b/prototyper/prototyper/src/sbi/console.rs
@@ -5,6 +5,31 @@ use spin::Mutex;
 
 use crate::platform::PLATFORM;
 
+// Returns the 64-bit physical address composed from the low/high parts.
+#[inline]
+fn physical_addr(lo: usize, hi: usize) -> u64 {
+    ((hi as u64) << 32) | (lo as u64)
+}
+
+// Checks whether the physical range is within platform DRAM and directly addressable.
+#[inline]
+fn is_physical_range_valid(start: u64, len: usize) -> bool {
+    if start > usize::MAX as u64 {
+        return false;
+    }
+
+    let Some(end) = start.checked_add(len as u64) else {
+        return false;
+    };
+
+    let memory_range = unsafe { PLATFORM.info.memory_range.as_ref() };
+
+    match memory_range {
+        Some(range) => start >= range.start as u64 && end <= range.end as u64,
+        None => false,
+    }
+}
+
 /// A trait that must be implemented by console devices to provide basic I/O functionality.
 pub trait ConsoleDevice {
     /// Reads bytes from the console into the provided buffer.
@@ -73,9 +98,15 @@ impl Console for SbiConsole {
     /// Write a physical memory buffer to the console.
     #[inline]
     fn write(&self, bytes: Physical<&[u8]>) -> SbiRet {
-        // TODO: verify valid memory range for a `Physical` slice.
-        let start = bytes.phys_addr_lo();
-        let buf = unsafe { core::slice::from_raw_parts(start as *const u8, bytes.num_bytes()) };
+        let len = bytes.num_bytes();
+        if len == 0 {
+            return SbiRet::success(0);
+        }
+        let start = physical_addr(bytes.phys_addr_lo(), bytes.phys_addr_hi());
+        if !is_physical_range_valid(start, len) {
+            return SbiRet::invalid_param();
+        }
+        let buf = unsafe { core::slice::from_raw_parts(start as *const u8, len) };
         let bytes_written = self.inner.lock().write(buf);
         SbiRet::success(bytes_written)
     }
@@ -83,9 +114,15 @@ impl Console for SbiConsole {
     /// Read from console into a physical memory buffer.
     #[inline]
     fn read(&self, bytes: Physical<&mut [u8]>) -> SbiRet {
-        // TODO: verify valid memory range for a `Physical` slice.
-        let start = bytes.phys_addr_lo();
-        let buf = unsafe { core::slice::from_raw_parts_mut(start as *mut u8, bytes.num_bytes()) };
+        let len = bytes.num_bytes();
+        if len == 0 {
+            return SbiRet::success(0);
+        }
+        let start = physical_addr(bytes.phys_addr_lo(), bytes.phys_addr_hi());
+        if !is_physical_range_valid(start, len) {
+            return SbiRet::invalid_param();
+        }
+        let buf = unsafe { core::slice::from_raw_parts_mut(start as *mut u8, len) };
         let bytes_read = self.inner.lock().read(buf);
         SbiRet::success(bytes_read)
     }


### PR DESCRIPTION
SBI DBCN console_write/console_read previously converted the physical buffer into a raw slice without validating its physical address range. Passing an invalid buffer (e.g. addr=0x2, len=0x24) could therefore hang Prototyper instead of returning invalid_param, violating the Console::write/read contract.

Validate the `[start, start + len)` range against the platform DRAM `memory_range` before creating the raw slice, and return SbiRet::invalid_param() on invalid ranges. Also compose the full physical address from hi/lo parts.

Fix: #192
## What
Fixed a potential firmware hang in the Prototyper's DBCN implementation when 
provided with invalid physical memory buffers.

## Why
Directly converting an unverified supervisor-provided physical address (e.g., 
addr=0x2) into a Rust slice and accessing it in M-mode triggers hardware 
exceptions or stable hangs. This violates the SBI Console contract, which 
requires returning `invalid_param` for inaccessible memory.

## How
- Compose the full 64-bit physical address from `phys_addr_hi` and `phys_addr_lo`.
- Implement a check to validate the `[start, start + len)` range against the 
  platform's DRAM `memory_range`.
- Use `checked_add` to safely calculate the end address and prevent overflow.
- Return `SbiRet::invalid_param()` if the range is invalid or inaccessible.
## Testing
Verified using a custom S-mode C payload on QEMU Virt machine.
#### Observed Output:

``` Plaintext
[RustSBI] INFO  - Boot HART MHPM Mask:          : 0x07ffff
[RustSBI] INFO  - The patched dtb is located at 0x8005c000 with length 0x1eb0.
[RustSBI] INFO  - Redirecting hart 0 to 0x00000080600000 in Supervisor mode.
ANY0
```
(Note: 'A' = Payload start, 'N' = Invalid addr check passed, 'Y' = Valid addr check passed, '0' = QEMU Exit 0)
Test Setup:

Payload linked at 0x80600000.

Manually initialized sp to 0x90000000 (DRAM end).

Case 1 (Invalid Write): Call console_write with addr=0x2. Expected: Returns -2 (invalid_param). Observed: Prints 'N' and continues.

Case 2 (Valid Read): Call console_read with addr=0x80700000. Expected: Returns 0 (success). Observed: Prints 'Y'.

Exit: System shuts down via SRST to confirm completion.

<details>
<summary>点击查看测试 Payload 代码 (C)</summary>

``` c
#include <stdint.h>

struct sbiret {
    long error;
    long value;
};

// Legacy putchar for markers
static inline void console_putchar(uint64_t ch) {
    register uint64_t a0 asm("a0") = ch;
    register uint64_t a7 asm("a7") = 1; 
    asm volatile ("ecall" : "+r"(a0) : "r"(a7) : "memory", "a1", "a2", "a3", "a4", "a5", "a6");
}

static inline struct sbiret sbi_dbcn_console_write(uint64_t len, uint64_t addr_lo, uint64_t addr_hi) {
    register uint64_t a0 asm("a0") = len;
    register uint64_t a1 asm("a1") = addr_lo;
    register uint64_t a2 asm("a2") = addr_hi;
    register uint64_t a6 asm("a6") = 0; 
    register uint64_t a7 asm("a7") = 0x4442434EULL; 
    asm volatile ("ecall" : "+r"(a0), "+r"(a1), "+r"(a2), "+r"(a6), "+r"(a7) : : "memory", "a3", "a4", "a5");
    return (struct sbiret){ .error = (long)a0, .value = (long)a1 };
}

static inline struct sbiret sbi_dbcn_console_read(uint64_t len, uint64_t addr_lo, uint64_t addr_hi) {
    register uint64_t a0 asm("a0") = len;
    register uint64_t a1 asm("a1") = addr_lo;
    register uint64_t a2 asm("a2") = addr_hi;
    register uint64_t a6 asm("a6") = 1; 
    register uint64_t a7 asm("a7") = 0x4442434EULL; 
    asm volatile ("ecall" : "+r"(a0), "+r"(a1), "+r"(a2), "+r"(a6), "+r"(a7) : : "memory", "a3", "a4", "a5");
    return (struct sbiret){ .error = (long)a0, .value = (long)a1 };
}

static inline void shutdown(void) {
    register uint64_t a0 asm("a0") = 0;
    register uint64_t a1 asm("a1") = 0;
    register uint64_t a6 asm("a6") = 0;
    register uint64_t a7 asm("a7") = 0x53525354ULL; 
    asm volatile ("ecall" : "+r"(a0), "+r"(a1), "+r"(a6), "+r"(a7) : : "memory", "a2", "a3", "a4", "a5");
    for (;;) { asm volatile ("wfi"); }
}

static void payload_main(void) {
    console_putchar('A'); // Start marker

    // Test invalid address
    struct sbiret w = sbi_dbcn_console_write(0x24, 0x2, 0x0);
    console_putchar(w.error == 0 ? 'Y' : 'N'); // Expected 'N'

    // Test valid address
    struct sbiret r = sbi_dbcn_console_read(0x24, 0x80700000, 0x0);
    console_putchar(r.error == 0 ? 'Y' : 'N'); // Expected 'Y'

    shutdown();
}

__attribute__((naked, noreturn, section(".text.entry"), aligned(4))) void _start(void) {
    asm volatile(
        "li sp, 0x90000000\n"
        "j payload_main\n"
    );
    __builtin_unreachable();
}
```
<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
