### PR TITLE
fix(prototyper): make sbi_console_getchar non-blocking

### DIFF
--- a/prototyper/prototyper/src/platform/console.rs
+++ b/prototyper/prototyper/src/platform/console.rs
@@ -106,13 +106,11 @@ impl UartBflbWrap {
 impl ConsoleDevice for UartBflbWrap {
     fn read(&self, buf: &mut [u8]) -> usize {
         let uart = unsafe { &(*self.inner) };
-        while uart.fifo_config_1.read().receive_available_bytes() == 0 {
-            core::hint::spin_loop();
+        let rx_available = uart.fifo_config_1.read().receive_available_bytes() as usize;
+        if rx_available == 0 {
+            return 0;
         }
-        let len = core::cmp::min(
-            uart.fifo_config_1.read().receive_available_bytes() as usize,
-            buf.len(),
-        );
+        let len = core::cmp::min(rx_available, buf.len());
         buf.iter_mut()
             .take(len)
             .for_each(|slot| *slot = uart.fifo_read.read());

--- a/prototyper/prototyper/src/sbi/console.rs
+++ b/prototyper/prototyper/src/sbi/console.rs
@@ -77,17 +77,13 @@ impl SbiConsole {
 
     /// Reads a single character from the console.
     ///
-    /// This method will block until a character is available to be read.
-    ///
     /// # Returns
-    /// The read character as a usize
+    /// Returns the character as a usize on success, or '-1' for failure.
     #[inline]
     pub fn getchar(&self) -> usize {
         let mut c = 0u8;
-        while self.inner.lock().read(core::slice::from_mut(&mut c)) == 0 {
-            core::hint::spin_loop();
-        }
-        c as usize
+        let nread = self.inner.lock().read(core::slice::from_mut(&mut c));
+        if nread == 1 { c as usize } else { usize::MAX }
     }
 
     // Rejects buffers that this firmware cannot safely turn into raw slices.


### PR DESCRIPTION
## Summary
Fixes #194. Resolves the blocking behavior of `sbi_console_getchar` that violates the RISC-V SBI specification. Refactors `UartBflbWrap::read` to be a non-blocking implementation.

---

## What Changed

* **`SbiConsole::getchar`**: Updated the logic to check the read length `nread` from the underlying driver. If `nread` is 0 (no input), it immediately returns `usize::MAX` (representing `-1`) instead of spinning.

* **`UartBflbWrap::read`**: Refactored the driver logic by removing the `while` loop that waited for `receive_available_bytes()`. 
    * If `rx_available` is 0, it returns 0 immediately. 
    * Otherwise, it reads `min(rx_available, buf.len())` characters from the FIFO and returns the actual number of bytes read.

---

## Why

* Specification Compliance: The RISC-V SBI specification requires `sbi_console_getchar` to return `-1` if no character is available. The previous blocking implementation, included:UartBflbWrap::read , violated this requirement.
* Implementations such as OpenSBI's `uart8250`are non-blocking.
* Driver implementations, such as [RT-Thread's `bl_mcu_sdk`](https://github.com/RT-Thread/rt-thread/blob/master/bsp/bouffalo_lab/libraries/bl_mcu_sdk/drivers/lhal/src/bflb_uart.c#L236)
``` rust
ATTR_TCM_SECTION int bflb_uart_get(struct bflb_device_s *dev, uint8_t *data, uint32_t len)
{
    int ch = -1;
    uint32_t count = 0;

    while (count < len) {
        if ((ch = bflb_uart_getchar(dev)) < 0) {
            break;
        }
        data[count] = ch;
        count++;
    }
    return count;
}
```
* The [BouffaloSDK UART - poll example](https://bl-mcu-sdk.readthedocs.io/zh-cn/latest/samples/peripherals/uart/uart_poll.html) 
``` rust
int ch;
while (1) {
    ch = bflb_uart_getchar(uartx);
    if (ch != -1) {
        bflb_uart_putchar(uartx, ch);
    }
}
```

---

**Fixes: #194**