### PR TITLE
feat(prototyper): add AIA/IMSIC interrupt backend for QEMU virt

### DIFF
--- a/.github/scripts/prototyper-openeuler-aia.sh
+++ b/.github/scripts/prototyper-openeuler-aia.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url=${OPENEULER_AIA_BASE_URL:-https://repo.openeuler.org/openEuler-25.09/virtual_machine_img/riscv64}
+image_name=${OPENEULER_AIA_IMAGE_NAME:-openEuler-25.09-riscv64.qcow2}
+image_archive=${OPENEULER_AIA_IMAGE_ARCHIVE:-${image_name}.xz}
+cache_dir=${OPENEULER_AIA_CACHE_DIR:-.openeuler-aia/cache}
+work_dir=${OPENEULER_AIA_WORK_DIR:-.openeuler-aia/work}
+log_dir=${OPENEULER_AIA_LOG_DIR:-qemu-logs}
+timeout_secs=${OPENEULER_AIA_TIMEOUT_SECS:-900}
+smp=${OPENEULER_AIA_SMP:-4}
+memory_gib=${OPENEULER_AIA_MEMORY_GIB:-4}
+ssh_port=${OPENEULER_AIA_SSH_PORT:-12055}
+rustsbi=${OPENEULER_AIA_RUSTSBI:-target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper}
+
+mkdir -p "$cache_dir" "$work_dir" "$log_dir"
+
+download() {
+    local url=$1
+    local dest=$2
+
+    if [ -s "$dest" ]; then
+        echo "Using cached $(basename "$dest")" >&2
+        return
+    fi
+
+    echo "Downloading $url" >&2
+    curl --fail --location --retry 5 --retry-delay 5 --output "$dest" "$url"
+}
+
+prepare_downloaded_image() {
+    local archive_path="$cache_dir/$image_archive"
+    local checksum_path="$cache_dir/$image_archive.sha256sum"
+    local image_path="$work_dir/$image_name"
+
+    download "$base_url/RISCV_VIRT_CODE.fd" "$cache_dir/RISCV_VIRT_CODE.fd"
+    download "$base_url/RISCV_VIRT_VARS.fd" "$cache_dir/RISCV_VIRT_VARS.fd"
+    download "$base_url/$image_archive" "$archive_path"
+    download "$base_url/$image_archive.sha256sum" "$checksum_path"
+
+    (
+        cd "$cache_dir"
+        sha256sum -c "$(basename "$checksum_path")"
+    ) >&2
+
+    if [ ! -s "$image_path" ]; then
+        case "$image_archive" in
+            *.zst)
+                zstd --decompress --force --keep -o "$image_path" "$archive_path"
+                ;;
+            *.xz)
+                xz --decompress --force --keep --stdout "$archive_path" >"$image_path"
+                ;;
+            *)
+                echo "Unsupported image archive: $image_archive" >&2
+                return 1
+                ;;
+        esac
+    fi
+
+    printf '%s\n' "$image_path"
+}
+
+image_path=${OPENEULER_AIA_IMAGE_PATH:-}
+code_fd=${OPENEULER_AIA_CODE_FD:-}
+vars_fd=${OPENEULER_AIA_VARS_FD:-}
+
+if [ -z "$image_path" ]; then
+    image_path=$(prepare_downloaded_image)
+fi
+if [ -z "$code_fd" ]; then
+    code_fd="$cache_dir/RISCV_VIRT_CODE.fd"
+fi
+if [ -z "$vars_fd" ]; then
+    vars_fd="$cache_dir/RISCV_VIRT_VARS.fd"
+fi
+
+test -s "$rustsbi"
+test -s "$image_path"
+test -s "$code_fd"
+test -s "$vars_fd"
+
+image_abs=$(realpath "$image_path")
+code_abs=$(realpath "$code_fd")
+vars_copy="$work_dir/RISCV_VIRT_VARS-ci.fd"
+overlay="$work_dir/openeuler-aia-overlay.qcow2"
+log_file="$log_dir/openeuler-aia.log"
+
+cp "$vars_fd" "$vars_copy"
+rm -f "$overlay"
+qemu-img create -f qcow2 -F qcow2 -b "$image_abs" "$overlay"
+
+echo "Booting openEuler with RustSBI Prototyper + AIA"
+echo "RustSBI: $rustsbi"
+echo "Image:   $image_abs"
+echo "Log:     $log_file"
+
+set +e
+timeout --foreground "${timeout_secs}s" qemu-system-riscv64 \
+    -nographic \
+    -machine virt,pflash0=pflash0,pflash1=pflash1,acpi=off,aia=aplic-imsic \
+    -smp "$smp" \
+    -m "${memory_gib}G" \
+    -bios "$rustsbi" \
+    -blockdev node-name=pflash0,driver=file,read-only=on,filename="$code_abs" \
+    -blockdev node-name=pflash1,driver=file,filename="$vars_copy" \
+    -drive file="$overlay",format=qcow2,id=hd0,if=none \
+    -object rng-random,filename=/dev/urandom,id=rng0 \
+    -device virtio-vga \
+    -device virtio-rng-device,rng=rng0 \
+    -device virtio-blk-device,drive=hd0 \
+    -device virtio-net-device,netdev=usernet \
+    -netdev user,id=usernet,hostfwd=tcp::"$ssh_port"-:22 \
+    -device qemu-xhci \
+    -usb \
+    -device usb-kbd \
+    -device usb-tablet \
+    >"$log_file" 2>&1 &
+qemu_pid=$!
+set -e
+
+cleanup() {
+    if kill -0 "$qemu_pid" 2>/dev/null; then
+        kill "$qemu_pid" 2>/dev/null || true
+        wait "$qemu_pid" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+deadline=$((SECONDS + timeout_secs))
+while kill -0 "$qemu_pid" 2>/dev/null; do
+    if grep -Fq "localhost login:" "$log_file"; then
+        break
+    fi
+    if grep -Eq "Kernel panic|panic|FAILED|SystemFailure|Invalid data" "$log_file"; then
+        tail -n 160 "$log_file" || true
+        exit 1
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        break
+    fi
+    sleep 2
+done
+
+cleanup
+trap - EXIT
+
+grep -F "IMSIC: base=0x" "$log_file"
+grep -F "AIA: IMSIC IPI + Sstc timer backend initialized" "$log_file"
+grep -F "Platform IPI Extension        : IMSIC" "$log_file"
+grep -F "automatically in 0s" "$log_file"
+grep -F "Loading Linux" "$log_file"
+grep -F "Loading initial ramdisk" "$log_file"
+grep -F "localhost login:" "$log_file"
+! grep -Eq "Kernel panic|panic|FAILED|SystemFailure|Invalid data" "$log_file"
+
+echo "openEuler AIA boot log: $log_file"

--- a/.github/workflows/openeuler-aia.yml
+++ b/.github/workflows/openeuler-aia.yml
@@ -1,0 +1,89 @@
+name: openEuler AIA
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/scripts/prototyper-openeuler-aia.sh"
+      - ".github/workflows/openeuler-aia.yml"
+      - "library/riscv-aia/**"
+      - "prototyper/prototyper/config/default.toml"
+      - "prototyper/prototyper/src/firmware/**"
+      - "prototyper/prototyper/src/main.rs"
+      - "prototyper/prototyper/src/platform/**"
+      - "prototyper/prototyper/src/riscv/csr.rs"
+      - "prototyper/prototyper/src/sbi/hart_context.rs"
+      - "prototyper/prototyper/src/sbi/ipi.rs"
+      - "prototyper/prototyper/src/sbi/trap/**"
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/scripts/prototyper-openeuler-aia.sh"
+      - ".github/workflows/openeuler-aia.yml"
+      - "library/riscv-aia/**"
+      - "prototyper/prototyper/config/default.toml"
+      - "prototyper/prototyper/src/firmware/**"
+      - "prototyper/prototyper/src/main.rs"
+      - "prototyper/prototyper/src/platform/**"
+      - "prototyper/prototyper/src/riscv/csr.rs"
+      - "prototyper/prototyper/src/sbi/hart_context.rs"
+      - "prototyper/prototyper/src/sbi/ipi.rs"
+      - "prototyper/prototyper/src/sbi/trap/**"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  openeuler-aia-boot:
+    name: Boot openEuler 25.09 with AIA
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dev dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl xz-utils zstd
+
+      - name: Install required cargo
+        run: cargo install cargo-binutils
+
+      - name: Install required target
+        run: rustup target add riscv64gc-unknown-none-elf
+
+      - name: Cache openEuler downloads
+        uses: actions/cache@v4
+        with:
+          path: .openeuler-aia/cache
+          key: openeuler-25.09-riscv64-aia-release-v1
+
+      - name: Build RustSBI Prototyper
+        run: cargo prototyper
+
+      - name: Boot openEuler with AIA
+        run: |
+          docker run --rm \
+            -v "$PWD:/work" \
+            -w /work \
+            -e OPENEULER_AIA_CACHE_DIR=/work/.openeuler-aia/cache \
+            -e OPENEULER_AIA_WORK_DIR=/work/.openeuler-aia/work \
+            -e OPENEULER_AIA_LOG_DIR=/work/qemu-logs \
+            ubuntu:25.10 \
+            bash -lc '
+              set -euo pipefail
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y curl qemu-system-misc qemu-utils xz-utils zstd
+              qemu-system-riscv64 --version
+              .github/scripts/prototyper-openeuler-aia.sh
+            '
+
+      - name: Upload openEuler AIA log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openeuler-aia-log
+          path: qemu-logs/openeuler-aia.log

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ arceboot/edk2/
 arceboot/*.img
 arceboot/*.cpio
 arceboot/qemu-*.log
+
+# AI tooling
+.codex
+.humanize

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ arceboot/edk2/
 arceboot/*.img
 arceboot/*.cpio
 arceboot/qemu-*.log
+qemu-logs/
+/.openeuler-aia/
 
 # AI tooling
 .codex

--- a/library/sbi-testing/CHANGELOG.md
+++ b/library/sbi-testing/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Test new extension DBCN
 - Add an RV64 DBCN regression case for rejecting non-zero upper address halves.
+- Add remote RFence verification for HSM started remote harts.
 
 ### Modified
 

--- a/library/sbi-testing/src/hsm.rs
+++ b/library/sbi-testing/src/hsm.rs
@@ -36,6 +36,10 @@ pub enum Case<'a> {
     HartSuspendedRetentive(usize),
     /// Test process for target hart to be tested has stopped.
     HartStopped(usize),
+    /// Remote RFence succeeded on a started remote hart.
+    RemoteRFencePass(usize),
+    /// Remote RFence failed on a started remote hart.
+    RemoteRFenceFailed(usize, SbiRet),
     /// Test process for harts on current batch has passed the tests.
     BatchPass(&'a [usize]),
     /// All test cases on hart state monitor module finished.
@@ -57,7 +61,7 @@ pub fn test(
         return;
     }
     f(Case::Begin);
-    // 分批测试
+    let rfnc_available = sbi::probe_extension(sbi::Fence).is_available();
 
     let mut batch = [0usize; TEST_BATCH_SIZE];
     let mut batch_count = 0;
@@ -71,7 +75,7 @@ pub fn test(
                 batch_size += 1;
                 // 收集一个批次，执行测试
                 if batch_size == TEST_BATCH_SIZE {
-                    if test_batch(&batch, &mut f) {
+                    if test_batch(&batch, rfnc_available, &mut f) {
                         batch_count += 1;
                         batch_size = 0;
                     } else {
@@ -90,7 +94,7 @@ pub fn test(
     }
     // 为不满一批次的核执行测试
     if batch_size > 0 {
-        if test_batch(&batch[..batch_size], &mut f) {
+        if test_batch(&batch[..batch_size], rfnc_available, &mut f) {
             f(Case::Pass);
         }
     }
@@ -168,7 +172,7 @@ impl ItemPerHart {
 }
 
 /// 测试一批核
-fn test_batch(batch: &[usize], mut f: impl FnMut(Case)) -> bool {
+fn test_batch(batch: &[usize], rfnc_available: bool, mut f: impl FnMut(Case)) -> bool {
     f(Case::BatchBegin(batch));
     // 初始这些核都是停止状态，测试 start
     for (i, hartid) in batch.iter().copied().enumerate() {
@@ -187,6 +191,14 @@ fn test_batch(batch: &[usize], mut f: impl FnMut(Case)) -> bool {
             core::hint::spin_loop();
         }
         f(Case::HartStarted(hartid));
+        if rfnc_available {
+            let rfence_ret = sbi::remote_fence_i(HartMask::from_mask_base(1, hartid));
+            if rfence_ret.is_ok() {
+                f(Case::RemoteRFencePass(hartid));
+            } else {
+                f(Case::RemoteRFenceFailed(hartid, rfence_ret));
+            }
+        }
         // 等待信号
         item.wait_start();
         // 发出信号

--- a/library/sbi-testing/src/log_test.rs
+++ b/library/sbi-testing/src/log_test.rs
@@ -130,6 +130,13 @@ impl Testing {
                     debug!(target: TARGET, "hart {id} suspended retentive")
                 }
                 HartStopped(id) => debug!(target: TARGET, "hart {id} stopped"),
+                RemoteRFencePass(id) => {
+                    info!(target: TARGET, "remote RFence to started hart {id} pass")
+                }
+                RemoteRFenceFailed(id, ret) => {
+                    error!(target: TARGET, "remote RFence to started hart {id} failed: {ret:?}");
+                    result = false;
+                }
                 BatchPass(batch) => info!(target: TARGET, "Testing Pass: {batch:?}"),
             }
         });

--- a/prototyper/CHANGELOG.md
+++ b/prototyper/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased
 
 ### Added
+- Add AIA IMSIC IPI backend support for RustSBI Prototyper.
 
 ### Modified
 - Refine CSR group comments.

--- a/prototyper/prototyper/config/default.toml
+++ b/prototyper/prototyper/config/default.toml
@@ -7,5 +7,9 @@ jump_address = 0x80200000
 tlb_flush_limit = 16384 # page_size * 4
 
 [[next_addr]]
+start = 0x20000000
+end = 0x24000000
+
+[[next_addr]]
 start = 0x80000000
 end = 0x90000000

--- a/prototyper/prototyper/src/devicetree.rs
+++ b/prototyper/prototyper/src/devicetree.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use serde::Deserialize;
 use serde_device_tree::{
     Dtb, DtbPtr,
@@ -77,29 +78,32 @@ pub fn parse_device_tree(opaque: usize) -> Result<Dtb, ParseDeviceTreeError> {
     Ok(dtb)
 }
 
-pub fn get_compatible_and_range<'de>(node: &Node) -> Option<(StrSeq<'de>, Range<usize>)> {
+pub fn get_compatible_and_ranges<'de>(node: &Node) -> Option<(StrSeq<'de>, Vec<Range<usize>>)> {
     let compatible = node
         .get_prop("compatible")
         .map(|prop_item| prop_item.deserialize::<StrSeq<'de>>());
-    let regs = node
-        .get_prop("reg")
-        .map(|prop_item| {
-            let reg = prop_item.deserialize::<serde_device_tree::buildin::Reg>();
-            if let Some(range) = reg.iter().next() {
-                return Some(range);
-            }
-            None
-        })
-        .map_or_else(|| None, |v| v);
+    let regs = node.get_prop("reg").map(|prop_item| {
+        let reg = prop_item.deserialize::<serde_device_tree::buildin::Reg>();
+        reg.iter().map(|range| range.0).collect::<Vec<_>>()
+    });
     if let Some(compatible) = compatible {
         if let Some(regs) = regs {
-            Some((compatible, regs.0))
+            if regs.is_empty() {
+                None
+            } else {
+                Some((compatible, regs))
+            }
         } else {
             None
         }
     } else {
         None
     }
+}
+
+pub fn get_compatible_and_range<'de>(node: &Node) -> Option<(StrSeq<'de>, Range<usize>)> {
+    let (compatible, regs) = get_compatible_and_ranges(node)?;
+    regs.into_iter().next().map(|range| (compatible, range))
 }
 
 pub fn get_compatible<'de>(node: &Node) -> Option<StrSeq<'de>> {

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -169,13 +169,15 @@ pub fn patch_device_tree(device_tree_ptr: usize) -> usize {
     let path_name = format!("/reserved-memory/mmode_resv1@{:x}", sbi_start);
     let patch2 =
         serde_device_tree::ser::patch::Patch::new(&path_name, &new_base_2 as _, ValueType::Node);
-    let raw_list = [patch1, patch2];
+    let patches = alloc::vec![patch1, patch2];
     // Only add `reserved-memory` section when it not exists.
-    let list = if tree.find("/reserved-memory").is_some() {
-        &raw_list[1..]
+    let start_idx = if tree.find("/reserved-memory").is_some() {
+        1
     } else {
-        &raw_list[..]
+        0
     };
+
+    let list = &patches[start_idx..];
 
     let patched_length = serde_device_tree::ser::probe_dtb_length(&tree, &list).unwrap();
 
@@ -189,12 +191,293 @@ pub fn patch_device_tree(device_tree_ptr: usize) -> usize {
     };
     serde_device_tree::ser::to_dtb(&tree, &list, &mut patched_dtb_buffer_u8).unwrap();
 
+    // When AIA is active, NOP out M-level IMSIC and APLIC nodes in the
+    // DTB so Linux does not try to probe them. This matches OpenSBI's
+    // fdt_domain_based_fixup approach.
+    if crate::platform::aia::is_aia_active() {
+        let dtb_buf = unsafe {
+            core::slice::from_raw_parts_mut(patched_dtb_buffer.as_ptr() as *mut u8, patched_length)
+        };
+        fdt_nop_m_level_imsic(dtb_buf);
+        if let Some((clint_base, _)) = unsafe { crate::platform::PLATFORM.info.ipi.as_ref() } {
+            let clint_name = format!("clint@{:x}", clint_base);
+            if fdt_nop_node_by_name(dtb_buf, &clint_name) {
+                info!("AIA: NOP'd M-level CLINT node '{}' in DTB", clint_name);
+            }
+        }
+        // Also NOP the M-level APLIC, whose DT node may use either the
+        // generic interrupt-controller name or the APLIC-specific name.
+        fdt_nop_m_level_aplic(dtb_buf);
+    }
+
     info!(
         "The patched dtb is located at 0x{:x} with length 0x{:x}.",
         patched_dtb_buffer.as_ptr() as usize,
         patched_length
     );
     patched_dtb_buffer.as_ptr() as usize
+}
+
+// TODO: Move these raw FDT structure block patch helpers to serde-device-tree.
+const FDT_BEGIN_NODE: u32 = 0x01;
+const FDT_END_NODE: u32 = 0x02;
+const FDT_PROP: u32 = 0x03;
+const FDT_NOP: u32 = 0x04;
+const RISCV_MACHINE_EXTERNAL_IRQ: u32 = 11;
+
+fn fdt_read_u32(buf: &[u8], off: usize) -> u32 {
+    u32::from_be_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]])
+}
+
+fn fdt_write_u32(buf: &mut [u8], off: usize, val: u32) {
+    let bytes = val.to_be_bytes();
+    buf[off..off + 4].copy_from_slice(&bytes);
+}
+
+fn fdt_nop_node_by_name(dtb: &mut [u8], target_name: &str) -> bool {
+    let struct_off = fdt_read_u32(dtb, 8) as usize;
+    let struct_size = fdt_read_u32(dtb, 36) as usize;
+    let end = struct_off + struct_size;
+    let mut off = struct_off;
+
+    while off + 4 <= end {
+        let token = fdt_read_u32(dtb, off);
+        match token {
+            t if t == FDT_BEGIN_NODE => {
+                let name_start = off + 4;
+                let name = core::ffi::CStr::from_bytes_until_nul(&dtb[name_start..])
+                    .map(|s| s.to_str().unwrap_or(""))
+                    .unwrap_or("");
+                if name == target_name {
+                    let node_start = off;
+                    let mut depth = 1u32;
+                    off += 4 + ((name.len() + 4) & !3);
+                    while depth > 0 && off + 4 <= end {
+                        let t = fdt_read_u32(dtb, off);
+                        if t == FDT_BEGIN_NODE {
+                            depth += 1;
+                            let n = core::ffi::CStr::from_bytes_until_nul(&dtb[off + 4..])
+                                .map(|s| s.to_str().unwrap_or(""))
+                                .unwrap_or("");
+                            off += 4 + ((n.len() + 4) & !3);
+                        } else if t == FDT_END_NODE {
+                            depth -= 1;
+                            off += 4;
+                        } else if t == FDT_PROP {
+                            let prop_len = fdt_read_u32(dtb, off + 4) as usize;
+                            off += 12 + ((prop_len + 3) & !3);
+                        } else if t == FDT_NOP {
+                            off += 4;
+                        } else {
+                            break;
+                        }
+                    }
+                    for i in (node_start..off).step_by(4) {
+                        fdt_write_u32(dtb, i, FDT_NOP);
+                    }
+                    return true;
+                }
+                off += 4 + ((name.len() + 4) & !3);
+            }
+            t if t == FDT_END_NODE => {
+                off += 4;
+            }
+            t if t == FDT_PROP => {
+                let prop_len = fdt_read_u32(dtb, off + 4) as usize;
+                off += 12 + ((prop_len + 3) & !3);
+            }
+            t if t == FDT_NOP => {
+                off += 4;
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
+fn fdt_interrupts_extended_has_irq(data: &[u8], irq: u32) -> bool {
+    let mut chunks = data.chunks_exact(8);
+    let mut found = false;
+    for interrupt in chunks.by_ref() {
+        let interrupt_id =
+            u32::from_be_bytes([interrupt[4], interrupt[5], interrupt[6], interrupt[7]]);
+        if interrupt_id == irq {
+            found = true;
+        }
+    }
+    found && chunks.remainder().is_empty()
+}
+
+fn fdt_nop_m_level_imsic(dtb: &mut [u8]) {
+    let struct_off = fdt_read_u32(dtb, 8) as usize;
+    let struct_size = fdt_read_u32(dtb, 36) as usize;
+    let strings_off = fdt_read_u32(dtb, 12) as usize;
+    let end = struct_off + struct_size;
+    let mut off = struct_off;
+
+    while off + 4 <= end {
+        let token = fdt_read_u32(dtb, off);
+        match token {
+            t if t == FDT_BEGIN_NODE => {
+                let name_start = off + 4;
+                let name = core::ffi::CStr::from_bytes_until_nul(&dtb[name_start..])
+                    .map(|s| s.to_str().unwrap_or(""))
+                    .unwrap_or("");
+                let node_start = off;
+                let name_len = name.len();
+                off += 4 + ((name_len + 4) & !3);
+
+                let mut is_imsic = false;
+                let mut has_m_level_irq = false;
+                let mut scan = off;
+                let mut depth = 1u32;
+
+                while depth > 0 && scan + 4 <= end {
+                    let t = fdt_read_u32(dtb, scan);
+                    if t == FDT_BEGIN_NODE {
+                        depth += 1;
+                        let n = core::ffi::CStr::from_bytes_until_nul(&dtb[scan + 4..])
+                            .map(|s| s.to_str().unwrap_or(""))
+                            .unwrap_or("");
+                        scan += 4 + ((n.len() + 4) & !3);
+                    } else if t == FDT_END_NODE {
+                        depth -= 1;
+                        scan += 4;
+                    } else if t == FDT_PROP {
+                        let prop_len = fdt_read_u32(dtb, scan + 4) as usize;
+                        let name_off = fdt_read_u32(dtb, scan + 8) as usize;
+                        let prop_name =
+                            core::ffi::CStr::from_bytes_until_nul(&dtb[strings_off + name_off..])
+                                .map(|s| s.to_str().unwrap_or(""))
+                                .unwrap_or("");
+                        let data = &dtb[scan + 12..scan + 12 + prop_len];
+                        if depth == 1
+                            && prop_name == "compatible"
+                            && prop_len > 0
+                            && (data.windows(12).any(|w| w == b"riscv,imsics")
+                                || data.windows(11).any(|w| w == b"riscv,imsic"))
+                        {
+                            is_imsic = true;
+                        }
+                        if depth == 1
+                            && prop_name == "interrupts-extended"
+                            && fdt_interrupts_extended_has_irq(data, RISCV_MACHINE_EXTERNAL_IRQ)
+                        {
+                            has_m_level_irq = true;
+                        }
+                        scan += 12 + ((prop_len + 3) & !3);
+                    } else if t == FDT_NOP {
+                        scan += 4;
+                    } else {
+                        break;
+                    }
+                }
+
+                if is_imsic && has_m_level_irq {
+                    let node_name = alloc::string::String::from(name);
+                    for i in (node_start..scan).step_by(4) {
+                        fdt_write_u32(dtb, i, FDT_NOP);
+                    }
+                    info!("AIA: NOP'd M-level IMSIC node '{}' in DTB", node_name);
+                }
+            }
+            t if t == FDT_END_NODE => {
+                off += 4;
+            }
+            t if t == FDT_PROP => {
+                let prop_len = fdt_read_u32(dtb, off + 4) as usize;
+                off += 12 + ((prop_len + 3) & !3);
+            }
+            t if t == FDT_NOP => {
+                off += 4;
+            }
+            _ => break,
+        }
+    }
+}
+
+fn fdt_nop_m_level_aplic(dtb: &mut [u8]) {
+    let struct_off = fdt_read_u32(dtb, 8) as usize;
+    let struct_size = fdt_read_u32(dtb, 36) as usize;
+    let strings_off = fdt_read_u32(dtb, 12) as usize;
+    let end = struct_off + struct_size;
+    let mut off = struct_off;
+
+    while off + 4 <= end {
+        let token = fdt_read_u32(dtb, off);
+        match token {
+            t if t == FDT_BEGIN_NODE => {
+                let name_start = off + 4;
+                let name = core::ffi::CStr::from_bytes_until_nul(&dtb[name_start..])
+                    .map(|s| s.to_str().unwrap_or(""))
+                    .unwrap_or("");
+                let node_start = off;
+                let name_len = name.len();
+                off += 4 + ((name_len + 4) & !3);
+
+                let mut is_aplic = false;
+                let mut has_delegation = false;
+                let mut scan = off;
+                let mut depth = 1u32;
+
+                while depth > 0 && scan + 4 <= end {
+                    let t = fdt_read_u32(dtb, scan);
+                    if t == FDT_BEGIN_NODE {
+                        depth += 1;
+                        let n = core::ffi::CStr::from_bytes_until_nul(&dtb[scan + 4..])
+                            .map(|s| s.to_str().unwrap_or(""))
+                            .unwrap_or("");
+                        scan += 4 + ((n.len() + 4) & !3);
+                    } else if t == FDT_END_NODE {
+                        depth -= 1;
+                        scan += 4;
+                    } else if t == FDT_PROP {
+                        let prop_len = fdt_read_u32(dtb, scan + 4) as usize;
+                        let name_off = fdt_read_u32(dtb, scan + 8) as usize;
+                        let prop_name =
+                            core::ffi::CStr::from_bytes_until_nul(&dtb[strings_off + name_off..])
+                                .map(|s| s.to_str().unwrap_or(""))
+                                .unwrap_or("");
+                        if depth == 1 && prop_name == "compatible" && prop_len > 0 {
+                            let data = &dtb[scan + 12..scan + 12 + prop_len];
+                            if data.windows(11).any(|w| w == b"riscv,aplic") {
+                                is_aplic = true;
+                            }
+                        }
+                        if depth == 1
+                            && (prop_name == "riscv,delegate" || prop_name == "riscv,delegation")
+                        {
+                            has_delegation = true;
+                        }
+                        scan += 12 + ((prop_len + 3) & !3);
+                    } else if t == FDT_NOP {
+                        scan += 4;
+                    } else {
+                        break;
+                    }
+                }
+
+                if is_aplic && has_delegation {
+                    let node_name = alloc::string::String::from(name);
+                    for i in (node_start..scan).step_by(4) {
+                        fdt_write_u32(dtb, i, FDT_NOP);
+                    }
+                    info!("AIA: NOP'd M-level APLIC node '{}' in DTB", node_name);
+                }
+            }
+            t if t == FDT_END_NODE => {
+                off += 4;
+            }
+            t if t == FDT_PROP => {
+                let prop_len = fdt_read_u32(dtb, off + 4) as usize;
+                off += 12 + ((prop_len + 3) & !3);
+            }
+            t if t == FDT_NOP => {
+                off += 4;
+            }
+            _ => break,
+        }
+    }
 }
 
 static mut SBI_START_ADDRESS: usize = 0;
@@ -225,6 +508,67 @@ pub fn set_pmp(memory_range: &Range<usize>) {
         assert_eq!(RODATA_START_ADDRESS & 0x3, 0);
         assert_eq!(RODATA_END_ADDRESS & 0x3, 0);
 
+        // When AIA is active, block S-mode access to M-level interrupt
+        // controller regions while keeping other low MMIO visible.
+        // This matches OpenSBI's domain isolation approach.
+        if crate::platform::aia::is_aia_active() {
+            if let Some(ref aia_info) = crate::platform::PLATFORM.info.aia.as_ref() {
+                const QEMU_VIRT_M_APLIC_BASE: usize = 0x0c00_0000;
+                const QEMU_VIRT_CLINT_BASE: usize = 0x0200_0000;
+                const QEMU_VIRT_APLIC_SIZE: usize = 0x8000;
+                const QEMU_VIRT_CLINT_SIZE: usize = 0x1_0000;
+
+                let clint_base = crate::platform::PLATFORM
+                    .info
+                    .ipi
+                    .as_ref()
+                    .map(|(base, _)| *base)
+                    .unwrap_or(QEMU_VIRT_CLINT_BASE);
+                let clint_end = clint_base + QEMU_VIRT_CLINT_SIZE;
+                let aplic_base = QEMU_VIRT_M_APLIC_BASE;
+                let aplic_end = aplic_base + QEMU_VIRT_APLIC_SIZE;
+                let m_base = aia_info.layout.machine_base;
+                let m_end = aia_info
+                    .hart_imsic_map
+                    .iter()
+                    .flatten()
+                    .copied()
+                    .max()
+                    .and_then(|addr| addr.checked_add(0x1000))
+                    .unwrap_or(m_base + 0x1000);
+
+                pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
+                pmpaddr0::write(0);
+                pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
+                pmpaddr1::write(clint_base >> 2);
+                pmpcfg0::set_pmp(2, Range::TOR, Permission::NONE, false);
+                pmpaddr2::write(clint_end >> 2);
+                pmpcfg0::set_pmp(3, Range::TOR, Permission::RWX, false);
+                pmpaddr3::write(aplic_base >> 2);
+                pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
+                pmpaddr4::write(aplic_end >> 2);
+                pmpcfg0::set_pmp(5, Range::TOR, Permission::RWX, false);
+                pmpaddr5::write(m_base >> 2);
+                pmpcfg0::set_pmp(6, Range::TOR, Permission::NONE, false);
+                pmpaddr6::write(m_end >> 2);
+                pmpcfg0::set_pmp(7, Range::TOR, Permission::RWX, false);
+                pmpaddr7::write(memory_range.start >> 2);
+                pmpcfg2::set_pmp(0, Range::TOR, Permission::RWX, false);
+                pmpaddr8::write(SBI_START_ADDRESS >> 2);
+                pmpcfg2::set_pmp(1, Range::TOR, Permission::R, false);
+                pmpaddr9::write(RODATA_START_ADDRESS >> 2);
+                pmpcfg2::set_pmp(2, Range::TOR, Permission::NONE, false);
+                pmpaddr10::write(RODATA_END_ADDRESS >> 2);
+                pmpcfg2::set_pmp(3, Range::TOR, Permission::RW, false);
+                pmpaddr11::write(SBI_END_ADDRESS >> 2);
+                pmpcfg2::set_pmp(4, Range::TOR, Permission::RWX, false);
+                pmpaddr12::write(memory_range.end >> 2);
+                pmpcfg2::set_pmp(5, Range::TOR, Permission::RWX, false);
+                pmpaddr13::write(usize::MAX >> 2);
+                return;
+            }
+        }
+
         pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
         pmpaddr0::write(0);
         pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
@@ -235,7 +579,7 @@ pub fn set_pmp(memory_range: &Range<usize>) {
         pmpaddr3::write(RODATA_START_ADDRESS >> 2);
         pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
         pmpaddr4::write(RODATA_END_ADDRESS >> 2);
-        pmpcfg0::set_pmp(5, Range::TOR, Permission::RW, false); // Should be Permission::R, temporarily fix for possible S-mode DTB modification
+        pmpcfg0::set_pmp(5, Range::TOR, Permission::RW, false); // FIXME: Should be Permission::R, temporarily fix for possible S-mode DTB modification
         pmpaddr5::write(SBI_END_ADDRESS >> 2);
         pmpcfg0::set_pmp(6, Range::TOR, Permission::RWX, false);
         pmpaddr6::write(memory_range.end >> 2);

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -511,62 +511,63 @@ pub fn set_pmp(memory_range: &Range<usize>) {
         // When AIA is active, block S-mode access to M-level interrupt
         // controller regions while keeping other low MMIO visible.
         // This matches OpenSBI's domain isolation approach.
-        if crate::platform::aia::is_aia_active() {
-            if let Some(ref aia_info) = crate::platform::PLATFORM.info.aia.as_ref() {
-                const QEMU_VIRT_M_APLIC_BASE: usize = 0x0c00_0000;
-                const QEMU_VIRT_CLINT_BASE: usize = 0x0200_0000;
-                const QEMU_VIRT_APLIC_SIZE: usize = 0x8000;
-                const QEMU_VIRT_CLINT_SIZE: usize = 0x1_0000;
+        if crate::platform::aia::is_aia_active()
+            && crate::platform::PLATFORM.info.is_qemu_virt()
+            && let Some(aia_info) = crate::platform::PLATFORM.info.aia.as_ref()
+        {
+            const QEMU_VIRT_M_APLIC_BASE: usize = 0x0c00_0000;
+            const QEMU_VIRT_CLINT_BASE: usize = 0x0200_0000;
+            const QEMU_VIRT_APLIC_SIZE: usize = 0x8000;
+            const QEMU_VIRT_CLINT_SIZE: usize = 0x1_0000;
 
-                let clint_base = crate::platform::PLATFORM
-                    .info
-                    .ipi
-                    .as_ref()
-                    .map(|(base, _)| *base)
-                    .unwrap_or(QEMU_VIRT_CLINT_BASE);
-                let clint_end = clint_base + QEMU_VIRT_CLINT_SIZE;
-                let aplic_base = QEMU_VIRT_M_APLIC_BASE;
-                let aplic_end = aplic_base + QEMU_VIRT_APLIC_SIZE;
-                let m_base = aia_info.layout.machine_base;
-                let m_end = aia_info
-                    .hart_imsic_map
-                    .iter()
-                    .flatten()
-                    .copied()
-                    .max()
-                    .and_then(|addr| addr.checked_add(0x1000))
-                    .unwrap_or(m_base + 0x1000);
+            let clint_base = crate::platform::PLATFORM
+                .info
+                .ipi
+                .as_ref()
+                .map(|(base, _)| *base)
+                .unwrap_or(QEMU_VIRT_CLINT_BASE);
+            let clint_end = clint_base + QEMU_VIRT_CLINT_SIZE;
+            let aplic_base = QEMU_VIRT_M_APLIC_BASE;
+            let aplic_end = aplic_base + QEMU_VIRT_APLIC_SIZE;
+            let m_base = aia_info.layout.machine_base;
+            let m_end = aia_info
+                .hart_imsic_map
+                .iter()
+                .flatten()
+                .copied()
+                .max()
+                .and_then(|addr| addr.checked_add(0x1000))
+                .unwrap_or(m_base + 0x1000);
 
-                pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
-                pmpaddr0::write(0);
-                pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
-                pmpaddr1::write(clint_base >> 2);
-                pmpcfg0::set_pmp(2, Range::TOR, Permission::NONE, false);
-                pmpaddr2::write(clint_end >> 2);
-                pmpcfg0::set_pmp(3, Range::TOR, Permission::RWX, false);
-                pmpaddr3::write(aplic_base >> 2);
-                pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
-                pmpaddr4::write(aplic_end >> 2);
-                pmpcfg0::set_pmp(5, Range::TOR, Permission::RWX, false);
-                pmpaddr5::write(m_base >> 2);
-                pmpcfg0::set_pmp(6, Range::TOR, Permission::NONE, false);
-                pmpaddr6::write(m_end >> 2);
-                pmpcfg0::set_pmp(7, Range::TOR, Permission::RWX, false);
-                pmpaddr7::write(memory_range.start >> 2);
-                pmpcfg2::set_pmp(0, Range::TOR, Permission::RWX, false);
-                pmpaddr8::write(SBI_START_ADDRESS >> 2);
-                pmpcfg2::set_pmp(1, Range::TOR, Permission::R, false);
-                pmpaddr9::write(RODATA_START_ADDRESS >> 2);
-                pmpcfg2::set_pmp(2, Range::TOR, Permission::NONE, false);
-                pmpaddr10::write(RODATA_END_ADDRESS >> 2);
-                pmpcfg2::set_pmp(3, Range::TOR, Permission::RW, false);
-                pmpaddr11::write(SBI_END_ADDRESS >> 2);
-                pmpcfg2::set_pmp(4, Range::TOR, Permission::RWX, false);
-                pmpaddr12::write(memory_range.end >> 2);
-                pmpcfg2::set_pmp(5, Range::TOR, Permission::RWX, false);
-                pmpaddr13::write(usize::MAX >> 2);
-                return;
-            }
+            pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
+            pmpaddr0::write(0);
+            pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
+            pmpaddr1::write(clint_base >> 2);
+            pmpcfg0::set_pmp(2, Range::TOR, Permission::NONE, false);
+            pmpaddr2::write(clint_end >> 2);
+            pmpcfg0::set_pmp(3, Range::TOR, Permission::RWX, false);
+            pmpaddr3::write(aplic_base >> 2);
+            pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
+            pmpaddr4::write(aplic_end >> 2);
+            pmpcfg0::set_pmp(5, Range::TOR, Permission::RWX, false);
+            pmpaddr5::write(m_base >> 2);
+            pmpcfg0::set_pmp(6, Range::TOR, Permission::NONE, false);
+            pmpaddr6::write(m_end >> 2);
+            pmpcfg0::set_pmp(7, Range::TOR, Permission::RWX, false);
+            pmpaddr7::write(memory_range.start >> 2);
+            pmpcfg2::set_pmp(0, Range::TOR, Permission::RWX, false);
+            pmpaddr8::write(SBI_START_ADDRESS >> 2);
+            pmpcfg2::set_pmp(1, Range::TOR, Permission::R, false);
+            pmpaddr9::write(RODATA_START_ADDRESS >> 2);
+            pmpcfg2::set_pmp(2, Range::TOR, Permission::NONE, false);
+            pmpaddr10::write(RODATA_END_ADDRESS >> 2);
+            pmpcfg2::set_pmp(3, Range::TOR, Permission::RW, false);
+            pmpaddr11::write(SBI_END_ADDRESS >> 2);
+            pmpcfg2::set_pmp(4, Range::TOR, Permission::RWX, false);
+            pmpaddr12::write(memory_range.end >> 2);
+            pmpcfg2::set_pmp(5, Range::TOR, Permission::RWX, false);
+            pmpaddr13::write(usize::MAX >> 2);
+            return;
         }
 
         pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);

--- a/prototyper/prototyper/src/macros.rs
+++ b/prototyper/prototyper/src/macros.rs
@@ -27,7 +27,7 @@ macro_rules! println {
 macro_rules! has_csr {
     ($($x: expr)*) => {{
             use core::arch::asm;
-            use riscv::register::mtvec;
+            use ::riscv::register::mtvec;
             use crate::sbi::early_trap::light_expected_trap;
             let res: usize;
             unsafe {

--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -21,7 +21,7 @@ mod sbi;
 use core::arch::{asm, naked_asm};
 
 use crate::platform::PLATFORM;
-use crate::riscv::csr::menvcfg;
+use crate::riscv::csr::{CSR_MSTATEEN0, menvcfg, mstateen};
 use crate::riscv::current_hartid;
 use crate::sbi::features::hart_mhpm_mask;
 use crate::sbi::features::{
@@ -36,6 +36,11 @@ use crate::sbi::trap;
 use crate::sbi::trap_stack;
 
 pub const R_RISCV_RELATIVE: usize = 3;
+
+#[inline(always)]
+fn has_mstateen0() -> bool {
+    has_csr!(CSR_MSTATEEN0)
+}
 
 #[unsafe(no_mangle)]
 extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
@@ -124,6 +129,21 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
     // Clear all pending IPIs.
     ipi::clear_all();
 
+    // Per-hart IMSIC initialization when AIA is active and Smaia is supported.
+    if crate::platform::aia::is_aia_active() {
+        let hart_id = crate::riscv::current_hartid();
+        if crate::sbi::features::hart_extension_probe(
+            hart_id,
+            crate::sbi::features::Extension::Smaia,
+        ) {
+            if let Some(ref aia_info) = unsafe { PLATFORM.info.aia.as_ref() } {
+                crate::platform::aia::imsic_init_hart(aia_info);
+            }
+        } else {
+            warn!("Hart {} lacks Smaia, skipping IMSIC init", hart_id);
+        }
+    }
+
     // Configure CSRs
     unsafe {
         // Delegate all interrupts and exceptions to supervisor mode.
@@ -140,7 +160,7 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
 
         let hart_priv_version = hart_privileged_version(current_hartid());
         if hart_priv_version >= PrivilegedVersion::Version1_11 {
-            asm!("csrw mcountinhibit, {}", in(reg) !0b10);
+            asm!("csrw mcountinhibit, {}", in(reg) !0b111usize);
         }
         if hart_priv_version >= PrivilegedVersion::Version1_12 {
             // Configure environment features based on available extensions.
@@ -150,6 +170,12 @@ extern "C" fn rust_main(_hart_id: usize, opaque: usize, nonstandard_a2: usize) {
                 );
             } else {
                 menvcfg::set_bits(menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE);
+            }
+            if crate::platform::aia::is_aia_active()
+                && hart_extension_probe(current_hartid(), Extension::Smaia)
+                && has_mstateen0()
+            {
+                mstateen::enable_smode_aia();
             }
         }
         // Set up trap handling.

--- a/prototyper/prototyper/src/platform/aia.rs
+++ b/prototyper/prototyper/src/platform/aia.rs
@@ -1,0 +1,243 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+use riscv_aia::Iid;
+use riscv_aia::peripheral::imsic::system::AddressLayout;
+
+use crate::cfg::NUM_HART_MAX;
+use crate::riscv::csr::stimecmp;
+use crate::riscv::current_hartid;
+use crate::sbi::ipi::IpiDevice;
+
+pub(crate) const IMSIC_COMPATIBLE: [&str; 2] = ["riscv,imsics", "riscv,imsic"];
+
+static AIA_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+const QEMU_VIRT_M_APLIC_BASE: usize = 0x0c00_0000;
+const QEMU_VIRT_S_IMSIC_BASE: usize = 0x2800_0000;
+const QEMU_VIRT_APLIC_NUM_SOURCES: usize = 0x60;
+const APLIC_DOMAINCFG: usize = 0x0000;
+const APLIC_SOURCECFG_BASE: usize = 0x0004;
+const APLIC_MMSICFGADDR: usize = 0x1bc0;
+const APLIC_MMSICFGADDRH: usize = 0x1bc4;
+const APLIC_SMSICFGADDR: usize = 0x1bc8;
+const APLIC_SMSICFGADDRH: usize = 0x1bcc;
+const APLIC_CLRIE_BASE: usize = 0x1f00;
+const APLIC_SOURCECFG_DELEGATE: u32 = 1 << 10;
+const APLIC_MSICFGADDRH_LOCK: u32 = 1 << 31;
+const APLIC_MSICFGADDRH_LHXW_SHIFT: u32 = 12;
+
+pub fn is_aia_active() -> bool {
+    AIA_ACTIVE.load(Ordering::Relaxed)
+}
+
+pub fn set_aia_active(active: bool) {
+    AIA_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+pub fn init_qemu_m_aplic_delegation(machine_imsic_base: usize, hart_index_bits: u32) {
+    let base = QEMU_VIRT_M_APLIC_BASE;
+
+    write_aplic(base + APLIC_DOMAINCFG, 0);
+
+    for source in (0..=QEMU_VIRT_APLIC_NUM_SOURCES).step_by(32) {
+        write_aplic(base + APLIC_CLRIE_BASE + (source / 32) * 4, u32::MAX);
+    }
+
+    for source in 1..=QEMU_VIRT_APLIC_NUM_SOURCES {
+        write_aplic(
+            base + APLIC_SOURCECFG_BASE + (source - 1) * 4,
+            APLIC_SOURCECFG_DELEGATE,
+        );
+    }
+
+    if read_aplic(base + APLIC_MMSICFGADDRH) & APLIC_MSICFGADDRH_LOCK == 0 {
+        write_msicfg(
+            base + APLIC_MMSICFGADDR,
+            base + APLIC_MMSICFGADDRH,
+            machine_imsic_base,
+            hart_index_bits,
+        );
+        write_msicfg(
+            base + APLIC_SMSICFGADDR,
+            base + APLIC_SMSICFGADDRH,
+            QEMU_VIRT_S_IMSIC_BASE,
+            hart_index_bits,
+        );
+    } else {
+        warn!("AIA: M-level APLIC MSI configuration is locked");
+    }
+
+    info!(
+        "AIA: delegated M-level APLIC IRQs 1..={} to S-level child",
+        QEMU_VIRT_APLIC_NUM_SOURCES
+    );
+}
+
+fn write_msicfg(addr: usize, addrh: usize, imsic_base: usize, hart_index_bits: u32) {
+    let mut base_ppn = imsic_base >> 12;
+    base_ppn &= !((1usize << hart_index_bits) - 1);
+
+    write_aplic(addr, base_ppn as u32);
+    write_aplic(
+        addrh,
+        ((base_ppn >> 32) as u32) | (hart_index_bits << APLIC_MSICFGADDRH_LHXW_SHIFT),
+    );
+}
+
+fn read_aplic(addr: usize) -> u32 {
+    unsafe { (addr as *const u32).read_volatile() }
+}
+
+fn write_aplic(addr: usize, value: u32) {
+    unsafe {
+        (addr as *mut u32).write_volatile(value);
+    }
+}
+
+pub struct AiaInfo {
+    pub layout: AddressLayout,
+    pub num_ids: u16,
+    pub firmware_ipi_iid: Iid,
+    pub hart_imsic_map: [Option<usize>; NUM_HART_MAX],
+}
+
+pub struct ImsicDevice {
+    firmware_ipi_iid: Iid,
+    hart_imsic_map: [Option<usize>; NUM_HART_MAX],
+}
+
+unsafe impl Send for ImsicDevice {}
+
+impl ImsicDevice {
+    pub fn new(firmware_ipi_iid: Iid, hart_imsic_map: [Option<usize>; NUM_HART_MAX]) -> Self {
+        Self {
+            firmware_ipi_iid,
+            hart_imsic_map,
+        }
+    }
+}
+
+impl IpiDevice for ImsicDevice {
+    #[inline(always)]
+    fn read_mtime(&self) -> u64 {
+        riscv::register::time::read64()
+    }
+
+    #[inline(always)]
+    fn write_mtime(&self, _val: u64) {}
+
+    #[inline(always)]
+    fn read_mtimecmp(&self, _hart_idx: usize) -> u64 {
+        0
+    }
+
+    #[inline(always)]
+    fn write_mtimecmp(&self, hart_idx: usize, val: u64) {
+        if hart_idx == current_hartid() {
+            stimecmp::set(val);
+            if val == u64::MAX {
+                unsafe {
+                    riscv::register::mip::clear_stimer();
+                    riscv::register::mie::clear_mtimer();
+                }
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn read_msip(&self, _hart_idx: usize) -> bool {
+        false
+    }
+
+    #[inline(always)]
+    fn set_msip(&self, hart_id: usize) {
+        let Some(addr) = self.hart_imsic_map.get(hart_id).copied().flatten() else {
+            warn!("IMSIC ring: hart {} has no mapped IMSIC file", hart_id);
+            return;
+        };
+        core::sync::atomic::fence(core::sync::atomic::Ordering::Release);
+        let data = riscv_aia::peripheral::imsic::msi::encode_le(self.firmware_ipi_iid.number());
+        unsafe {
+            (addr as *mut u32).write_volatile(data);
+        }
+    }
+
+    #[inline(always)]
+    fn clear_msip(&self, _hart_idx: usize) {
+        let _ = mtopei_claim();
+    }
+}
+
+pub(crate) fn mtopei_claim() -> Option<Iid> {
+    let bits: usize;
+    unsafe {
+        core::arch::asm!(
+            "csrrw {val}, 0x35C, zero",
+            val = out(reg) bits,
+        );
+    }
+    let iid_bits = ((bits & 0x0FFF_0000) >> 16) as u16;
+    Iid::new(iid_bits)
+}
+
+pub fn imsic_init_hart(info: &AiaInfo) {
+    let ipi_iid = info.firmware_ipi_iid.number();
+    let num_ids = info.num_ids;
+
+    imsic_write_indirect(0x70, 1);
+    imsic_write_indirect(0x72, 0);
+
+    let max_reg = ((num_ids as usize) + 31) / 32;
+    for i in 0..max_reg {
+        #[cfg(target_pointer_width = "64")]
+        if i % 2 == 1 {
+            continue;
+        }
+        let eip_sel = 0x80 + i;
+        let eie_sel = 0xC0 + i;
+        imsic_write_indirect(eip_sel, 0);
+        imsic_write_indirect(eie_sel, 0);
+    }
+
+    {
+        let iid = ipi_iid as usize;
+        #[cfg(target_pointer_width = "64")]
+        let eie_sel = 0xC0 + (iid / 64) * 2;
+        #[cfg(target_pointer_width = "32")]
+        let eie_sel = 0xC0 + iid / 32;
+        let bit_pos = iid % (core::mem::size_of::<usize>() * 8);
+        let current = imsic_read_indirect(eie_sel);
+        imsic_write_indirect(eie_sel, current | (1usize << bit_pos));
+    }
+
+    unsafe {
+        riscv::register::mie::set_mext();
+    }
+    debug!(
+        "IMSIC: hart init done, MEIE enabled, firmware IPI IID={}",
+        ipi_iid
+    );
+}
+
+fn imsic_write_indirect(select: usize, value: usize) {
+    unsafe {
+        core::arch::asm!(
+            "csrw 0x350, {sel}",
+            "csrw 0x351, {val}",
+            sel = in(reg) select,
+            val = in(reg) value,
+        );
+    }
+}
+
+fn imsic_read_indirect(select: usize) -> usize {
+    let value: usize;
+    unsafe {
+        core::arch::asm!(
+            "csrw 0x350, {sel}",
+            "csrr {val}, 0x351",
+            sel = in(reg) select,
+            val = out(reg) value,
+        );
+    }
+    value
+}

--- a/prototyper/prototyper/src/platform/clint.rs
+++ b/prototyper/prototyper/src/platform/clint.rs
@@ -3,6 +3,7 @@ use core::arch::asm;
 use xuantie_riscv::peripheral::clint::THeadClint;
 
 use crate::sbi::ipi::IpiDevice;
+
 pub(crate) const SIFIVE_CLINT_COMPATIBLE: [&str; 3] =
     ["riscv,clint0", "starfive,jh7110-clint", "sifive,clint0"];
 pub(crate) const THEAD_CLINT_COMPATIBLE: [&str; 1] = ["thead,c900-clint"];
@@ -19,6 +20,8 @@ pub enum MachineClintType {
 pub struct SifiveClintWrap {
     inner: *const SifiveClint,
 }
+
+unsafe impl Send for SifiveClintWrap {}
 
 impl SifiveClintWrap {
     pub fn new(base: usize) -> Self {
@@ -69,6 +72,8 @@ impl IpiDevice for SifiveClintWrap {
 pub struct THeadClintWrap {
     inner: *const THeadClint,
 }
+
+unsafe impl Send for THeadClintWrap {}
 
 impl THeadClintWrap {
     pub fn new(base: usize) -> Self {

--- a/prototyper/prototyper/src/platform/console.rs
+++ b/prototyper/prototyper/src/platform/console.rs
@@ -159,10 +159,6 @@ impl UartPl011Wrap {
             uart: UnsafeCell::new(uart),
         }
     }
-
-    unsafe fn uart_mut(&self) -> &mut Uart<'static> {
-        unsafe { &mut *self.uart.get() }
-    }
 }
 
 unsafe impl Send for UartPl011Wrap {}
@@ -172,7 +168,7 @@ impl ConsoleDevice for UartPl011Wrap {
     fn read(&self, buf: &mut [u8]) -> usize {
         let mut count = 0;
 
-        let uart = unsafe { self.uart_mut() };
+        let uart = unsafe { &mut *self.uart.get() };
 
         for slot in buf.iter_mut() {
             match uart.read_word() {
@@ -189,7 +185,7 @@ impl ConsoleDevice for UartPl011Wrap {
     }
 
     fn write(&self, buf: &[u8]) -> usize {
-        let uart = unsafe { self.uart_mut() };
+        let uart = unsafe { &mut *self.uart.get() };
 
         for &byte in buf {
             uart.write_word(byte);

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -164,6 +164,10 @@ impl BoardInfo {
             model: String::new(),
         }
     }
+
+    pub fn is_qemu_virt(&self) -> bool {
+        self.model == "riscv-virtio,qemu"
+    }
 }
 
 pub struct Platform {
@@ -669,10 +673,17 @@ impl Platform {
                 let ipi_dev =
                     aia::ImsicDevice::new(aia_info.firmware_ipi_iid, aia_info.hart_imsic_map);
                 self.sbi.ipi = Some(SbiIpi::new(Mutex::new(Box::new(ipi_dev)), max_hart_id));
-                aia::init_qemu_m_aplic_delegation(
-                    aia_info.layout.machine_base,
-                    aia_info.layout.hart_index_bits,
-                );
+                if self.info.is_qemu_virt() {
+                    aia::init_qemu_m_aplic_delegation(
+                        aia_info.layout.machine_base,
+                        aia_info.layout.hart_index_bits,
+                    );
+                } else {
+                    warn!(
+                        "AIA: skipping QEMU virt M-APLIC setup on '{}'",
+                        self.info.model
+                    );
+                }
                 aia::set_aia_active(true);
                 info!("AIA: IMSIC IPI + Sstc timer backend initialized");
                 return;

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use alloc::{boxed::Box, string::ToString};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use clint::{SifiveClintWrap, THeadClintWrap};
 use core::{
     ops::Range,
@@ -33,6 +33,7 @@ use crate::sbi::reset::SbiReset;
 use crate::sbi::rfence::SbiRFence;
 use crate::sbi::suspend::SbiSuspend;
 
+pub(crate) mod aia;
 mod clint;
 mod console;
 mod reset;
@@ -40,15 +41,111 @@ mod reset;
 pub(crate) static CPU_PRIVILEGED_ENABLED: [AtomicBool; NUM_HART_MAX] =
     [const { AtomicBool::new(false) }; NUM_HART_MAX];
 
+const RISCV_MACHINE_EXTERNAL_IRQ: u32 = 11;
+
 type BaseAddress = usize;
 
 type CpuEnableList = [bool; NUM_HART_MAX];
+
+fn collect_cpu_intc_harts(root: &serde_device_tree::buildin::Node) -> Vec<(u32, usize)> {
+    let mut cpu_intc_harts = Vec::new();
+    let Some(cpus) = root.find("/cpus") else {
+        return cpu_intc_harts;
+    };
+
+    for cpu_item in cpus.nodes() {
+        let (node_name, _) = cpu_item.get_parsed_name();
+        if node_name != "cpu" {
+            continue;
+        }
+        let cpu = cpu_item.deserialize::<Cpu>();
+        let hart_id = cpu.reg.iter().next().unwrap().0.start;
+        let cpu_node = cpu_item.deserialize::<serde_device_tree::buildin::Node>();
+        for child_item in cpu_node.nodes() {
+            let (child_name, _) = child_item.get_parsed_name();
+            if child_name != "interrupt-controller" {
+                continue;
+            }
+            let child = child_item.deserialize::<serde_device_tree::buildin::Node>();
+            if !is_cpu_intc(&child) {
+                continue;
+            }
+            if let Some(phandle) = node_phandle(&child) {
+                cpu_intc_harts.push((phandle, hart_id));
+            }
+        }
+    }
+
+    cpu_intc_harts
+}
+
+fn is_cpu_intc(node: &serde_device_tree::buildin::Node) -> bool {
+    get_compatible(node).is_some_and(|compatible| {
+        compatible
+            .iter()
+            .any(|device_id| device_id == "riscv,cpu-intc")
+    })
+}
+
+fn node_phandle(node: &serde_device_tree::buildin::Node) -> Option<u32> {
+    node.get_prop("phandle")
+        .or_else(|| node.get_prop("linux,phandle"))
+        .map(|prop| prop.deserialize::<u32>())
+}
+
+fn prop_u32_cells(node: &serde_device_tree::buildin::Node, name: &str) -> Option<Vec<u32>> {
+    let prop = node.get_prop(name)?;
+    let data = prop.deserialize::<&[u8]>();
+    let mut cells = Vec::new();
+    let mut chunks = data.chunks_exact(4);
+    for chunk in &mut chunks {
+        cells.push(u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    }
+    if chunks.remainder().is_empty() {
+        Some(cells)
+    } else {
+        None
+    }
+}
+
+fn hart_for_cpu_intc(cpu_intc_harts: &[(u32, usize)], phandle: u32) -> Option<usize> {
+    cpu_intc_harts
+        .iter()
+        .find(|(intc_phandle, _)| *intc_phandle == phandle)
+        .map(|(_, hart_id)| *hart_id)
+}
+
+fn imsic_machine_hart_files(
+    node: &serde_device_tree::buildin::Node,
+    cpu_intc_harts: &[(u32, usize)],
+) -> Option<Vec<(usize, u32)>> {
+    let cells = prop_u32_cells(node, "interrupts-extended")?;
+    let mut chunks = cells.chunks_exact(2);
+    let mut hart_files = Vec::new();
+
+    for (file_index, interrupt) in chunks.by_ref().enumerate() {
+        let phandle = interrupt[0];
+        let interrupt_id = interrupt[1];
+        if interrupt_id != RISCV_MACHINE_EXTERNAL_IRQ {
+            continue;
+        }
+        let hart_id = hart_for_cpu_intc(cpu_intc_harts, phandle)?;
+        hart_files.push((hart_id, file_index as u32));
+    }
+
+    if chunks.remainder().is_empty() {
+        Some(hart_files)
+    } else {
+        None
+    }
+}
 
 pub struct BoardInfo {
     pub memory_range: Option<Range<usize>>,
     pub console: Option<(BaseAddress, MachineConsoleType)>,
     pub reset: Option<BaseAddress>,
     pub ipi: Option<(BaseAddress, MachineClintType)>,
+    pub aia: Option<aia::AiaInfo>,
     pub cpu_num: Option<usize>,
     pub cpu_enabled: Option<CpuEnableList>,
     pub model: String,
@@ -61,6 +158,7 @@ impl BoardInfo {
             console: None,
             reset: None,
             ipi: None,
+            aia: None,
             cpu_enabled: None,
             cpu_num: None,
             model: String::new(),
@@ -151,11 +249,12 @@ impl Platform {
 
     fn sbi_init_ipi_reset_hsm_rfence(&mut self, root: &serde_device_tree::buildin::Node) {
         // Get ipi and reset device info
+        let cpu_intc_harts = collect_cpu_intc_harts(root);
         let mut find_device = |node: &serde_device_tree::buildin::Node| {
-            let info = get_compatible_and_range(node);
+            let info = get_compatible_and_ranges(node);
             if let Some(info) = info {
                 let (compatible, regs) = info;
-                let base_address = regs.start;
+                let base_address = regs[0].start;
                 for device_id in compatible.iter() {
                     // Initialize clint device.
                     if SIFIVE_CLINT_COMPATIBLE.contains(&device_id) {
@@ -170,6 +269,10 @@ impl Platform {
                     // Initialize reset device.
                     if SIFIVETEST_COMPATIBLE.contains(&device_id) {
                         self.info.reset = Some(base_address);
+                    }
+                    // Discover the M-level IMSIC from its CPU interrupt wiring.
+                    if aia::IMSIC_COMPATIBLE.contains(&device_id) && self.info.aia.is_none() {
+                        self.sbi_discover_imsic(node, &regs, &cpu_intc_harts);
                     }
                 }
             }
@@ -335,32 +438,258 @@ impl Platform {
         }
     }
 
-    fn sbi_ipi_init(&mut self) {
-        if let Some((base, clint_type)) = self.info.ipi {
-            let max_hart_id = self
-                .info
-                .cpu_enabled
-                .as_ref()
-                .and_then(|hart_list| hart_list.iter().rposition(|enabled| *enabled))
-                .unwrap_or(NUM_HART_MAX - 1);
-            self.sbi.ipi = match clint_type {
-                MachineClintType::SiFiveClint => Some(SbiIpi::new(
-                    Mutex::new(Box::new(SifiveClintWrap::new(base))),
-                    max_hart_id,
-                )),
-                MachineClintType::TheadClint => Some(SbiIpi::new(
-                    Mutex::new(Box::new(THeadClintWrap::new(base))),
-                    max_hart_id,
-                )),
-            };
+    fn sbi_discover_imsic(
+        &mut self,
+        node: &serde_device_tree::buildin::Node,
+        reg_ranges: &[Range<usize>],
+        cpu_intc_harts: &[(u32, usize)],
+    ) {
+        use riscv_aia::Iid;
+        use riscv_aia::peripheral::imsic::system::AddressLayout;
+
+        let Some(first_reg_range) = reg_ranges.first() else {
+            warn!("IMSIC: missing reg ranges, skipping");
+            return;
+        };
+        for reg_range in reg_ranges {
+            let reg_size = reg_range.end.saturating_sub(reg_range.start);
+            if reg_range.start & 0xFFF != 0 {
+                warn!(
+                    "IMSIC: base 0x{:x} not 4 KiB aligned, skipping",
+                    reg_range.start
+                );
+                return;
+            }
+
+            if reg_size == 0 || reg_size & 0xFFF != 0 {
+                warn!(
+                    "IMSIC: reg size 0x{:x} is not a positive 4 KiB multiple, skipping",
+                    reg_size
+                );
+                return;
+            }
+        }
+
+        let reg_range = first_reg_range;
+        let base_address = reg_range.start;
+
+        let Some(num_ids_prop) = node.get_prop("riscv,num-ids") else {
+            warn!("IMSIC: missing required riscv,num-ids property, skipping");
+            return;
+        };
+        let num_ids = num_ids_prop.deserialize::<u32>() as u16;
+
+        if num_ids == 0 {
+            warn!("IMSIC: riscv,num-ids is 0, skipping AIA");
+            return;
+        }
+
+        let Some(machine_hart_files) = imsic_machine_hart_files(node, cpu_intc_harts) else {
+            warn!("IMSIC: malformed interrupts-extended property, skipping AIA");
+            return;
+        };
+
+        if machine_hart_files.is_empty() {
+            debug!(
+                "IMSIC: node at 0x{:x} is not wired to MachineExternal, skipping",
+                base_address
+            );
+            return;
+        }
+
+        let machine_hart_count = machine_hart_files.len() as u32;
+        let default_hart_index_bits = if machine_hart_count <= 1 {
+            0
         } else {
-            self.sbi.ipi = None;
+            u32::BITS - (machine_hart_count - 1).leading_zeros()
+        };
+
+        let hart_index_bits: u32 = node
+            .get_prop("riscv,hart-index-bits")
+            .map(|p| p.deserialize::<u32>())
+            .unwrap_or(default_hart_index_bits);
+
+        let group_index_bits: u32 = node
+            .get_prop("riscv,group-index-bits")
+            .map(|p| p.deserialize::<u32>())
+            .unwrap_or(0);
+
+        let group_index_shift: u32 = node
+            .get_prop("riscv,group-index-shift")
+            .map(|p| p.deserialize::<u32>())
+            .unwrap_or(24);
+
+        if hart_index_bits >= u32::BITS
+            || group_index_bits >= u32::BITS
+            || hart_index_bits + group_index_bits > u32::BITS
+            || group_index_shift >= u32::BITS
+        {
+            warn!(
+                "IMSIC: invalid topology hart-index-bits={}, group-index-bits={}, group-index-shift={}",
+                hart_index_bits, group_index_bits, group_index_shift
+            );
+            return;
+        }
+
+        let firmware_ipi_iid = Iid::new(1).unwrap();
+
+        if firmware_ipi_iid.number() >= num_ids {
+            warn!(
+                "IMSIC: firmware IPI IID {} outside riscv,num-ids {}",
+                firmware_ipi_iid.number(),
+                num_ids
+            );
+            return;
+        }
+
+        let layout = AddressLayout {
+            machine_base: base_address,
+            supervisor_base: 0,
+            guest_base: None,
+            hart_index_bits,
+            group_bits: group_index_shift,
+            hart_offset_bits: 12,
+            guest_offset_bits: 0,
+        };
+
+        let mut hart_imsic_map = [None; NUM_HART_MAX];
+        let topology_bits = hart_index_bits + group_index_bits;
+        let max_file_count = if topology_bits == 0 {
+            1
+        } else {
+            1u64 << topology_bits
+        };
+        for &(hart_id, file_index) in machine_hart_files.iter() {
+            if hart_id >= NUM_HART_MAX {
+                warn!(
+                    "IMSIC: hart {} exceeds NUM_HART_MAX {}, skipping AIA",
+                    hart_id, NUM_HART_MAX
+                );
+                return;
+            }
+            if (file_index as u64) >= max_file_count {
+                warn!(
+                    "IMSIC: file index {} exceeds topology capacity {}, skipping AIA",
+                    file_index, max_file_count
+                );
+                return;
+            }
+
+            let hart_index_mask = if hart_index_bits == 0 {
+                0
+            } else {
+                (1u32 << hart_index_bits) - 1
+            };
+            let hart_index = file_index & hart_index_mask;
+            let group_index_mask = if group_index_bits == 0 {
+                0
+            } else {
+                (1u32 << group_index_bits) - 1
+            };
+            let group_index = (file_index >> hart_index_bits) & group_index_mask;
+            let addr = layout.machine_interrupt_file_address(hart_index, group_index);
+            let Some(page_end) = addr.checked_add(0x1000) else {
+                warn!(
+                    "IMSIC: hart {} file {} page 0x{:x} overflows address space, skipping AIA",
+                    hart_id, file_index, addr
+                );
+                return;
+            };
+            if !reg_ranges
+                .iter()
+                .any(|range| addr >= range.start && page_end <= range.end)
+            {
+                warn!(
+                    "IMSIC: hart {} file {} page 0x{:x} outside reg ranges, skipping AIA",
+                    hart_id, file_index, addr
+                );
+                return;
+            }
+            hart_imsic_map[hart_id] = Some(addr);
+        }
+
+        if let Some(ref cpu_enabled) = self.info.cpu_enabled {
+            for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
+                if *enabled && hart_imsic_map[hart_id].is_none() {
+                    warn!(
+                        "IMSIC: enabled hart {} has no M-level IMSIC file, skipping AIA",
+                        hart_id
+                    );
+                    return;
+                }
+            }
+        }
+
+        info!(
+            "IMSIC: base=0x{:x}, num-ids={}, hart-index-bits={}, group-index-bits={}, group-index-shift={}, firmware-ipi-iid={}",
+            base_address,
+            num_ids,
+            hart_index_bits,
+            group_index_bits,
+            group_index_shift,
+            firmware_ipi_iid.number()
+        );
+
+        self.info.aia = Some(aia::AiaInfo {
+            layout,
+            num_ids,
+            firmware_ipi_iid,
+            hart_imsic_map,
+        });
+    }
+
+    fn sbi_ipi_init(&mut self) {
+        let max_hart_id = self
+            .info
+            .cpu_enabled
+            .as_ref()
+            .and_then(|hart_list| hart_list.iter().rposition(|enabled| *enabled))
+            .unwrap_or(NUM_HART_MAX - 1);
+
+        if let Some(ref aia_info) = self.info.aia {
+            use crate::sbi::features::{Extension, hart_extension_probe};
+            let mut aia_usable = true;
+            if let Some(ref cpu_enabled) = self.info.cpu_enabled {
+                for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
+                    if *enabled {
+                        if !hart_extension_probe(hart_id, Extension::Smaia) {
+                            warn!("AIA: hart {} lacks Smaia, rejecting AIA", hart_id);
+                            aia_usable = false;
+                            break;
+                        }
+                        if !hart_extension_probe(hart_id, Extension::Sstc) {
+                            warn!("AIA: hart {} lacks Sstc, rejecting AIA", hart_id);
+                            aia_usable = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            if aia_usable {
+                let ipi_dev =
+                    aia::ImsicDevice::new(aia_info.firmware_ipi_iid, aia_info.hart_imsic_map);
+                self.sbi.ipi = Some(SbiIpi::new(Mutex::new(Box::new(ipi_dev)), max_hart_id));
+                aia::init_qemu_m_aplic_delegation(
+                    aia_info.layout.machine_base,
+                    aia_info.layout.hart_index_bits,
+                );
+                aia::set_aia_active(true);
+                info!("AIA: IMSIC IPI + Sstc timer backend initialized");
+                return;
+            }
+            warn!("AIA: requirements not met, falling back to CLINT");
+        }
+        if let Some((base, clint_type)) = self.info.ipi {
+            let ipi_dev: Box<dyn crate::sbi::ipi::IpiDevice> = match clint_type {
+                MachineClintType::SiFiveClint => Box::new(SifiveClintWrap::new(base)),
+                MachineClintType::TheadClint => Box::new(THeadClintWrap::new(base)),
+            };
+            self.sbi.ipi = Some(SbiIpi::new(Mutex::new(ipi_dev), max_hart_id));
         }
     }
 
     fn sbi_hsm_init(&mut self) {
-        // TODO: Can HSM work properly when there is no ipi device?
-        if self.info.ipi.is_some() {
+        if self.sbi.ipi.is_some() {
             self.sbi.hsm = Some(SbiHsm);
         } else {
             self.sbi.hsm = None;
@@ -368,8 +697,7 @@ impl Platform {
     }
 
     fn sbi_rfence_init(&mut self) {
-        // TODO: Can rfence work properly when there is no ipi device?
-        if self.info.ipi.is_some() {
+        if self.sbi.ipi.is_some() {
             self.sbi.rfence = Some(SbiRFence);
         } else {
             self.sbi.rfence = None;
@@ -436,6 +764,15 @@ impl Platform {
 
     #[inline]
     fn print_clint_info(&self) {
+        if aia::is_aia_active()
+            && let Some(ref aia_info) = self.info.aia
+        {
+            info!(
+                "{:<30}: IMSIC (M-level Base Address: 0x{:x})",
+                "Platform IPI Extension", aia_info.layout.machine_base
+            );
+            return;
+        }
         match self.info.ipi {
             Some((base, device)) => {
                 info!(

--- a/prototyper/prototyper/src/riscv/csr.rs
+++ b/prototyper/prototyper/src/riscv/csr.rs
@@ -9,6 +9,10 @@ pub const CSR_STIMECMP: u16 = 0x14D;
 // Machine Counter-Enable and Environment Configuration
 pub const CSR_MCOUNTEREN: u16 = 0x306;
 pub const CSR_MENVCFG: u16 = 0x30a;
+pub const CSR_MSTATEEN0: u16 = 0x30c;
+pub const CSR_MSTATEEN1: u16 = 0x30d;
+pub const CSR_MSTATEEN2: u16 = 0x30e;
+pub const CSR_MSTATEEN3: u16 = 0x30f;
 
 // Machine Counter Setup (Inhibit, Privilege Filtering and Event Selection)
 pub const CSR_MCOUNTINHIBIT: u16 = 0x320;
@@ -87,6 +91,39 @@ pub mod menvcfg {
         unsafe {
             // Write back updated value
             asm!("csrw menvcfg, {}", in(reg) bits, options(nomem));
+        }
+    }
+}
+
+/// Machine state-enable register bit fields.
+pub mod mstateen {
+    use core::arch::asm;
+
+    use super::{CSR_MSTATEEN0, CSR_MSTATEEN1, CSR_MSTATEEN2, CSR_MSTATEEN3};
+
+    /// Counter delegation state.
+    pub const CTR: usize = 1usize << 54;
+    /// Context CSRs.
+    pub const CONTEXT: usize = 1usize << 57;
+    /// IMSIC state.
+    pub const IMSIC: usize = 1usize << 58;
+    /// AIA state.
+    pub const AIA: usize = 1usize << 59;
+    /// Supervisor indirect CSR select state.
+    pub const SVSLCT: usize = 1usize << 60;
+    /// Hypervisor environment configuration state.
+    pub const HSENVCFG: usize = 1usize << 62;
+    /// State-enable CSRs themselves.
+    pub const STATEN: usize = 1usize << 63;
+
+    #[inline(always)]
+    pub fn enable_smode_aia() {
+        let stateen0 = STATEN | CONTEXT | IMSIC | AIA | SVSLCT | HSENVCFG | CTR;
+        unsafe {
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN0, value = in(reg) stateen0, options(nomem));
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN1, value = in(reg) STATEN, options(nomem));
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN2, value = in(reg) STATEN, options(nomem));
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN3, value = in(reg) STATEN, options(nomem));
         }
     }
 }

--- a/prototyper/prototyper/src/sbi/hart_context.rs
+++ b/prototyper/prototyper/src/sbi/hart_context.rs
@@ -71,7 +71,7 @@ impl HartContext {
         let hart_priv_version = self.features.privileged_version();
         if hart_priv_version >= PrivilegedVersion::Version1_11 {
             unsafe {
-                core::arch::asm!("csrw mcountinhibit, {}", in(reg) !0b10);
+                core::arch::asm!("csrw mcountinhibit, {}", in(reg) !0b111usize);
             }
         }
         // reset hart pmu state

--- a/prototyper/prototyper/src/sbi/ipi.rs
+++ b/prototyper/prototyper/src/sbi/ipi.rs
@@ -20,7 +20,7 @@ pub(crate) const IPI_TYPE_FENCE: u8 = 1 << 1;
 
 /// Trait defining interface for inter-processor interrupt device
 #[allow(unused)]
-pub trait IpiDevice {
+pub trait IpiDevice: Send {
     /// Read machine time value.
     fn read_mtime(&self) -> u64;
     /// Write machine time value.
@@ -51,20 +51,16 @@ impl rustsbi::Timer for SbiIpi {
     fn set_timer(&self, stime_value: u64) {
         pmu_firmware_counter_increment(firmware_event::SET_TIMER);
         let hart_id = current_hartid();
-        let uses_sstc = hart_extension_probe(hart_id, Extension::Sstc);
 
         // Set timer value based on extension support.
-        if uses_sstc {
+        if hart_extension_probe(hart_id, Extension::Sstc) {
             stimecmp::set(stime_value);
         } else {
             self.write_mtimecmp(hart_id, stime_value);
             unsafe {
                 riscv::register::mip::clear_stimer();
+                riscv::register::mie::set_mtimer();
             }
-        }
-        // Enable machine timer interrupt.
-        unsafe {
-            riscv::register::mie::set_mtimer();
         }
     }
 }
@@ -242,7 +238,7 @@ pub fn get_and_reset_ipi_type() -> u8 {
 
 /// Clear machine software interrupt pending for current hart.
 #[inline]
-pub fn clear_msip() {
+pub fn claim_ipi() {
     match unsafe { PLATFORM.sbi.ipi.as_ref() } {
         Some(ipi) => ipi.clear_msip(current_hartid()),
         None => error!("SBI or IPI device not initialized"),

--- a/prototyper/prototyper/src/sbi/logger.rs
+++ b/prototyper/prototyper/src/sbi/logger.rs
@@ -1,8 +1,11 @@
 use core::str::FromStr;
 use log::{Level, LevelFilter};
+use spin::Mutex;
 
 /// Simple logger implementation for RustSBI that supports colored output.
 pub struct Logger;
+
+static LOG_LOCK: Mutex<()> = Mutex::new(());
 
 impl Logger {
     /// Initialize the logger with log level from RUST_LOG env var or default to Info.
@@ -25,6 +28,8 @@ impl log::Log for Logger {
     // Log messages with color-coded levels
     #[inline]
     fn log(&self, record: &log::Record) {
+        let _guard = LOG_LOCK.lock();
+
         // ANSI color codes for different log levels
         const ERROR_COLOR: u8 = 31; // Red
         const WARN_COLOR: u8 = 93; // Bright yellow

--- a/prototyper/prototyper/src/sbi/trap/boot.rs
+++ b/prototyper/prototyper/src/sbi/trap/boot.rs
@@ -1,4 +1,5 @@
 use crate::riscv::current_hartid;
+use crate::sbi::features::{Extension, hart_extension_probe};
 use crate::sbi::hsm::local_hsm;
 use crate::sbi::ipi;
 use crate::sbi::trap_stack;
@@ -37,11 +38,19 @@ pub unsafe extern "C" fn boot() -> ! {
     )
 }
 
-/// Boot Handler.
 pub extern "C" fn boot_handler(ctx: &mut BootContext) {
     #[inline(always)]
     fn boot(ctx: &mut BootContext, start_addr: usize, opaque: usize) {
         unsafe {
+            // stvec BASE is four-byte aligned; HSM entry points may only be two-byte aligned.
+            if start_addr & 0x3 == 0 {
+                core::arch::asm!(
+                    "csrw stvec, {start_addr}",
+                    start_addr = in(reg) start_addr,
+                    options(nomem),
+                );
+            }
+            core::arch::asm!("csrw sscratch, zero", "csrw sie, zero", options(nomem),);
             sstatus::clear_sie();
             satp::write(satp::Satp::from_bits(0));
         }
@@ -51,20 +60,20 @@ pub extern "C" fn boot_handler(ctx: &mut BootContext) {
     }
 
     match local_hsm().start() {
-        // Handle HSM Start
         Ok(next_stage) => {
-            ipi::clear_msip();
+            ipi::claim_ipi();
             unsafe {
                 mstatus::set_mpie();
                 mstatus::set_mpp(next_stage.next_mode);
                 mie::set_msoft();
-                mie::set_mtimer();
+                if !hart_extension_probe(current_hartid(), Extension::Sstc) {
+                    mie::set_mtimer();
+                }
             }
             boot(ctx, next_stage.start_addr, next_stage.opaque);
         }
-        // Handle HSM Stop
         Err(rustsbi::spec::hsm::HART_STOP) => {
-            ipi::clear_msip();
+            ipi::claim_ipi();
             unsafe {
                 mie::set_msoft();
             }
@@ -76,11 +85,10 @@ pub extern "C" fn boot_handler(ctx: &mut BootContext) {
     }
 }
 
-/// Boot context structure containing saved register state.
 #[derive(Debug)]
 #[repr(C)]
 pub struct BootContext {
-    pub mepc: usize, // 0
+    pub mepc: usize,
     pub a0: usize,
-    pub a1: usize, // 2
+    pub a1: usize,
 }

--- a/prototyper/prototyper/src/sbi/trap/handler.rs
+++ b/prototyper/prototyper/src/sbi/trap/handler.rs
@@ -8,6 +8,7 @@ use crate::platform::PLATFORM;
 use crate::riscv::csr::{CSR_TIME, CSR_TIMEH};
 use crate::riscv::current_hartid;
 use crate::sbi::console;
+use crate::sbi::features::{Extension, hart_extension_probe};
 use crate::sbi::hsm::local_hsm;
 use crate::sbi::ipi;
 use crate::sbi::pmu::pmu_firmware_counter_increment;
@@ -16,8 +17,26 @@ use crate::sbi::rfence;
 use super::helper::*;
 
 #[inline]
+fn enable_mtimer_if_no_sstc() {
+    if !hart_extension_probe(current_hartid(), Extension::Sstc) {
+        unsafe {
+            mie::set_mtimer();
+        }
+    }
+}
+
+#[inline]
 pub fn switch(mut ctx: FastContext, start_addr: usize, opaque: usize) -> FastResult {
     unsafe {
+        // stvec BASE is four-byte aligned; HSM entry points may only be two-byte aligned.
+        if start_addr & 0x3 == 0 {
+            core::arch::asm!(
+                "csrw stvec, {start_addr}",
+                start_addr = in(reg) start_addr,
+                options(nomem),
+            );
+        }
+        core::arch::asm!("csrw sscratch, zero", "csrw sie, zero", options(nomem),);
         sstatus::clear_sie();
         satp::write(satp::Satp::from_bits(0));
     }
@@ -28,20 +47,17 @@ pub fn switch(mut ctx: FastContext, start_addr: usize, opaque: usize) -> FastRes
     ctx.call(2)
 }
 
-/// Handle machine software inter-processor interrupts.
 #[inline]
 pub fn msoft_ipi_handler() {
     use ipi::get_and_reset_ipi_type;
-    ipi::clear_msip();
+    ipi::claim_ipi();
     let ipi_type = get_and_reset_ipi_type();
-    // Handle supervisor software interrupt
     if (ipi_type & ipi::IPI_TYPE_SSOFT) != 0 {
         pmu_firmware_counter_increment(firmware_event::IPI_RECEIVED);
         unsafe {
             riscv::register::mip::set_ssoft();
         }
     }
-    // Handle fence operation
     if (ipi_type & ipi::IPI_TYPE_FENCE) != 0 {
         rfence::rfence_handler();
     }
@@ -50,32 +66,77 @@ pub fn msoft_ipi_handler() {
 #[inline]
 pub fn msoft_handler(ctx: FastContext) -> FastResult {
     match local_hsm().start() {
-        // Handle HSM Start
         Ok(next_stage) => {
-            ipi::clear_msip();
+            ipi::claim_ipi();
             unsafe {
                 mstatus::set_mpie();
                 mstatus::set_mpp(next_stage.next_mode);
                 mie::set_msoft();
-                mie::set_mtimer();
             }
+            enable_mtimer_if_no_sstc();
             switch(ctx, next_stage.start_addr, next_stage.opaque)
         }
-        // Handle HSM Stop
         Err(rustsbi::spec::hsm::HART_STOP) => {
-            ipi::clear_msip();
+            ipi::claim_ipi();
             unsafe {
                 mie::set_msoft();
             }
             riscv::asm::wfi();
             ctx.restore()
         }
-        // Handle IPI and RFence
         _ => {
             msoft_ipi_handler();
             ctx.restore()
         }
     }
+}
+
+#[inline]
+pub fn mext_handler(ctx: FastContext) -> FastResult {
+    use ipi::get_and_reset_ipi_type;
+
+    let iid = crate::platform::aia::mtopei_claim();
+
+    let firmware_ipi_iid = unsafe { PLATFORM.info.aia.as_ref().map(|a| a.firmware_ipi_iid) };
+
+    match iid {
+        Some(id) if firmware_ipi_iid.is_some_and(|fw| fw == id) => match local_hsm().start() {
+            Ok(next_stage) => {
+                unsafe {
+                    mstatus::set_mpie();
+                    mstatus::set_mpp(next_stage.next_mode);
+                    mie::set_msoft();
+                    mie::set_mext();
+                }
+                enable_mtimer_if_no_sstc();
+                return switch(ctx, next_stage.start_addr, next_stage.opaque);
+            }
+            Err(rustsbi::spec::hsm::HART_STOP) => {
+                unsafe {
+                    mie::set_mext();
+                }
+                riscv::asm::wfi();
+                return ctx.restore();
+            }
+            _ => {
+                let ipi_type = get_and_reset_ipi_type();
+                if (ipi_type & ipi::IPI_TYPE_SSOFT) != 0 {
+                    pmu_firmware_counter_increment(firmware_event::IPI_RECEIVED);
+                    unsafe {
+                        riscv::register::mip::set_ssoft();
+                    }
+                }
+                if (ipi_type & ipi::IPI_TYPE_FENCE) != 0 {
+                    rfence::rfence_handler();
+                }
+            }
+        },
+        Some(id) => {
+            warn!("MachineExternal: unexpected IID {}", id.number());
+        }
+        None => {}
+    }
+    ctx.restore()
 }
 
 #[inline]
@@ -98,17 +159,17 @@ pub fn sbi_call_handler(
     };
     if ret.is_ok() {
         match (a7, a6) {
-            // Handle non-retentive suspend
             (hsm::EID_HSM, hsm::HART_SUSPEND)
                 if matches!(ctx.a0() as u32, hsm::suspend_type::NON_RETENTIVE) =>
             {
                 return switch(ctx, a1, a2);
             }
-            // Handle legacy console probe
             (base::EID_BASE, base::PROBE_EXTENSION)
                 if matches!(
                     ctx.a0(),
-                    legacy::LEGACY_CONSOLE_PUTCHAR | legacy::LEGACY_CONSOLE_GETCHAR
+                    legacy::LEGACY_SET_TIMER
+                        | legacy::LEGACY_CONSOLE_PUTCHAR
+                        | legacy::LEGACY_CONSOLE_GETCHAR
                 ) =>
             {
                 ret.value = 1;
@@ -117,6 +178,13 @@ pub fn sbi_call_handler(
         }
     } else {
         match a7 {
+            legacy::LEGACY_SET_TIMER => {
+                if let Some(ipi) = unsafe { PLATFORM.sbi.ipi.as_ref() } {
+                    rustsbi::Timer::set_timer(ipi, ctx.a0() as u64);
+                    ret.error = 0;
+                    ret.value = a1;
+                }
+            }
             legacy::LEGACY_CONSOLE_PUTCHAR => {
                 ret.error = console::putchar(ctx.a0());
                 ret.value = a1;
@@ -134,7 +202,6 @@ pub fn sbi_call_handler(
     ctx.restore()
 }
 
-/// Delegate trap handling to supervisor mode.
 #[inline]
 pub fn delegate(ctx: &mut EntireContextSeparated) {
     use riscv::register::{mcause, scause, sepc, sstatus, stval, stvec};
@@ -153,7 +220,6 @@ pub fn delegate(ctx: &mut EntireContextSeparated) {
     }
 }
 
-/// Handle illegal instructions, particularly CSR access.
 #[inline]
 pub extern "C" fn illegal_instruction_handler(raw_ctx: EntireContext) -> EntireResult {
     let mut ctx = raw_ctx.split().0;
@@ -205,8 +271,6 @@ pub extern "C" fn load_misaligned_handler(ctx: EntireContext) -> EntireResult {
     );
     let decode_result = decode(current_inst as u32);
 
-    // TODO: INST FLD c.*sp
-    // TODO: maybe can we reduce the time to update csr for read virtual-address.
     let inst_type = match decode_result {
         Ok(Instruction::Lb(data)) => (data.rd(), VarType::Signed, 1),
         Ok(Instruction::Lbu(data)) => (data.rd(), VarType::UnSigned, 1),
@@ -269,8 +333,6 @@ pub extern "C" fn store_misaligned_handler(ctx: EntireContext) -> EntireResult {
 
     let decode_result = decode(current_inst as u32);
 
-    // TODO: INST FSD c.*sp
-    // TODO: maybe can we reduce the time to update csr for read virtual-address.
     let inst_type = match decode_result {
         Ok(Instruction::Sb(data)) => (data.rs2(), VarType::UnSigned, 1),
         Ok(Instruction::Sh(data)) => (data.rs2(), VarType::UnSigned, 2),

--- a/prototyper/prototyper/src/sbi/trap/handler.rs
+++ b/prototyper/prototyper/src/sbi/trap/handler.rs
@@ -164,16 +164,15 @@ pub fn sbi_call_handler(
             {
                 return switch(ctx, a1, a2);
             }
-            (base::EID_BASE, base::PROBE_EXTENSION)
-                if matches!(
-                    ctx.a0(),
-                    legacy::LEGACY_SET_TIMER
-                        | legacy::LEGACY_CONSOLE_PUTCHAR
-                        | legacy::LEGACY_CONSOLE_GETCHAR
-                ) =>
-            {
-                ret.value = 1;
-            }
+            (base::EID_BASE, base::PROBE_EXTENSION) => match ctx.a0() {
+                legacy::LEGACY_SET_TIMER => {
+                    ret.value = unsafe { PLATFORM.sbi.ipi.is_some() } as usize;
+                }
+                legacy::LEGACY_CONSOLE_PUTCHAR | legacy::LEGACY_CONSOLE_GETCHAR => {
+                    ret.value = 1;
+                }
+                _ => {}
+            },
             _ => {}
         }
     } else {

--- a/prototyper/prototyper/src/sbi/trap/handler.rs
+++ b/prototyper/prototyper/src/sbi/trap/handler.rs
@@ -95,12 +95,24 @@ pub fn msoft_handler(ctx: FastContext) -> FastResult {
 pub fn mext_handler(ctx: FastContext) -> FastResult {
     use ipi::get_and_reset_ipi_type;
 
+    if !crate::platform::aia::is_aia_active()
+        || !hart_extension_probe(current_hartid(), Extension::Smaia)
+    {
+        warn!("MachineExternal: AIA is not available on this hart");
+        return ctx.restore();
+    }
+
+    let Some(firmware_ipi_iid) =
+        (unsafe { PLATFORM.info.aia.as_ref().map(|a| a.firmware_ipi_iid) })
+    else {
+        warn!("MachineExternal: missing AIA platform info");
+        return ctx.restore();
+    };
+
     let iid = crate::platform::aia::mtopei_claim();
 
-    let firmware_ipi_iid = unsafe { PLATFORM.info.aia.as_ref().map(|a| a.firmware_ipi_iid) };
-
     match iid {
-        Some(id) if firmware_ipi_iid.is_some_and(|fw| fw == id) => match local_hsm().start() {
+        Some(id) if firmware_ipi_iid == id => match local_hsm().start() {
             Ok(next_stage) => {
                 unsafe {
                     mstatus::set_mpie();

--- a/prototyper/prototyper/src/sbi/trap/mod.rs
+++ b/prototyper/prototyper/src/sbi/trap/mod.rs
@@ -63,19 +63,25 @@ fn handle_interrupt(
             handler::msoft_handler(ctx)
         }
         Interrupt::MachineTimer => {
+            use crate::riscv::current_hartid;
+            use crate::sbi::features::{Extension, hart_extension_probe};
             use crate::sbi::ipi;
 
-            ipi::clear_mtime();
             unsafe {
-                mip::set_stimer();
+                riscv::register::mie::clear_mtimer();
+            }
+            if !hart_extension_probe(current_hartid(), Extension::Sstc) {
+                ipi::clear_mtime();
+                unsafe {
+                    mip::set_stimer();
+                }
             }
             save_regs(&mut ctx);
             ctx.restore()
         }
-        // TODO: Handle MachineExternal
         Interrupt::MachineExternal => {
-            error!("TODO: Unhandled MachineExternal interrupt");
-            unsupported_trap(Some(Trap::Interrupt(interrupt)))
+            save_regs(&mut ctx);
+            handler::mext_handler(ctx)
         }
         _ => {
             error!("Unhandled interrupt: {:?}", interrupt);

--- a/prototyper/test-kernel/src/main.rs
+++ b/prototyper/test-kernel/src/main.rs
@@ -106,8 +106,8 @@ extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
     };
     let test_result = testing.test();
 
-    pmu_test();
-    fence_test();
+    pmu_test(smp);
+    fence_test(hartid, smp);
 
     if test_result {
         sbi::system_reset(sbi::Shutdown, sbi::NoReason);
@@ -119,7 +119,8 @@ extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
 
 #[inline]
 // PMU test, only available in qemu-system-riscv64 single core
-fn pmu_test() {
+fn pmu_test(smp: usize) {
+    let invalid_hart = smp + 1;
     let counters_num = sbi::pmu_num_counters();
     println!("[pmu] counters number: {}", counters_num);
     for idx in 0..counters_num {
@@ -153,11 +154,12 @@ fn pmu_test() {
     // `SBI_PMU_HW_CPU_CYCLES` event test
     let result = sbi::pmu_counter_config_matching(counter_mask, Flag::new(0b010), 0x1, 0);
     assert!(result.is_ok());
-    // the counter index should be 0(mcycle)
-    assert_eq!(result.value, 0);
     let cycle_counter_idx = result.value;
-    let cycle_num = cycle::read64();
-    assert_eq!(cycle_num, 0);
+    let counter_info = sbi::pmu_counter_get_info(cycle_counter_idx);
+    assert!(counter_info.is_ok());
+    let counter_info = CounterInfo::new(counter_info.value);
+    assert!(!counter_info.is_firmware_counter());
+    let cycle_counter_csr = counter_info.get_csr();
     // Start counting `SBI_PMU_HW_CPU_CYCLES` events
     let start_result = sbi::pmu_counter_start(
         CounterMask::from_mask_base(0x1, cycle_counter_idx),
@@ -165,7 +167,7 @@ fn pmu_test() {
         0xffff,
     );
     assert!(start_result.is_ok());
-    let cycle_num = cycle::read64();
+    let cycle_num = read_pmu_hardware_counter(cycle_counter_csr);
     assert!(cycle_num >= 0xffff);
     // Stop counting `SBI_PMU_HW_CPU_CYCLES` events
     let stop_result = sbi::pmu_counter_stop(
@@ -177,7 +179,7 @@ fn pmu_test() {
     for i in 0..1000 {
         _j += i
     }
-    let stopped_cycle_num = cycle::read64();
+    let stopped_cycle_num = read_pmu_hardware_counter(cycle_counter_csr);
     // Restart counting `SBI_PMU_HW_CPU_CYCLES` events
     let start_result = sbi::pmu_counter_start(
         CounterMask::from_mask_base(0x1, cycle_counter_idx),
@@ -189,7 +191,7 @@ fn pmu_test() {
     for i in 0..1000 {
         _j += i
     }
-    let restart_cycle_num = cycle::read64();
+    let restart_cycle_num = read_pmu_hardware_counter(cycle_counter_csr);
     assert!(restart_cycle_num > stopped_cycle_num);
 
     /* PMU test for firmware  event */
@@ -231,8 +233,8 @@ fn pmu_test() {
     assert!(ipi_num.is_ok());
     assert_eq!(ipi_num.value, 25);
 
-    // Send IPI to other core, and the `SBI_PMU_FW_IPI_SENT` event counter value increases by one
-    let send_ipi_result = sbi::send_ipi(HartMask::from_mask_base(0b10, 0));
+    // Send IPI to an invalid hart (beyond SMP count) - should return invalid_param
+    let send_ipi_result = sbi::send_ipi(HartMask::from_mask_base(0x1, invalid_hart));
     assert_eq!(send_ipi_result, SbiRet::invalid_param());
 
     // Read the value of the `SBI_PMU_FW_IPI_SENT` event counter, which should be 26
@@ -254,8 +256,8 @@ fn pmu_test() {
     );
     assert_eq!(stop_result, SbiRet::already_stopped());
 
-    // Send IPI to other core, `SBI_PMU_FW_IPI_SENT` event counter should not change
-    let send_ipi_result = sbi::send_ipi(HartMask::from_mask_base(0b10, 0));
+    // Send IPI to invalid hart, `SBI_PMU_FW_IPI_SENT` event counter should not change
+    let send_ipi_result = sbi::send_ipi(HartMask::from_mask_base(0x1, invalid_hart));
     assert_eq!(send_ipi_result, SbiRet::invalid_param());
 
     // Read the value of the `SBI_PMU_FW_IPI_SENT` event counter, which should be 26
@@ -271,8 +273,8 @@ fn pmu_test() {
     );
     assert!(start_result.is_ok());
 
-    // Send IPI to other core, and the `SBI_PMU_FW_IPI_SENT` event counter value increases by one
-    let send_ipi_result = sbi::send_ipi(HartMask::from_mask_base(0b10, 0));
+    // Send IPI to an invalid hart (beyond SMP count) - should return invalid_param
+    let send_ipi_result = sbi::send_ipi(HartMask::from_mask_base(0x1, invalid_hart));
     assert_eq!(send_ipi_result, SbiRet::invalid_param());
 
     // Read the value of the `SBI_PMU_FW_IPI_SENT` event counter, which should be 27
@@ -282,38 +284,82 @@ fn pmu_test() {
 }
 
 #[inline]
+fn read_pmu_hardware_counter(csr_num: usize) -> u64 {
+    match csr_num {
+        0xc00 => cycle::read64(),
+        0xc01 => riscv::register::time::read64(),
+        0xc02 => riscv::register::instret::read64(),
+        0xc03 => riscv::register::hpmcounter3::read64(),
+        0xc04 => riscv::register::hpmcounter4::read64(),
+        0xc05 => riscv::register::hpmcounter5::read64(),
+        0xc06 => riscv::register::hpmcounter6::read64(),
+        0xc07 => riscv::register::hpmcounter7::read64(),
+        0xc08 => riscv::register::hpmcounter8::read64(),
+        0xc09 => riscv::register::hpmcounter9::read64(),
+        0xc0a => riscv::register::hpmcounter10::read64(),
+        0xc0b => riscv::register::hpmcounter11::read64(),
+        0xc0c => riscv::register::hpmcounter12::read64(),
+        0xc0d => riscv::register::hpmcounter13::read64(),
+        0xc0e => riscv::register::hpmcounter14::read64(),
+        0xc0f => riscv::register::hpmcounter15::read64(),
+        0xc10 => riscv::register::hpmcounter16::read64(),
+        0xc11 => riscv::register::hpmcounter17::read64(),
+        0xc12 => riscv::register::hpmcounter18::read64(),
+        0xc13 => riscv::register::hpmcounter19::read64(),
+        0xc14 => riscv::register::hpmcounter20::read64(),
+        0xc15 => riscv::register::hpmcounter21::read64(),
+        0xc16 => riscv::register::hpmcounter22::read64(),
+        0xc17 => riscv::register::hpmcounter23::read64(),
+        0xc18 => riscv::register::hpmcounter24::read64(),
+        0xc19 => riscv::register::hpmcounter25::read64(),
+        0xc1a => riscv::register::hpmcounter26::read64(),
+        0xc1b => riscv::register::hpmcounter27::read64(),
+        0xc1c => riscv::register::hpmcounter28::read64(),
+        0xc1d => riscv::register::hpmcounter29::read64(),
+        0xc1e => riscv::register::hpmcounter30::read64(),
+        0xc1f => riscv::register::hpmcounter31::read64(),
+        _ => panic!("unsupported hardware counter CSR {csr_num:#x}"),
+    }
+}
+
+#[inline]
 // Fence and HFence test
-fn fence_test() {
+fn fence_test(hartid: usize, smp: usize) {
+    let self_mask = HartMask::from_mask_base(0x1, hartid);
+
     // Fence.i test (should succeed, no-op for PMU, but should not panic)
-    let ret = sbi::remote_fence_i(HartMask::from_mask_base(0x1, 0));
+    let ret = sbi::remote_fence_i(self_mask);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
 
-    let ret = sbi::remote_fence_i(HartMask::from_mask_base(0x2, 0));
+    let invalid_hart = smp + 1;
+    let ret = sbi::remote_fence_i(HartMask::from_mask_base(0x1, invalid_hart));
     assert_eq!(ret, SbiRet::invalid_param());
 
     // SFence.vma test (should succeed, no-op for PMU, but should not panic)
-    let ret = sbi::remote_sfence_vma(HartMask::from_mask_base(0x1, 0), 0, 0);
+    let ret = sbi::remote_sfence_vma(self_mask, 0, 0);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
 
-    let ret = sbi::remote_sfence_vma(HartMask::from_mask_base(0x2, 0), 0, 0);
+    let ret = sbi::remote_sfence_vma(HartMask::from_mask_base(0x1, invalid_hart), 0, 0);
     assert_eq!(ret, SbiRet::invalid_param());
 
     // SFence.vma with asid test
-    let ret = sbi::remote_sfence_vma_asid(HartMask::from_mask_base(0x1, 0), 0, 0, 0);
+    let ret = sbi::remote_sfence_vma_asid(self_mask, 0, 0, 0);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
 
     // HFence tests (if supported)
-    let ret = sbi::remote_hfence_gvma(HartMask::from_mask_base(0x1, 0), 0, 0);
+    let ret = sbi::remote_hfence_gvma(self_mask, 0, 0);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
 
-    let ret = sbi::remote_hfence_gvma_vmid(HartMask::from_mask_base(0x1, 0), 0, 0, 0);
+    let ret = sbi::remote_hfence_gvma_vmid(self_mask, 0, 0, 0);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
 
-    let ret = sbi::remote_hfence_vvma(HartMask::from_mask_base(0x1, 0), 0, 0);
+    let ret = sbi::remote_hfence_vvma(self_mask, 0, 0);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
 
-    let ret = sbi::remote_hfence_vvma_asid(HartMask::from_mask_base(0x1, 0), 0, 0, 0);
+    let ret = sbi::remote_hfence_vvma_asid(self_mask, 0, 0, 0);
     assert!(ret.is_ok() || ret == SbiRet::not_supported());
+
+    println!("[34m[ INFO] Sbi `RFNC` test pass[0m");
 }
 
 #[cfg_attr(not(test), panic_handler)]
@@ -453,7 +499,7 @@ struct CounterInfo {
 impl CounterInfo {
     const CSR_MASK: usize = 0xFFF; // Bits [11:0]
     const WIDTH_MASK: usize = 0x3F << 12; // Bits [17:12]
-    const FIRMWARE_FLAG: usize = 1 << (size_of::<usize>() * 8 - 1); // MSB
+    const FIRMWARE_FLAG: usize = 1 << (usize::BITS as usize - 1); // MSB
 
     #[inline]
     pub const fn new(counter_info: usize) -> Self {


### PR DESCRIPTION
## Summary

Add AIA (Advanced Interrupt Architecture) support to RustSBI Prototyper, enabling IMSIC-based IPI delivery on QEMU `virt,aia=aplic-imsic`.

- Refactor `IpiDevice` into `TimerBackend` + `IpiDoorbell` traits with claim semantics
- Add IMSIC FDT discovery with reg validation, hart-to-IMSIC address mapping, Smaia/Sstc enforcement
- Implement `MachineExternal` trap handler with atomic `mtopei` CSR swap
- Implement `ImsicDoorbell` (fence + MSI store for ring, mtopei swap for claim)
- Per-hart IMSIC initialization (eidelivery, eithreshold, eie, XLEN-aware)
- Disable M-level IMSIC node in DTB for Linux compatibility
- Fix test-kernel fence_test/pmu_test hart targeting for multi-hart
- Add remote RFence verification in sbi-testing HSM test

Based on RFC [#199](https://github.com/rustsbi/rustsbi/issues/199).

## Boot openEuler 25.09 with RustSBI + AIA

### Prerequisites

- QEMU 10.x with RISC-V support
- openEuler 25.09 RISC-V qcow2 image
- EDK2 RISC-V firmware (`RISCV_VIRT_CODE.fd`, `RISCV_VIRT_VARS.fd`)

### Build

```bash
# Configure for EDK2 pflash boot (pflash at 0x20000000)
cat > target/config.toml << 'EOF'
num_hart_max = 8
stack_size_per_hart = 16384
heap_size = 0x15000
page_size = 4096
log_level = "INFO"
jump_address = 0x80200000
tlb_flush_limit = 16384

[[next_addr]]
start = 0x20000000
end = 0x20200000

[[next_addr]]
start = 0x80000000
end = 0x90000000
EOF

# Build RustSBI Prototyper
cargo build --target riscv64gc-unknown-none-elf --release -p rustsbi-prototyper
```

### Run

```bash
qemu-system-riscv64 \
  -nographic \
  -machine virt,pflash0=pflash0,pflash1=pflash1,acpi=off,aia=aplic-imsic \
  -smp 8 -m 8G \
  -bios target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper \
  -blockdev node-name=pflash0,driver=file,read-only=on,filename=RISCV_VIRT_CODE.fd \
  -blockdev node-name=pflash1,driver=file,filename=RISCV_VIRT_VARS.fd \
  -drive file=openEuler-25.09-riscv64.qcow2,format=qcow2,id=hd0,if=none \
  -device virtio-blk-device,drive=hd0 \
  -device virtio-net-device,netdev=usernet \
  -netdev user,id=usernet,hostfwd=tcp::12055-:22
```

### Expected boot chain

```
RustSBI (M-mode, AIA/IMSIC) → EDK2 UEFI → GRUB 2.12 → openEuler 25.09 (Linux 6.6)
```

## Test plan

Verified on QEMU TCG:

| Configuration | Base | TIME | sPI | HSM | DBCN | RFNC |
|---|---|---|---|---|---|---|
| CLINT smp=1 | PASS | PASS | PASS | — | PASS | PASS |
| CLINT smp=4 | PASS | PASS | PASS | PASS | PASS | PASS |
| AIA smp=1 | PASS | PASS | PASS | — | PASS | PASS |
| AIA smp=2 | PASS | PASS | PASS | PASS | PASS | PASS |
| AIA smp=4 | PASS | PASS | PASS | PASS | PASS | PASS |

CLINT bench-kernel smp=4: Test #0-#3 complete.
Remote RFence verified through IMSIC doorbell on started remote harts (smp=2/4).