### PR TITLE
fix(prototyper): reject stopped harts in prototyper IPI and RFENCE paths

### DIFF
--- a/prototyper/prototyper/src/sbi/ipi.rs
+++ b/prototyper/prototyper/src/sbi/ipi.rs
@@ -99,9 +99,11 @@ impl rustsbi::Ipi for SbiIpi {
                 return SbiRet::invalid_param();
             }
 
-            if hsm.allow_ipi() {
-                deliver_harts.push(hart_id);
+            if !hsm.allow_ipi() {
+                return SbiRet::invalid_param();
             }
+
+            deliver_harts.push(hart_id);
         }
 
         for hart_id in deliver_harts {
@@ -156,9 +158,11 @@ impl SbiIpi {
                 return SbiRet::invalid_param();
             }
 
-            if hsm.allow_ipi() {
-                deliver_harts.push(hart_id);
+            if !hsm.allow_ipi() {
+                return SbiRet::invalid_param();
             }
+
+            deliver_harts.push(hart_id);
         }
 
         // Send fence operations to target harts

--- a/prototyper/test-kernel/src/main.rs
+++ b/prototyper/test-kernel/src/main.rs
@@ -288,9 +288,15 @@ fn fence_test() {
     let ret = sbi::remote_fence_i(HartMask::from_mask_base(0x1, 0));
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
 
+    let ret = sbi::remote_fence_i(HartMask::from_mask_base(0x2, 0));
+    assert_eq!(ret, SbiRet::invalid_param());
+
     // SFence.vma test (should succeed, no-op for PMU, but should not panic)
     let ret = sbi::remote_sfence_vma(HartMask::from_mask_base(0x1, 0), 0, 0);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
+
+    let ret = sbi::remote_sfence_vma(HartMask::from_mask_base(0x2, 0), 0, 0);
+    assert_eq!(ret, SbiRet::invalid_param());
 
     // SFence.vma with asid test
     let ret = sbi::remote_sfence_vma_asid(HartMask::from_mask_base(0x1, 0), 0, 0, 0);


### PR DESCRIPTION
## Summary:
Fixes #207. Return `invalid_param` when a selected hart is enabled but not available for supervisor IPI/RFENCE delivery, and add test-kernel coverage for the stopped-hart RFENCE case.

## What changed:
- return `invalid_param` in `SbiIpi::send_ipi()` when a selected hart exists and is enabled but `allow_ipi() == false`
- return `invalid_param` in `SbiIpi::send_ipi_by_fence()` for the same condition
- extend `prototyper/test-kernel` to assert `invalid_param` for stopped-hart `remote_fence_i` and `remote_sfence_vma`

## Why:
The reported issue shows that `RustSBI Prototyper` returned `SBI_SUCCESS` for IPI and RFENCE requests targeting a hart in HSM `STOPPED` state.

This behavior differed from:
- the `rustsbi` trait documentation, which describes such harts as not available to the supervisor
- `OpenSBI`, which rejects the same requests with `SBI_ERR_INVALID_PARAM`

This change makes the prototyper behavior consistent with the documented interface and with the observed OpenSBI behavior.