### PR TITLE
ci(arceboot): test OpenSBI and RustSBI

### DIFF
--- a/.github/workflows/arceboot.yml
+++ b/.github/workflows/arceboot.yml
@@ -52,11 +52,13 @@ jobs:
   integration-test:
     name: QEMU integration tests (${{ matrix.bios_name }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         include:
-          - bios_name: qemu-opensbi
+          - bios_name: qemu-default
             bios_path: default
             bios_banner: OpenSBI
           - bios_name: rustsbi-v0.4.1
@@ -76,6 +78,7 @@ jobs:
           repository: rustsbi/rustsbi
           ref: 1e10645e9a3cc6230988b037df506f97310555b7
           path: firmware/rustsbi-v0.4.1
+          persist-credentials: false
 
       - name: Install required cargo
         run: |

--- a/.github/workflows/arceboot.yml
+++ b/.github/workflows/arceboot.yml
@@ -50,11 +50,32 @@ jobs:
           wait-for-processing: true
 
   integration-test:
-    name: QEMU integration tests
+    name: QEMU integration tests (${{ matrix.bios_name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - bios_name: qemu-opensbi
+            bios_path: default
+            bios_banner: OpenSBI
+          - bios_name: rustsbi-v0.4.1
+            bios_path: firmware/rustsbi-v0.4.1/target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper-dynamic.elf
+            bios_banner: "[RustSBI]"
+    env:
+      QEMU_BIOS: ${{ matrix.bios_path }}
+      BIOS_BANNER: ${{ matrix.bios_banner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Checkout pinned RustSBI v0.4.1
+        if: matrix.bios_name == 'rustsbi-v0.4.1'
+        uses: actions/checkout@v4
+        with:
+          repository: rustsbi/rustsbi
+          ref: 1e10645e9a3cc6230988b037df506f97310555b7
+          path: firmware/rustsbi-v0.4.1
 
       - name: Install required cargo
         run: |
@@ -66,6 +87,14 @@ jobs:
 
       - name: Build ArceBoot
         run: cargo xtask arceboot
+
+      - name: Build pinned RustSBI dynamic firmware
+        if: matrix.bios_name == 'rustsbi-v0.4.1'
+        working-directory: firmware/rustsbi-v0.4.1
+        run: |
+          rustup target add riscv64gc-unknown-none-elf
+          cargo prototyper --target riscv64gc-unknown-none-elf
+          test -s target/riscv64gc-unknown-none-elf/release/rustsbi-prototyper-dynamic.elf
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -105,7 +134,7 @@ jobs:
         run: |
           timeout 60 qemu-system-riscv64 \
             -m 128M -serial mon:stdio -nographic -machine virt \
-            -bios default \
+            -bios "$QEMU_BIOS" \
             -kernel target/riscv64gc-unknown-none-elf/release/arceboot.bin \
             -device virtio-blk-pci,drive=disk0 \
             -drive id=disk0,if=none,format=raw,file=arceboot/disk.img \
@@ -114,8 +143,11 @@ jobs:
       - name: Upload QEMU log (HelloRiscv)
         uses: actions/upload-artifact@v4
         with:
-          name: log-hello-riscv
+          name: log-${{ matrix.bios_name }}-hello-riscv
           path: arceboot/qemu-hello-riscv.log
+
+      - name: Check BIOS identity
+        run: grep -aqF "$BIOS_BANNER" arceboot/qemu-hello-riscv.log
 
       - name: Check QEMU output (HelloRiscv)
         run: bash arceboot/scripts/test/check_hello_test_riscv.sh
@@ -131,7 +163,7 @@ jobs:
         run: |
           timeout 60 qemu-system-riscv64 \
             -m 128M -serial mon:stdio -nographic -machine virt \
-            -bios default \
+            -bios "$QEMU_BIOS" \
             -kernel target/riscv64gc-unknown-none-elf/release/arceboot.bin \
             -device virtio-blk-pci,drive=disk0 \
             -drive id=disk0,if=none,format=raw,file=arceboot/disk.img \
@@ -140,7 +172,7 @@ jobs:
       - name: Upload QEMU log (AllocatePage)
         uses: actions/upload-artifact@v4
         with:
-          name: log-allocate
+          name: log-${{ matrix.bios_name }}-allocate
           path: arceboot/qemu-allocate.log
 
       - name: Check QEMU output (AllocatePage)
@@ -157,7 +189,7 @@ jobs:
         run: |
           timeout 60 qemu-system-riscv64 \
             -m 128M -serial mon:stdio -nographic -machine virt \
-            -bios default \
+            -bios "$QEMU_BIOS" \
             -kernel target/riscv64gc-unknown-none-elf/release/arceboot.bin \
             -device virtio-blk-pci,drive=disk0 \
             -drive id=disk0,if=none,format=raw,file=arceboot/disk.img \
@@ -166,7 +198,7 @@ jobs:
       - name: Upload QEMU log (Hello)
         uses: actions/upload-artifact@v4
         with:
-          name: log-hello
+          name: log-${{ matrix.bios_name }}-hello
           path: arceboot/qemu-hello.log
 
       - name: Check QEMU output (Hello)


### PR DESCRIPTION
Closes #228

ArceBoot's three QEMU integration cases currently run only with `-bios default`, which selects QEMU's bundled OpenSBI. This adds a two-entry firmware matrix so the same `arceboot.bin` is exercised with both OpenSBI and RustSBI.

The RustSBI entry checks out the v0.4.1 source at commit `1e10645e9a3cc6230988b037df506f97310555b7` and builds its dynamic firmware. It does not build the Prototyper from the PR checkout: PR #225 deliberately removed that dependency so changes under `library/**` and `prototyper/**` would not become hidden inputs to this workflow again.

The workflow also:

- gives each matrix entry distinct log artifact names;
- checks the first QEMU log for the expected firmware banner; and
- keeps `fail-fast` disabled so one firmware result does not hide the other.

## Validation

- `actionlint` with `shellcheck` enabled
- `cargo fmt --check -p arceboot`
- `cargo xtask arceboot`
- `cargo prototyper --target riscv64gc-unknown-none-elf` at the pinned RustSBI commit
- QEMU 11.1.0 smoke runs with OpenSBI and RustSBI v0.4.1: both found one FAT block device and reached ArceBoot's autoboot path; RustSBI redirected hart 0 to `0x80200000` in Supervisor mode

The full `HelloRiscv`, `AllocatePage`, and `Hello` cases were not reproduced locally because their setup script downloads an Ubuntu cross-toolchain and uses Linux loop mounts. This PR is left as a draft for the matrix jobs to run those cases on the GitHub runner.

## AI-assisted work

Codex was used to help draft and test this workflow change. The resulting single-file diff was reviewed with the checks listed above, including real QEMU runs for both firmware paths.

Related context: https://github.com/rustsbi/rustsbi/pull/225#discussion_r3801761172
