### PR TITLE
feat(cove-rt): add covh sbi calls for fid #0 to #2

### DIFF
--- a/library/riscv-cove-rt/src/host.rs
+++ b/library/riscv-cove-rt/src/host.rs
@@ -1,5 +1,5 @@
 //! Chapter 10, COVE Host Extension (EID #0x434F5648 "COVH").
-use riscv_cove::host::{EID_COVH, GET_TSM_INFO, TsmInfo};
+use riscv_cove::host::{CONVERT_PAGES, EID_COVH, GET_TSM_INFO, RECLAIM_PAGES, TsmInfo};
 use sbi_spec::binary::{Physical, SbiRet};
 
 /// Reads the current TSM state, its configuration and supported features.
@@ -8,6 +8,20 @@ use sbi_spec::binary::{Physical, SbiRet};
 pub fn covh_get_tsm_info(mem: Physical<&mut TsmInfo>) -> SbiRet {
     // TODO mem.phys_addr_hi should be used. The physical memory parameter should be parsed in `_hi` and `_lo` pairs, ref: https://lists.riscv.org/g/tech-ap-tee/topic/114646239#msg207 .
     unsafe { sbi_rt::raw::sbi_call_2(EID_COVH, GET_TSM_INFO, mem.phys_addr_lo(), mem.num_bytes()) }
+}
+
+/// Convert normal physical pages to confidential memory pages for CoVE TVM usage.
+#[inline]
+#[doc(alias = "sbi_covh_convert_pages")]
+pub fn covh_convert_pages(base_page_addr: usize, num_pages: usize) -> SbiRet {
+    unsafe { sbi_rt::raw::sbi_call_2(EID_COVH, CONVERT_PAGES, base_page_addr, num_pages) }
+}
+
+/// Reclaim confidential memory pages back to normal physical pages.
+#[inline]
+#[doc(alias = "sbi_covh_reclaim_pages")]
+pub fn covh_reclaim_pages(page_addr: usize, num_pages: usize) -> SbiRet {
+    unsafe { sbi_rt::raw::sbi_call_2(EID_COVH, RECLAIM_PAGES, page_addr, num_pages) }
 }
 
 // TODO other functions


### PR DESCRIPTION
## Summary

Implement COVH Host Extension SBI calls for FID #0 ~ #2:

- `covh_get_tsm_info` (FID #0) — query TSM state and capabilities
- `covh_convert_pages` (FID #1) — convert normal pages to confidential pages  
- `covh_reclaim_pages` (FID #2) — reclaim confidential pages back to normal

## References

- Spec: Chapter 10 of riscv-cove spec v0.7
- Implementation follows style of existing SBI extensions in `sbi-rt/src/`

## Test Plan

- [ ] `cargo build --target riscv64imac-unknown-none-elf -p riscv-cove-rt` passes