### PR TITLE
fix(prototyper): validate DBCN physical buffers by SBI ABI

### DIFF
--- a/.github/scripts/prototyper-qemu-boot.sh
+++ b/.github/scripts/prototyper-qemu-boot.sh
@@ -77,6 +77,8 @@ run_once() {
       grep -F 'Sbi `TIME` test pass' "$log_file"
       grep -F 'Sbi `sPI` test pass' "$log_file"
       grep -F 'Sbi `DBCN` test pass' "$log_file"
+      grep -F 'DBCN rejected non-zero upper-half write' "$log_file"
+      grep -F 'DBCN rejected non-zero upper-half read' "$log_file"
       grep -F '[pmu] counters number:' "$log_file"
       ;;
     bench)

--- a/library/sbi-testing/CHANGELOG.md
+++ b/library/sbi-testing/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Test new extension DBCN
+- Add an RV64 DBCN regression case for rejecting non-zero upper address halves.
 
 ### Modified
 
@@ -45,4 +46,3 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [Unreleased]: https://github.com/rustsbi/sbi-testing/compare/v0.0.2...HEAD
 [0.0.2]: https://github.com/rustsbi/sbi-testing/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/rustsbi/sbi-testing/compare/v0.0.0...v0.0.1
-

--- a/library/sbi-testing/src/dbcn.rs
+++ b/library/sbi-testing/src/dbcn.rs
@@ -1,4 +1,4 @@
-﻿//! Debug console extension test suite.
+//! Debug console extension test suite.
 
 use sbi::SbiRet;
 use sbi_spec::binary::Physical;
@@ -24,6 +24,14 @@ pub enum Case {
     Read(usize),
     /// Test failed for can't read to buffer.
     ReadingFailed(SbiRet),
+    /// Test process for rejecting a write with a non-zero upper address half.
+    NonzeroUpperWriteRejected(SbiRet),
+    /// Test failed because a write with a non-zero upper address half was accepted.
+    NonzeroUpperWriteAccepted(usize),
+    /// Test process for rejecting a read with a non-zero upper address half.
+    NonzeroUpperReadRejected(SbiRet),
+    /// Test failed because a read with a non-zero upper address half was accepted.
+    NonzeroUpperReadAccepted(usize),
     /// All test cases on debug console extension has passed.
     Pass,
 }
@@ -60,6 +68,33 @@ pub fn test(mut f: impl FnMut(Case)) {
         f(Case::Read(len));
     } else {
         f(Case::ReadingFailed(ret));
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    {
+        let nonzero_upper = 1usize << 32;
+
+        let ret = sbi::console_write(Physical::new(
+            words.len(),
+            words.as_ptr() as _,
+            nonzero_upper,
+        ));
+        if let Some(len) = ret.ok() {
+            f(Case::NonzeroUpperWriteAccepted(len));
+        } else {
+            f(Case::NonzeroUpperWriteRejected(ret));
+        }
+
+        let ret = sbi::console_read(Physical::new(
+            buffer.len(),
+            buffer.as_mut_ptr() as _,
+            nonzero_upper,
+        ));
+        if let Some(len) = ret.ok() {
+            f(Case::NonzeroUpperReadAccepted(len));
+        } else {
+            f(Case::NonzeroUpperReadRejected(ret));
+        }
     }
 
     f(Case::Pass);

--- a/library/sbi-testing/src/log_test.rs
+++ b/library/sbi-testing/src/log_test.rs
@@ -160,6 +160,26 @@ impl Testing {
                     error!(target: TARGET, "reading failed: {ret:?}");
                     result = false;
                 }
+                NonzeroUpperWriteRejected(ret) => {
+                    info!(target: TARGET, "DBCN rejected non-zero upper-half write: {ret:?}");
+                }
+                NonzeroUpperWriteAccepted(len) => {
+                    error!(
+                        target: TARGET,
+                        "DBCN accepted non-zero upper-half write: {len} bytes written"
+                    );
+                    result = false;
+                }
+                NonzeroUpperReadRejected(ret) => {
+                    info!(target: TARGET, "DBCN rejected non-zero upper-half read: {ret:?}");
+                }
+                NonzeroUpperReadAccepted(len) => {
+                    error!(
+                        target: TARGET,
+                        "DBCN accepted non-zero upper-half read: {len} bytes read"
+                    );
+                    result = false;
+                }
             }
         });
         result

--- a/prototyper/prototyper/src/sbi/console.rs
+++ b/prototyper/prototyper/src/sbi/console.rs
@@ -1,33 +1,29 @@
 use alloc::boxed::Box;
-use core::fmt::{self, Write};
+use core::fmt;
 use rustsbi::{Console, Physical, SbiRet};
 use spin::Mutex;
 
 use crate::platform::PLATFORM;
 
-// Returns the 64-bit physical address composed from the low/high parts.
+// Checks whether `(phys_addr_lo, phys_addr_hi, len)` can be represented
+// as a native address range on this machine.
+//
+// See the shared-memory physical address rules in
+// <https://github.com/riscv-non-isa/riscv-sbi-doc/blob/v3.0/src/binary-encoding.adoc>
+// and the DBCN call definitions in
+// <https://github.com/riscv-non-isa/riscv-sbi-doc/blob/v3.0/src/ext-debug-console.adoc>.
 #[inline]
-fn physical_addr(lo: usize, hi: usize) -> u64 {
-    ((hi as u64) << 32) | (lo as u64)
-}
-
-// Checks whether the physical range is within platform DRAM and directly addressable.
-#[inline]
-fn is_physical_range_valid(start: u64, len: usize) -> bool {
-    if start > usize::MAX as u64 {
-        return false;
+fn checked_physical_addr(lo: usize, hi: usize, len: usize) -> Result<usize, SbiRet> {
+    // If the address exceeds our implementation's native `usize` capacity,
+    // return SBI_ERR_FAILED as we are enforcing a stricter range limit.
+    if hi != 0 {
+        return Err(SbiRet::failed());
     }
 
-    let Some(end) = start.checked_add(len as u64) else {
-        return false;
-    };
+    // Check for native usize overflow. If it overflows, it's definitively an invalid address.
+    let _end = lo.checked_add(len).ok_or_else(SbiRet::invalid_address)?;
 
-    let memory_range = unsafe { PLATFORM.info.memory_range.as_ref() };
-
-    match memory_range {
-        Some(range) => start >= range.start as u64 && end <= range.end as u64,
-        None => false,
-    }
+    Ok(lo)
 }
 
 /// A trait that must be implemented by console devices to provide basic I/O functionality.
@@ -72,7 +68,10 @@ impl SbiConsole {
     /// Always returns 0 to indicate success
     #[inline]
     pub fn putchar(&mut self, c: usize) -> usize {
-        self.write_char(c as u8 as char).unwrap();
+        let byte = [c as u8];
+        while self.inner.lock().write(&byte) == 0 {
+            core::hint::spin_loop();
+        }
         0
     }
 
@@ -85,49 +84,77 @@ impl SbiConsole {
     #[inline]
     pub fn getchar(&self) -> usize {
         let mut c = 0u8;
-        let console = self.inner.lock();
-        // Block until we successfully read 1 byte
-        while console.read(core::slice::from_mut(&mut c)) != 1 {
+        while self.inner.lock().read(core::slice::from_mut(&mut c)) == 0 {
             core::hint::spin_loop();
         }
         c as usize
     }
+
+    // Rejects buffers that this firmware cannot safely turn into raw slices.
+    //
+    // The SBI address tuple may still be valid,
+    // but this implementation only accepts buffers inside `PLATFORM.info.memory_range`.
+    #[inline]
+    fn checked_physical_buffer<P>(&self, bytes: &Physical<P>) -> Result<(usize, usize), SbiRet> {
+        let len = bytes.num_bytes();
+        if len == 0 {
+            return Ok((0, 0));
+        }
+
+        let start = match checked_physical_addr(bytes.phys_addr_lo(), bytes.phys_addr_hi(), len) {
+            Ok(start) => start,
+            Err(err) => return Err(err),
+        };
+
+        match unsafe { PLATFORM.info.memory_range.as_ref() } {
+            Some(range)
+                if start >= range.start
+                    && start.checked_add(len).is_some_and(|end| end <= range.end) => {}
+            _ => return Err(SbiRet::failed()),
+        }
+
+        Ok((start, len))
+    }
 }
 
 impl Console for SbiConsole {
-    /// Write a physical memory buffer to the console.
+    /// Writes bytes from the physical buffer described by `bytes`.
     #[inline]
     fn write(&self, bytes: Physical<&[u8]>) -> SbiRet {
-        let len = bytes.num_bytes();
+        let (start, len) = match self.checked_physical_buffer(&bytes) {
+            Ok(buf) => buf,
+            Err(err) => return err,
+        };
         if len == 0 {
             return SbiRet::success(0);
         }
-        let start = physical_addr(bytes.phys_addr_lo(), bytes.phys_addr_hi());
-        if !is_physical_range_valid(start, len) {
-            return SbiRet::invalid_param();
-        }
+
+        // SAFETY: `checked_physical_buffer` only returns ranges that
+        // were accepted as representable and within `memory_range`.
         let buf = unsafe { core::slice::from_raw_parts(start as *const u8, len) };
         let bytes_written = self.inner.lock().write(buf);
         SbiRet::success(bytes_written)
     }
 
-    /// Read from console into a physical memory buffer.
+    /// Reads bytes into the physical buffer described by `bytes`.
     #[inline]
     fn read(&self, bytes: Physical<&mut [u8]>) -> SbiRet {
-        let len = bytes.num_bytes();
+        let (start, len) = match self.checked_physical_buffer(&bytes) {
+            Ok(buf) => buf,
+            Err(err) => return err,
+        };
         if len == 0 {
             return SbiRet::success(0);
         }
-        let start = physical_addr(bytes.phys_addr_lo(), bytes.phys_addr_hi());
-        if !is_physical_range_valid(start, len) {
-            return SbiRet::invalid_param();
-        }
+
+        // SAFETY: `checked_physical_buffer` only returns ranges that
+        // were accepted as representable and within `memory_range`.
         let buf = unsafe { core::slice::from_raw_parts_mut(start as *mut u8, len) };
         let bytes_read = self.inner.lock().read(buf);
         SbiRet::success(bytes_read)
     }
 
-    /// Write a single byte to the console.
+    /// Writes `byte` to the console.
     #[inline]
     fn write_byte(&self, byte: u8) -> SbiRet {
         self.inner.lock().write(&[byte]);
@@ -140,10 +167,11 @@ impl fmt::Write for SbiConsole {
     #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let mut bytes = s.as_bytes();
-        let console = self.inner.lock();
-        // Write all bytes in chunks
         while !bytes.is_empty() {
-            let count = console.write(bytes);
+            let count = self.inner.lock().write(bytes);
+            if count == 0 {
+                return Err(fmt::Error);
+            }
             bytes = &bytes[count..];
         }
         Ok(())


### PR DESCRIPTION
## Summary

This PR fixes #195  DBCN physical-buffer validation in the prototyper to follow the SBI physical-address ABI, and adds a QEMU regression test for the affected RV64 edge case.

## What changed

### Prototyper

- reconstruct the DBCN physical address from `(phys_addr_lo, phys_addr_hi)` using the SBI `2 x XLEN` model instead of a hard-coded `u64` / `<< 32` split
- validate the decoded half-open range before creating raw slices
- return `invalid_address` for malformed SBI address tuples
- return `failed` for buffers that are well-formed
  but outside the platform memory window accepted by this implementation
- keep `read` and `write` on the same physical-buffer validation path
- avoid infinite retry in `fmt::Write::write_str` when the console makes no progress

### Tests / CI

- add an RV64 DBCN regression case that uses a non-zero upper address half
- fail the test if that request is incorrectly accepted
- extend the existing prototyper QEMU boot check to assert that both the non-zero upper-half write and non-zero upper-half read are rejected

## Why

The previous implementation #193  reconstructed DBCN addresses as if they were always `high 32 bits + low 32 bits -> u64`.

That does not match the SBI ABI for physical-address parameters,which are defined as `phys_addr_lo` plus `phys_addr_hi` forming a `2 x XLEN` quantity.

In the common `phys_addr_hi == 0` case this usually stayed hidden,but on RV64 it could mis-handle inputs whose upper half was non-zero.
