### PR TITLE
feat(covg): add TVM zero/shared pages and vCPU management (FID #12-#15)

### DIFF
--- a/library/riscv-cove-rt/src/host.rs
+++ b/library/riscv-cove-rt/src/host.rs
@@ -11,3 +11,144 @@ pub fn covh_get_tsm_info(mem: Physical<&mut TsmInfo>) -> SbiRet {
 }
 
 // TODO other functions
+/// Add initial zeroed confidential pages to a TVM (demand-mapped, not measured)
+///
+/// # Parameters
+/// - `tvm_id`: TVM identifier
+/// - `page_addr`: Confidential physical page address (already converted)
+/// - `page_type`: Page attributes/type
+/// - `num_pages`: Number of 4-KiB pages to add
+/// - `tvm_page_addr`: TVM GPA where the pages will be mapped
+///
+/// Corresponds to `sbi_covh_add_tvm_zero_pages` (FID #12) defined in the COVE Host
+/// Extension (EID: `0x434F5648`).
+///
+/// # Errors
+/// - `SBI_ERR_INVALID_PARAM` — invalid parameters
+/// - `SBI_ERR_INVALID_ADDRESS` — invalid physical or TVM address
+/// - `SBI_ERR_DENIED` — operation denied by TSM
+/// - `SBI_ERR_NOT_SUPPORTED` — TSM does not support this operation
+/// - `SBI_ERR_FAILED` — generic failure
+#[inline]
+#[doc(alias = "sbi_covh_add_tvm_zero_pages")]
+pub fn covh_add_tvm_zero_pages(
+    tvm_id: usize,
+    page_addr: usize,
+    page_type: usize,
+    num_pages: usize,
+    tvm_page_addr: usize,
+) -> SbiRet {
+    unsafe {
+        sbi_rt::raw::sbi_call_5(
+            EID_COVH,
+            ADD_TVM_ZERO_PAGES,
+            tvm_id,
+            page_addr,
+            page_type,
+            num_pages,
+            tvm_page_addr,
+        )
+    }
+}
+
+/// Map non-confidential shared pages into a TVM (host and TVM both accessible)
+///
+/// # Parameters
+/// - `tvm_id`: TVM identifier
+/// - `page_addr`: Non-confidential physical page address (host-accessible)
+/// - `page_type`: Page attributes/type
+/// - `num_pages`: Number of 4-KiB pages to add
+/// - `tvm_page_addr`: TVM GPA where the pages will be mapped
+///
+/// Corresponds to `sbi_covh_add_tvm_shared_pages` (FID #13) defined in the COVE Host
+/// Extension (EID: `0x434F5648`).
+///
+/// Note: Shared pages are non-confidential (not protected by TSM) and do NOT
+/// participate in measurement; the TVM must declare use of shared memory via
+/// the COVG extension as appropriate.
+///
+/// # Errors
+/// - `SBI_ERR_INVALID_PARAM` — invalid parameters
+/// - `SBI_ERR_INVALID_ADDRESS` — invalid physical or TVM address
+/// - `SBI_ERR_DENIED` — operation denied
+/// - `SBI_ERR_NOT_SUPPORTED` — TSM or platform doesn't support shared pages
+/// - `SBI_ERR_FAILED` — generic failure
+#[inline]
+#[doc(alias = "sbi_covh_add_tvm_shared_pages")]
+pub fn covh_add_tvm_shared_pages(
+    tvm_id: usize,
+    page_addr: usize,
+    page_type: usize,
+    num_pages: usize,
+    tvm_page_addr: usize,
+) -> SbiRet {
+    unsafe {
+        sbi_rt::raw::sbi_call_5(
+            EID_COVH,
+            ADD_TVM_SHARED_PAGES,
+            tvm_id,
+            page_addr,
+            page_type,
+            num_pages,
+            tvm_page_addr,
+        )
+    }
+}
+
+/// Create a vCPU inside a TVM.
+///
+/// # Parameters
+/// - `tvm_id`: TVM identifier
+/// - `tvm_vcpu_id`: Physical address of `TvmVcpuCreateParams` structure
+/// - `tvm_state_page_addr`: Physical address of pages to store vCPU state
+///
+/// Corresponds to `sbi_covh_create_tvm_vcpu` (FID #14) defined in the COVE Host
+/// Extension (EID: `0x434F5648`).
+///
+/// # Errors
+/// - `SBI_ERR_INVALID_PARAM` — invalid parameters
+/// - `SBI_ERR_INVALID_ADDRESS` — invalid physical address
+/// - `SBI_ERR_DENIED` — operation denied by TSM
+/// - `SBI_ERR_NOT_SUPPORTED` — vCPU creation not supported
+/// - `SBI_ERR_FAILED` — generic failure
+#[inline]
+#[doc(alias = "sbi_covh_create_tvm_vcpu")]
+pub fn covh_create_tvm_vcpu(
+    tvm_id: usize,
+    tvm_vcpu_id: usize,
+    tvm_state_page_addr: usize,
+) -> SbiRet {
+    unsafe {
+        sbi_rt::raw::sbi_call_3(
+            EID_COVH,
+            CREATE_TVM_VCPU,
+            tvm_id,
+            tvm_vcpu_id,
+            tvm_state_page_addr,
+        )
+    }
+}
+
+/// Run a TVM vCPU until it exits; returned `SbiRet.value` contains the TVM exit reason.
+///
+/// # Parameters
+/// - `tvm_id`: TVM identifier
+/// - `vcpu_id`: vCPU identifier
+///
+/// Corresponds to `sbi_covh_run_tvm_vcpu` (FID #15) defined in the COVE Host
+/// Extension (EID: `0x434F5648`).
+///
+/// # Errors / Return
+/// - On success, `SbiRet.error` is `SBI_SUCCESS` and `SbiRet.value` contains the
+///   TVM exit reason (e.g., ECALL, load/store page fault, etc.).
+/// - On failure, standard SBI error codes may be returned:
+///   `SBI_ERR_INVALID_PARAM`, `SBI_ERR_DENIED`, `SBI_ERR_NOT_SUPPORTED`,
+///   `SBI_ERR_FAILED`.
+///
+/// Note: After return the host MUST inspect the guest `scause` and the NACL
+/// shared memory to determine the precise exit cause and decide the next steps.
+#[inline]
+#[doc(alias = "sbi_covh_run_tvm_vcpu")]
+pub fn covh_run_tvm_vcpu(tvm_id: usize, vcpu_id: usize) -> SbiRet {
+    unsafe { sbi_rt::raw::sbi_call_2(EID_COVH, RUN_TVM_VCPU, tvm_id, vcpu_id) }
+}


### PR DESCRIPTION
Implement four new SBI calls for confidential guest TVM management:

- Add sbi_covh_add_tvm_zero_pages (FID #12): Map confidential physical pages as zero-initialized pages. These pages are cleared by TSM, not measured, and can be added after finalize.

- Add sbi_covh_add_tvm_shared_pages (FID #13): Map non-confidential physical pages as shared memory accessible by both host and TVM. These pages are not measured and must be declared via COVG extension by the TVM.

- Add sbi_covh_create_tvm_vcpu (FID #14): Create a new vCPU inside the specified TVM. The tvm_vcpu_id parameter points to TvmVcpuCreateParams structure. The vCPU state page is set at tvm_state_page_addr.

- Add sbi_covh_run_tvm_vcpu (FID #15): Run the specified vCPU until an exit occurs (ECALL, page fault, etc.). The sbiret.value returns the TVM exit reason. Host must check scause and NACL shared memory to determine exit reason and subsequent actions.

All functions include detailed comments distinguishing confidential pages from non-confidential pages per COVG specification requirements.

Signed-off-by: primercoder <3117705952@qq.com>


<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
