### PR TITLE
fix(arceboot): update ArceOS dependency for newer Rust

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,9 @@ arceboot = "xtask arceboot"
 prototyper = "xtask prototyper"
 test-kernel = "xtask test"
 bench-kernel = "xtask bench"
+
+[env]
+AX_CONFIG_PATH = { value = "arceboot/.axconfig.toml", relative = true }
+
+[target.riscv64gc-unknown-none-elf]
+rustflags = ["-Zcrate-attr=feature(core_io)", "-Aunused-features"]

--- a/arceboot/Cargo.toml
+++ b/arceboot/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Zhihang Shao <dio_ro@outlook.com>", "Jingxuan Wei <jensenwei007@gmai
 default = ["alloc", "fs", "paging", "virtiodisk"]
 
 alloc = ["axalloc"]
-paging = ["axhal/paging", "axmm"]
+paging = ["axhal/paging", "axhal/defplat", "axmm"]
 
 fs = ["axdriver", "axfs"]
 net = ["axdriver", "axnet"]
@@ -21,17 +21,19 @@ virtiodisk = ["axdriver/virtio-blk"]
 ramdisk_cpio = []
 
 [dependencies]
-axhal = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47" }
-axlog = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47" }
-axconfig = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47" }
-axsync = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47" }
-axalloc = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47", optional = true }
-axmm = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47", optional = true }
-axdriver = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47", optional = true, features = ["virtio-blk", "virtio-gpu"] }
-axfs = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47", optional = true }
-axnet = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47", optional = true }
-axdisplay = { git = "https://github.com/arceos-org/arceos.git", rev = "cde8c47", optional = true }
+axhal = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24" }
+axlog = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24" }
+axconfig = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24" }
+axsync = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24" }
+axalloc = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24", optional = true }
+axmm = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24", optional = true }
+axdriver = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24", optional = true, features = ["virtio-blk", "virtio-gpu"] }
+axfs = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24", optional = true }
+axnet = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24", optional = true }
+axdisplay = { git = "https://github.com/arceos-org/arceos.git", rev = "8f89bb24", optional = true }
+axplat = "0.4"
 axio = { version = "0.1", features = ["alloc"] }
+memory_addr = "0.4"
 
 crate_interface = "0.1"
 ctor_bare = "0.2"
@@ -40,9 +42,3 @@ object = { version = "0.37.1", default-features = false, features = [ "read", "p
 chrono = { version = "0.4.38", default-features = false }
 uefi-raw = "0.11.0"
 lazyinit = "0.2.2"
-
-# Pin transitive deps to avoid memory_addr version mismatch with axhal@cde8c47.
-# axhal@cde8c47 uses memory_addr 0.3.x, but page_table_multiarch >= 0.5.4 pulls
-# memory_addr 0.4.x which causes type conflicts.
-page_table_multiarch = "=0.5.3"
-page_table_entry = "=0.5.3"

--- a/arceboot/configs/platforms/riscv64-qemu-virt.toml
+++ b/arceboot/configs/platforms/riscv64-qemu-virt.toml
@@ -2,6 +2,8 @@
 arch = "riscv64"                    # str
 # Platform identifier.
 platform = "riscv64-qemu-virt"      # str
+# Platform package.
+package = "axplat-riscv64-qemu-virt" # str
 
 #
 # Platform configs
@@ -9,11 +11,17 @@ platform = "riscv64-qemu-virt"      # str
 [plat]
 # Platform family.
 family = "riscv64-qemu-virt"        # str
+# Maximum number of CPUs.
+max-cpu-num = 1                      # uint
+# Stack size on bootstrapping. (256K)
+boot-stack-size = 0x40000            # uint
 
 # Base address of the whole physical memory.
 phys-memory-base = 0x8000_0000      # uint
 # Size of the whole physical memory. (128M)
 phys-memory-size = 0x800_0000       # uint
+# End address of the whole physical memory.
+phys-memory-end = 0x8800_0000       # uint
 # Base physical address of the kernel image.
 kernel-base-paddr = 0x8020_0000     # uint
 # Base virtual address of the kernel image.
@@ -33,8 +41,8 @@ kernel-aspace-size = "0x0000_003f_ffff_f000"    # uint
 # Device specifications
 #
 [devices]
-# MMIO regions with format (`base_paddr`, `size`).
-mmio-regions = [
+# MMIO ranges with format (`base_paddr`, `size`).
+mmio-ranges = [
     [0x0010_1000, 0x1000],          # RTC
     [0x0c00_0000, 0x21_0000],       # PLIC
     [0x1000_0000, 0x1000],          # UART
@@ -42,8 +50,8 @@ mmio-regions = [
     [0x3000_0000, 0x1000_0000],     # PCI config space
     [0x4000_0000, 0x4000_0000],     # PCI memory ranges (ranges 1: 32-bit MMIO space)
 ]                                   # [(uint, uint)]
-# VirtIO MMIO regions with format (`base_paddr`, `size`).
-virtio-mmio-regions = [
+# VirtIO MMIO ranges with format (`base_paddr`, `size`).
+virtio-mmio-ranges = [
     [0x1000_1000, 0x1000],
     [0x1000_2000, 0x1000],
     [0x1000_3000, 0x1000],
@@ -66,6 +74,10 @@ pci-ranges = [
 
 # Timer interrupt frequency in Hz.
 timer-frequency = 10_000_000        # uint
+# Timer interrupt number.
+timer-irq = "0x8000_0000_0000_0005" # uint
+# IPI interrupt number.
+ipi-irq = "0x8000_0000_0000_0001"   # uint
 
 # rtc@101000 {
 #     interrupts = <0x0b>;

--- a/arceboot/src/main.rs
+++ b/arceboot/src/main.rs
@@ -16,12 +16,17 @@ mod panic;
 mod runtime;
 mod shell;
 
-#[cfg_attr(not(test), unsafe(no_mangle))]
-pub extern "C" fn rust_main(_cpu_id: usize, dtb: usize) -> ! {
+#[cfg_attr(not(test), axplat::main)]
+pub fn rust_main(cpu_id: usize, dtb: usize) -> ! {
+    unsafe { axhal::mem::clear_bss() };
+    axhal::init_percpu(cpu_id);
+    axhal::init_early(cpu_id, dtb);
+
     axlog::init();
     axlog::set_max_level(option_env!("AX_LOG").unwrap_or("")); // no effect if set `log-level-*` features
     info!("Logging is enabled.");
 
+    axhal::mem::init();
     info!("Found physcial memory regions:");
     for r in axhal::mem::memory_regions() {
         info!(
@@ -40,7 +45,7 @@ pub extern "C" fn rust_main(_cpu_id: usize, dtb: usize) -> ! {
     axmm::init_memory_management();
 
     info!("Initialize platform devices...");
-    axhal::platform_init();
+    axhal::init_later(cpu_id, dtb);
 
     #[cfg(any(feature = "fs", feature = "net", feature = "display"))]
     {
@@ -60,12 +65,10 @@ pub extern "C" fn rust_main(_cpu_id: usize, dtb: usize) -> ! {
     }
     ctor_bare::call_ctors();
 
-    // Set to DTB_ADDRESS
     unsafe {
         dtb::GLOBAL_NOW_DTB_ADDRESS = phys_to_virt(PhysAddr::from_usize(dtb)).as_usize();
     }
 
-    // ramdisk check
     #[cfg(feature = "ramdisk_cpio")]
     crate::medium::ramdisk_cpio::check_ramdisk();
 
@@ -73,7 +76,7 @@ pub extern "C" fn rust_main(_cpu_id: usize, dtb: usize) -> ! {
 
     info!("will shut down.");
 
-    axhal::misc::terminate();
+    axhal::power::system_off();
 }
 
 fn init_allocator() {

--- a/arceboot/src/panic.rs
+++ b/arceboot/src/panic.rs
@@ -3,5 +3,5 @@ use core::panic::PanicInfo;
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     error!("{}", info);
-    axhal::misc::terminate()
+    axhal::power::system_off()
 }

--- a/arceboot/src/runtime/service/boot_service.rs
+++ b/arceboot/src/runtime/service/boot_service.rs
@@ -368,11 +368,14 @@ pub unsafe extern "efiapi" fn locate_protocol(
 ) -> Status {
     Status::UNSUPPORTED
 }
-pub unsafe extern "C" fn install_multiple_protocol_interfaces(_handle: *mut Handle, ...) -> Status {
+pub unsafe extern "C" fn install_multiple_protocol_interfaces(
+    _handle: *mut Handle,
+    _: ...
+) -> Status {
     Status::UNSUPPORTED
 }
 
-pub unsafe extern "C" fn uninstall_multiple_protocol_interfaces(_handle: Handle, ...) -> Status {
+pub unsafe extern "C" fn uninstall_multiple_protocol_interfaces(_handle: Handle, _: ...) -> Status {
     Status::UNSUPPORTED
 }
 

--- a/arceboot/src/runtime/service/memory.rs
+++ b/arceboot/src/runtime/service/memory.rs
@@ -1,9 +1,10 @@
 use alloc::vec::Vec;
 use axhal::{
-    mem::{MemoryAddr, PhysAddr, VirtAddr},
+    mem::{PhysAddr, VirtAddr},
     paging::MappingFlags,
 };
 use axsync::Mutex;
+use memory_addr::MemoryAddr;
 use uefi_raw::table::boot::MemoryType;
 
 static ALLOCATED_PAGES: Mutex<Vec<(VirtAddr, usize)>> = Mutex::new(Vec::new());

--- a/arceboot/src/shell/cmd.rs
+++ b/arceboot/src/shell/cmd.rs
@@ -37,7 +37,7 @@ fn do_help(_args: &str) {
 
 fn do_exit(_args: &str) {
     axlog::ax_println!("======== ArceBoot will exit and shut down ========");
-    axhal::misc::terminate();
+    axhal::power::system_off();
 }
 
 fn do_env(_args: &str) {

--- a/xtask/src/arceboot.rs
+++ b/xtask/src/arceboot.rs
@@ -152,7 +152,7 @@ fn generate_config(arceboot_dir: &Path, arg: &ArcebootArg) -> Option<PathBuf> {
     let status = Command::new("axconfig-gen")
         .arg(defconfig.to_string_lossy().as_ref())
         .arg(plat_config.to_string_lossy().as_ref())
-        .args(["-w", &format!("smp={}", arg.smp)])
+        .args(["-w", &format!("plat.max-cpu-num={}", arg.smp)])
         .args(["-w", &format!("arch=\"{}\"", arch)])
         .args(["-w", &format!("platform=\"{}\"", arg.platform)])
         .args(["-o", out_config.to_string_lossy().as_ref()])
@@ -189,7 +189,7 @@ fn build_arceboot(
 ) -> Option<ExitStatus> {
     let linker_script = arceboot_dir.join("link.ld");
     let rustflags = format!(
-        "-C opt-level=z -C panic=abort -C relocation-model=static -C target-cpu=generic -C link-arg=-T{}",
+        "-Zcrate-attr=feature(core_io) -Aunused-features -C opt-level=z -C panic=abort -C relocation-model=static -C target-cpu=generic -C link-arg=-T{}",
         linker_script.display()
     );
 


### PR DESCRIPTION
## Summary

- Update ArceBoot's pinned ArceOS revision from `cde8c47` to `8f89bb24`.
- Adapt ArceBoot to the newer ArceOS/axhal initialization APIs:
  - use `axplat::main`
  - initialize `axhal` with `init_percpu`, `init_early`, `mem::init`, and `init_later`
  - replace `axhal::misc::terminate()` with `axhal::power::system_off()`
- Align the RISC-V QEMU platform config with `axplat-riscv64-qemu-virt` 0.4.x:
  - `package = "axplat-riscv64-qemu-virt"`
  - `plat.max-cpu-num`
  - `mmio-ranges`
  - `virtio-mmio-ranges`
  - CPU-side timer/IPI IRQ values
- Add the target-specific rustflags needed for direct `cargo clippy -p arceboot --target riscv64gc-unknown-none-elf` in CI.

## Why

The old ArceOS revision `cde8c47` uses `#![feature(doc_auto_cfg)]` in `axhal`.
That feature was removed in Rust 1.92, causing ArceBoot CI to fail before
ArceBoot itself can build.

I checked an intermediate ArceOS revision, `900a3104`, and it still contains
`doc_auto_cfg`. The selected revision, `8f89bb24`, no longer contains that
feature while remaining close enough to require a limited API/config migration.

## Test

- `cargo fmt --check -p arceboot`
- `cargo xtask arceboot`
- `cargo clippy -p arceboot --target riscv64gc-unknown-none-elf`
- `cargo xtask arceboot --payload`

