### PR TITLE
refactor(prototyper): decouple board discovery from the SBI extension set

### DIFF
--- a/.github/scripts/prototyper-qemu-boot.sh
+++ b/.github/scripts/prototyper-qemu-boot.sh
@@ -71,6 +71,14 @@ run_once() {
   grep -F 'Hello RustSBI!' "$log_file" || return 1
   grep -F "Platform HART Count           : $smp" "$log_file" || return 1
 
+  # Dispatcher-backed extension wiring: these lines render from the
+  # published SBI_DISPATCHER (presence chains + Once publish). A missing
+  # line means an extension was silently dropped during boot assembly.
+  grep -F 'Platform HSM Extension        : Available' "$log_file" || return 1
+  grep -F 'Platform RFence Extension     : Available' "$log_file" || return 1
+  grep -F 'Platform SUSP Extension       : Available' "$log_file" || return 1
+  grep -F 'Platform PMU Extension        : Available' "$log_file" || return 1
+
   # Boot-policy order guard: the boot-hart presentation sequence must
   # appear in phase order. A reorder or drop means the boot policy
   # changed even when every substring grep stays green.

--- a/.github/workflows/openeuler-aia.yml
+++ b/.github/workflows/openeuler-aia.yml
@@ -13,12 +13,7 @@ on:
       - "prototyper/prototyper/src/main.rs"
       - "prototyper/prototyper/src/platform/**"
       - "prototyper/prototyper/src/riscv/csr.rs"
-      - "prototyper/prototyper/src/sbi/features.rs"
-      - "prototyper/prototyper/src/sbi/hart_context.rs"
-      - "prototyper/prototyper/src/sbi/heap.rs"
-      - "prototyper/prototyper/src/sbi/hsm.rs"
-      - "prototyper/prototyper/src/sbi/ipi.rs"
-      - "prototyper/prototyper/src/sbi/trap/**"
+      - "prototyper/prototyper/src/sbi/**"
   push:
     branches: ["main"]
     paths:
@@ -31,12 +26,7 @@ on:
       - "prototyper/prototyper/src/main.rs"
       - "prototyper/prototyper/src/platform/**"
       - "prototyper/prototyper/src/riscv/csr.rs"
-      - "prototyper/prototyper/src/sbi/features.rs"
-      - "prototyper/prototyper/src/sbi/hart_context.rs"
-      - "prototyper/prototyper/src/sbi/heap.rs"
-      - "prototyper/prototyper/src/sbi/hsm.rs"
-      - "prototyper/prototyper/src/sbi/ipi.rs"
-      - "prototyper/prototyper/src/sbi/trap/**"
+      - "prototyper/prototyper/src/sbi/**"
   workflow_dispatch:
 
 env:

--- a/prototyper/prototyper/src/firmware/mod.rs
+++ b/prototyper/prototyper/src/firmware/mod.rs
@@ -239,7 +239,7 @@ pub fn patch_device_tree(device_tree_ptr: usize) -> usize {
             core::slice::from_raw_parts_mut(patched_dtb_buffer.as_ptr() as *mut u8, patched_length)
         };
         fdt_nop_m_level_imsic(dtb_buf);
-        if let Some((clint_base, _)) = unsafe { crate::platform::PLATFORM.info.ipi.as_ref() } {
+        if let Some((clint_base, _)) = crate::platform::board_info().ipi.as_ref() {
             let clint_name = format!("clint@{:x}", clint_base);
             if fdt_nop_node_by_name(dtb_buf, &clint_name) {
                 info!("AIA: NOP'd M-level CLINT node '{}' in DTB", clint_name);
@@ -552,16 +552,15 @@ pub fn set_pmp(memory_range: &Range<usize>) {
         // controller regions while keeping other low MMIO visible.
         // This matches OpenSBI's domain isolation approach.
         if crate::platform::aia::is_aia_active()
-            && crate::platform::PLATFORM.info.is_qemu_virt()
-            && let Some(aia_info) = crate::platform::PLATFORM.info.aia.as_ref()
+            && crate::platform::board_info().is_qemu_virt()
+            && let Some(aia_info) = crate::platform::board_info().aia.as_ref()
         {
             const QEMU_VIRT_M_APLIC_BASE: usize = 0x0c00_0000;
             const QEMU_VIRT_CLINT_BASE: usize = 0x0200_0000;
             const QEMU_VIRT_APLIC_SIZE: usize = 0x8000;
             const QEMU_VIRT_CLINT_SIZE: usize = 0x1_0000;
 
-            let clint_base = crate::platform::PLATFORM
-                .info
+            let clint_base = crate::platform::board_info()
                 .ipi
                 .as_ref()
                 .map(|(base, _)| *base)

--- a/prototyper/prototyper/src/macros.rs
+++ b/prototyper/prototyper/src/macros.rs
@@ -1,12 +1,7 @@
 #[allow(unused)]
 macro_rules! print {
     ($($arg:tt)*) => {
-        use core::fmt::Write;
-        if unsafe {$crate::platform::PLATFORM.have_console()} {
-            let console = unsafe { $crate::platform::PLATFORM.sbi.console.as_mut().unwrap() };
-            console.write_fmt(core::format_args!($($arg)*)).unwrap();
-            drop(console);
-        }
+        $crate::sbi::console::_print(core::format_args!($($arg)*))
     }
 }
 
@@ -14,12 +9,8 @@ macro_rules! print {
 macro_rules! println {
     () => ($crate::print!("\n\r"));
     ($($arg:tt)*) => {{
-        use core::fmt::Write;
-        if unsafe {$crate::platform::PLATFORM.have_console()} {
-            let console = unsafe { $crate::platform::PLATFORM.sbi.console.as_mut().unwrap() };
-            console.write_fmt(core::format_args!($($arg)*)).unwrap();
-            console.write_str("\n\r").unwrap();
-        }
+        $crate::sbi::console::_print(core::format_args!($($arg)*));
+        $crate::sbi::console::_print(core::format_args!("\n\r"));
     }}
 }
 

--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -24,7 +24,7 @@ use crate::sbi::features::{
     check_privilege, detect_hart_features, hart_mhpm_mask, hart_privileged_version,
 };
 use crate::sbi::heap;
-use crate::sbi::hsm::hsm;
+use crate::sbi::hsm::hart_hsm;
 use crate::sbi::ipi;
 use crate::sbi::trap_stack;
 use rustsbi_prototyper_macros::entry;
@@ -62,7 +62,7 @@ fn boot_hart(boot: &BootInfo) {
         "Redirecting hart {} to {:#016x} in {:?} mode.",
         hart_id, next.start_addr, next.next_mode
     );
-    hsm().start(next);
+    hart_hsm().start(next);
 
     enable_supervisor_services();
 }

--- a/prototyper/prototyper/src/platform/aia.rs
+++ b/prototyper/prototyper/src/platform/aia.rs
@@ -41,7 +41,7 @@ pub fn per_hart_init() {
     }
     let hart_id = current_hartid();
     if hart_extension_probe(hart_id, Extension::Smaia) {
-        if let Some(ref aia_info) = unsafe { super::PLATFORM.info.aia.as_ref() } {
+        if let Some(ref aia_info) = super::board_info().aia.as_ref() {
             imsic_init_hart(aia_info);
         }
     } else {

--- a/prototyper/prototyper/src/platform/boot.rs
+++ b/prototyper/prototyper/src/platform/boot.rs
@@ -3,7 +3,7 @@
 use core::ops::Range;
 use core::sync::atomic::Ordering;
 
-use super::{IS_K1_PLATFORM, PLATFORM, READY};
+use super::{IS_K1_PLATFORM, PLATFORM, READY, board_info, board_info_mut};
 use crate::riscv::spacemit_k1;
 
 /// Initializes the board from the device tree and runs the SoC-specific
@@ -43,12 +43,10 @@ pub fn wait_until_ready() {
 
 /// Returns the board's memory range (set during `Platform::init`).
 pub fn memory_range() -> Range<usize> {
-    unsafe { PLATFORM.info.memory_range.as_ref().unwrap().clone() }
+    board_info().memory_range.as_ref().unwrap().clone()
 }
 
 /// Reconciles the enabled-CPU table with the per-hart privilege checks.
 pub fn refresh_enabled_cpus() {
-    unsafe {
-        PLATFORM.sbi_cpu_init_with_feature();
-    }
+    board_info_mut().refresh_cpu_features();
 }

--- a/prototyper/prototyper/src/platform/boot.rs
+++ b/prototyper/prototyper/src/platform/boot.rs
@@ -3,16 +3,62 @@
 use core::ops::Range;
 use core::sync::atomic::Ordering;
 
-use super::{IS_K1_PLATFORM, PLATFORM, READY, board_info, board_info_mut};
+use super::{IS_K1_PLATFORM, READY, board_info, board_info_mut, print_board_info};
+use crate::devicetree::{Tree, parse_device_tree};
+use crate::fail;
 use crate::riscv::spacemit_k1;
+use crate::sbi;
+use crate::sbi::SbiDispatcher;
+use crate::sbi::hsm::SbiHsm;
+use crate::sbi::rfence::SbiRFence;
+use crate::sbi::suspend::SbiSuspend;
 
 /// Initializes the board from the device tree and runs the SoC-specific
 /// early initialization.
 pub fn init_board(fdt_address: usize) {
-    unsafe {
-        PLATFORM.init(fdt_address);
-        PLATFORM.print_board_info();
-    }
+    let dtb = parse_device_tree(fdt_address).unwrap_or_else(fail::device_tree_format);
+    let dtb = dtb.share();
+
+    let root: serde_device_tree::buildin::Node =
+        serde_device_tree::from_raw_mut(&dtb).unwrap_or_else(fail::device_tree_deserialize_root);
+    let tree: Tree = root.deserialize();
+
+    // Get console device, init sbi console and logger.
+    board_info_mut().discover_console(&root);
+    let console = sbi::console::init(board_info());
+    // Get other info that later platform initialization depends on.
+    board_info_mut().discover_misc(&tree);
+    // Get clint and reset device, init sbi ipi, reset, hsm, rfence and susp extension.
+    board_info_mut().discover_devices(&root);
+    let ipi = sbi::ipi::init(board_info());
+    let hsm = ipi.as_ref().map(|_| SbiHsm);
+    let reset = sbi::reset::init(board_info());
+    let rfence = ipi.as_ref().map(|_| SbiRFence);
+    let susp = hsm.as_ref().map(|_| SbiSuspend);
+    // Initialize pmu extension
+    let pmu = sbi::pmu::init(&root);
+
+    // Publish the SBI extension set before the K1 detect / READY release,
+    // so that harts observing `READY` also observe the published dispatcher.
+    sbi::SBI_DISPATCHER
+        .call_once(|| SbiDispatcher::new(console, ipi, hsm, reset, rfence, susp, pmu));
+
+    // Record K1 platform detection *before* releasing the ready flag, so
+    // that secondary harts observing `READY` also observe the flag.
+    // Match the root node's `compatible` strings first (OpenSBI's
+    // spacemit_k1_match[] table), falling back to the model string.
+    let k1_platform = match root.get_prop("compatible") {
+        Some(prop) => {
+            let seq = prop.deserialize::<serde_device_tree::buildin::StrSeq>();
+            spacemit_k1::is_k1_platform(&board_info().model, seq.iter())
+        }
+        None => spacemit_k1::is_k1_platform(&board_info().model, core::iter::empty::<&str>()),
+    };
+    IS_K1_PLATFORM.store(k1_platform, Ordering::Release);
+
+    READY.store(true, Ordering::Release);
+
+    print_board_info();
 
     if IS_K1_PLATFORM.load(Ordering::Acquire) {
         // Configure ML2SETUP for the boot hart
@@ -41,7 +87,7 @@ pub fn wait_until_ready() {
     }
 }
 
-/// Returns the board's memory range (set during `Platform::init`).
+/// Returns the board's memory range (set during `init_board`).
 pub fn memory_range() -> Range<usize> {
     board_info().memory_range.as_ref().unwrap().clone()
 }

--- a/prototyper/prototyper/src/platform/boot.rs
+++ b/prototyper/prototyper/src/platform/boot.rs
@@ -3,7 +3,7 @@
 use core::ops::Range;
 use core::sync::atomic::Ordering;
 
-use super::{IS_K1_PLATFORM, PLATFORM};
+use super::{IS_K1_PLATFORM, PLATFORM, READY};
 use crate::riscv::spacemit_k1;
 
 /// Initializes the board from the device tree and runs the SoC-specific
@@ -36,7 +36,7 @@ pub fn secondary_hart_init() {
 
 /// Spins until the boot hart has finished platform initialization.
 pub fn wait_until_ready() {
-    while !unsafe { PLATFORM.ready() } {
+    while !READY.load(Ordering::Acquire) {
         core::hint::spin_loop()
     }
 }

--- a/prototyper/prototyper/src/platform/console.rs
+++ b/prototyper/prototyper/src/platform/console.rs
@@ -52,6 +52,11 @@ impl<R: Register> Uart16550Wrap<R> {
     }
 }
 
+// SAFETY: `Uart16550Wrap` holds only a raw pointer to MMIO registers and no
+// Rust-side mutable state; moving the handle across harts is sound. Access
+// is serialized by the mutex around the published console device.
+unsafe impl<R: Register> Send for Uart16550Wrap<R> {}
+
 impl<R: Register> ConsoleDevice for Uart16550Wrap<R> {
     fn read(&self, buf: &mut [u8]) -> usize {
         unsafe { (*self.inner).read(buf) }
@@ -63,13 +68,31 @@ impl<R: Register> ConsoleDevice for Uart16550Wrap<R> {
 }
 
 /// For Uart AxiLite
-impl ConsoleDevice for MmioUartAxiLite {
+pub struct UartAxiLiteWrap {
+    inner: MmioUartAxiLite,
+}
+
+impl UartAxiLiteWrap {
+    pub fn new(base: usize) -> Self {
+        Self {
+            inner: MmioUartAxiLite::new(base),
+        }
+    }
+}
+
+// SAFETY: `MmioUartAxiLite` is a volatile MMIO handle with no Rust-side
+// mutable state; access is serialized by the mutex around the published
+// console device. The newtype exists so this assertion can be made locally
+// (orphan rule: both `Send` and the UART type are foreign).
+unsafe impl Send for UartAxiLiteWrap {}
+
+impl ConsoleDevice for UartAxiLiteWrap {
     fn read(&self, buf: &mut [u8]) -> usize {
-        self.read(buf)
+        self.inner.read(buf)
     }
 
     fn write(&self, buf: &[u8]) -> usize {
-        self.write(buf)
+        self.inner.write(buf)
     }
 }
 
@@ -88,6 +111,11 @@ impl UartSifiveWrap {
         Self { inner }
     }
 }
+
+// SAFETY: `UartSifiveWrap` only forwards to a volatile MMIO handle with no
+// Rust-side mutable state; access is serialized by the mutex around the
+// published console device.
+unsafe impl Send for UartSifiveWrap {}
 
 /// For Uart Sifive
 impl ConsoleDevice for UartSifiveWrap {
@@ -112,6 +140,11 @@ impl UartBflbWrap {
         }
     }
 }
+
+// SAFETY: `UartBflbWrap` only forwards to a volatile MMIO handle with no
+// Rust-side mutable state; access is serialized by the mutex around the
+// published console device.
+unsafe impl Send for UartBflbWrap {}
 
 impl ConsoleDevice for UartBflbWrap {
     fn read(&self, buf: &mut [u8]) -> usize {
@@ -231,7 +264,9 @@ unsafe impl Sync for UartXscaleWrap {}
 
 impl ConsoleDevice for UartXscaleWrap {
     fn read(&self, buf: &mut [u8]) -> usize {
-        // Safety: UartXscale uses volatile MMIO access; the outer Mutex in
+        // SAFETY: `UartXscale` performs volatile MMIO access; the outer mutex in
+        // the published console device serializes callers, so the borrowed
+        // handle cannot race.
         // SbiConsole serializes access in a single-threaded SBI context.
         let uart = unsafe { &mut *self.inner.get() };
         let mut count = 0;
@@ -247,7 +282,8 @@ impl ConsoleDevice for UartXscaleWrap {
     }
 
     fn write(&self, buf: &[u8]) -> usize {
-        // Safety: same as above.
+        // SAFETY: same justification as `read`: volatile MMIO access under the
+        // published console device's mutex.
         let uart = unsafe { &mut *self.inner.get() };
         for &c in buf {
             uart.putchar(c);

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -1,47 +1,26 @@
 use alloc::string::String;
-use alloc::{boxed::Box, string::ToString, vec::Vec};
-use clint::{SifiveClintWrap, THeadClintWrap};
+use alloc::{string::ToString, vec::Vec};
 use core::{
     ops::Range,
     sync::atomic::{AtomicBool, Ordering},
 };
-use reset::SifiveTestDeviceWrap;
-use spin::Mutex;
-use uart_xilinx::MmioUartAxiLite;
 
 use crate::cfg::NUM_HART_MAX;
 use crate::devicetree::*;
-use crate::fail;
 use crate::platform::clint::{MachineClintType, SIFIVE_CLINT_COMPATIBLE, THEAD_CLINT_COMPATIBLE};
-use crate::platform::console::Uart16550Wrap;
-use crate::platform::console::UartBflbWrap;
-use crate::platform::console::UartPl011Wrap;
-use crate::platform::console::UartSifiveWrap;
-use crate::platform::console::UartXscaleWrap;
 use crate::platform::console::{
     MachineConsoleType, UART16650U8_COMPATIBLE, UART16650U32_COMPATIBLE, UARTAXILITE_COMPATIBLE,
     UARTBFLB_COMPATIBLE, UARTPL011_COMPATIBLE, UARTSIFIVE_COMPATIBLE, UARTXSCALE_COMPATIBLE,
 };
 use crate::platform::reset::P1_PMIC_COMPATIBLE;
-use crate::platform::reset::P1PmicResetWrap;
 use crate::platform::reset::SIFIVETEST_COMPATIBLE;
-use crate::riscv::spacemit_k1;
-use crate::sbi::SBI;
-use crate::sbi::console::SbiConsole;
 use crate::sbi::features::extension_detection;
-use crate::sbi::hsm::SbiHsm;
-use crate::sbi::ipi::SbiIpi;
-use crate::sbi::logger;
-use crate::sbi::pmu::{EventToCounterMap, RawEventToCounterMap};
-use crate::sbi::reset::SbiReset;
-use crate::sbi::rfence::SbiRFence;
-use crate::sbi::suspend::SbiSuspend;
 
 pub(crate) mod aia;
 mod boot;
-mod clint;
-mod console;
-mod reset;
+pub(crate) mod clint;
+pub(crate) mod console;
+pub(crate) mod reset;
 
 pub use boot::{
     init_board, memory_range, refresh_enabled_cpus, secondary_hart_init, wait_until_ready,
@@ -52,7 +31,7 @@ pub(crate) static CPU_PRIVILEGED_ENABLED: [AtomicBool; NUM_HART_MAX] =
 
 /// Set to true once init detects the platform is a SpacemiT K1 / Ky X1.
 ///
-/// Written in `Platform::init` *before* the ready flag is released, so that a
+/// Written in `init_board` *before* the ready flag is released, so that a
 /// secondary hart observing `READY == true` is guaranteed to also observe
 /// this flag (main.rs secondary-hart path).
 pub(crate) static IS_K1_PLATFORM: AtomicBool = AtomicBool::new(false);
@@ -592,440 +571,167 @@ impl BoardInfo {
     }
 }
 
-pub struct Platform {
-    pub sbi: SBI,
+pub(crate) fn print_board_info() {
+    info!("RustSBI version {}", rustsbi::VERSION);
+    rustsbi::LOGO.lines().for_each(|line| info!("{}", line));
+    info!("Initializing RustSBI machine-mode environment.");
+
+    print_platform_info();
+    print_cpu_info();
+    print_device_info();
+    print_memory_info();
+    print_additional_info();
 }
 
-impl Platform {
-    pub const fn new() -> Self {
-        Platform { sbi: SBI::new() }
-    }
+#[inline]
+fn print_platform_info() {
+    info!("{:<30}: {}", "Platform Name", board_info().model);
+}
 
-    pub fn init(&mut self, fdt_address: usize) {
-        let dtb = parse_device_tree(fdt_address).unwrap_or_else(fail::device_tree_format);
-        let dtb = dtb.share();
+fn print_cpu_info() {
+    info!(
+        "{:<30}: {:?}",
+        "Platform HART Count",
+        board_info().cpu_num.unwrap_or(0)
+    );
 
-        let root: serde_device_tree::buildin::Node = serde_device_tree::from_raw_mut(&dtb)
-            .unwrap_or_else(fail::device_tree_deserialize_root);
-        let tree: Tree = root.deserialize();
-
-        // Get console device, init sbi console and logger.
-        board_info_mut().discover_console(&root);
-        self.init_sbi_console_and_logger();
-        // Get other info that later platform initialization depends on.
-        board_info_mut().discover_misc(&tree);
-        // Get clint and reset device, init sbi ipi, reset, hsm, rfence and susp extension.
-        board_info_mut().discover_devices(&root);
-        self.sbi_ipi_init();
-        self.sbi_hsm_init();
-        self.sbi_reset_init();
-        self.sbi_rfence_init();
-        self.sbi_susp_init();
-        // Initialize pmu extension
-        self.sbi_init_pmu(&root);
-
-        // Record K1 platform detection *before* releasing the ready flag, so
-        // that secondary harts observing `READY` also observe the flag.
-        // Match the root node's `compatible` strings first (OpenSBI's
-        // spacemit_k1_match[] table), falling back to the model string.
-        let k1_platform = match root.get_prop("compatible") {
-            Some(prop) => {
-                let seq = prop.deserialize::<serde_device_tree::buildin::StrSeq>();
-                spacemit_k1::is_k1_platform(&board_info().model, seq.iter())
-            }
-            None => spacemit_k1::is_k1_platform(&board_info().model, core::iter::empty::<&str>()),
-        };
-        IS_K1_PLATFORM.store(k1_platform, Ordering::Release);
-
-        READY.store(true, Ordering::Release);
-    }
-
-    fn init_sbi_console_and_logger(&mut self) {
-        // init console and logger
-        self.sbi_console_init();
-        logger::Logger::init().unwrap();
-        info!("Hello RustSBI!");
-    }
-
-    fn sbi_init_pmu(&mut self, root: &serde_device_tree::buildin::Node) {
-        let mut pmu_node: Option<Pmu> = None;
-        let mut find_pmu = |node: &serde_device_tree::buildin::Node| {
-            let info = get_compatible(node);
-            if let Some(compatible_strseq) = info {
-                let compatible_iter = compatible_strseq.iter();
-                for compatible in compatible_iter {
-                    if compatible == "riscv,pmu" {
-                        pmu_node = Some(node.deserialize::<Pmu>());
-                    }
-                }
-            }
-        };
-        root.search(&mut find_pmu);
-
-        if let Some(ref pmu) = pmu_node {
-            let sbi_pmu = self.sbi.pmu.get_or_insert_default();
-            if let Some(ref event_to_mhpmevent) = pmu.event_to_mhpmevent {
-                let len = event_to_mhpmevent.len();
-                for idx in 0..len {
-                    let event = event_to_mhpmevent.get_event_id(idx);
-                    let mhpmevent = event_to_mhpmevent.get_selector_value(idx);
-                    sbi_pmu.insert_event_to_mhpmevent(event, mhpmevent);
-                    debug!(
-                        "pmu: insert event: 0x{:08x}, mhpmevent: {:#016x}",
-                        event, mhpmevent
-                    );
-                }
-            }
-
-            if let Some(ref event_to_mhpmcounters) = pmu.event_to_mhpmcounters {
-                let len = event_to_mhpmcounters.len();
-                for idx in 0..len {
-                    let events = event_to_mhpmcounters.get_event_idx_range(idx);
-                    let mhpmcounters = event_to_mhpmcounters.get_counter_bitmap(idx);
-                    let event_to_counter =
-                        EventToCounterMap::new(mhpmcounters, *events.start(), *events.end());
-                    debug!("pmu: insert event_to_mhpmcounter: {:x?}", event_to_counter);
-                    sbi_pmu.insert_event_to_mhpmcounter(event_to_counter);
-                }
-            }
-
-            if let Some(ref raw_event_to_mhpmcounters) = pmu.raw_event_to_mhpmcounters {
-                let len = raw_event_to_mhpmcounters.len();
-                for idx in 0..len {
-                    let raw_event_select = raw_event_to_mhpmcounters.get_event_idx_base(idx);
-                    let select_mask = raw_event_to_mhpmcounters.get_event_idx_mask(idx);
-                    let counters_mask = raw_event_to_mhpmcounters.get_counter_bitmap(idx);
-                    let raw_event_to_counter =
-                        RawEventToCounterMap::new(counters_mask, raw_event_select, select_mask);
-                    debug!(
-                        "pmu: insert raw_event_to_mhpmcounter: {:x?}",
-                        raw_event_to_counter
-                    );
-                    sbi_pmu.insert_raw_event_to_mhpmcounter(raw_event_to_counter);
-                }
-            }
+    let Some(cpu_enabled) = &board_info().cpu_enabled else {
+        warn!("{:<30}: Not Available", "Enabled HARTs");
+        return;
+    };
+    let mut enabled_harts = [0; NUM_HART_MAX];
+    let mut count = 0;
+    for (i, &enabled) in cpu_enabled.iter().enumerate() {
+        if enabled {
+            enabled_harts[count] = i;
+            count += 1;
         }
     }
+    info!("{:<30}: {:?}", "Enabled HARTs", &enabled_harts[..count]);
+}
 
-    fn sbi_console_init(&mut self) {
-        if let Some((base, console_type)) = board_info().console {
-            self.sbi.console = match console_type {
-                MachineConsoleType::Uart16550U8 => Some(SbiConsole::new(Mutex::new(Box::new(
-                    Uart16550Wrap::<u8>::new(base),
-                )))),
-                MachineConsoleType::Uart16550U32 => Some(SbiConsole::new(Mutex::new(Box::new(
-                    Uart16550Wrap::<u32>::new(base),
-                )))),
-                MachineConsoleType::UartAxiLite => Some(SbiConsole::new(Mutex::new(Box::new(
-                    MmioUartAxiLite::new(base),
-                )))),
-                MachineConsoleType::UartBflb => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartBflbWrap::new(base),
-                )))),
-                MachineConsoleType::UartSifive => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartSifiveWrap::new(base),
-                )))),
-                MachineConsoleType::UartPl011 => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartPl011Wrap::new(base),
-                )))),
-                MachineConsoleType::UartXscale => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartXscaleWrap::new(base, board_info().console_clock),
-                )))),
-            };
-        } else {
-            self.sbi.console = None;
-        }
-    }
+#[inline]
+fn print_device_info() {
+    print_clint_info();
+    print_console_info();
+    print_reset_info();
+    print_hsm_info();
+    print_rfence_info();
+    print_susp_info();
+    print_pmu_info();
+}
 
-    fn sbi_reset_init(&mut self) {
-        if let Some(base) = board_info().reset {
-            self.sbi.reset = Some(SbiReset::new(Mutex::new(Box::new(
-                SifiveTestDeviceWrap::new(base),
-            ))));
-        } else if let Some((i2c_base, pmic_addr)) = board_info().pmic_reset {
-            self.sbi.reset = Some(SbiReset::new(Mutex::new(Box::new(P1PmicResetWrap::new(
-                i2c_base, pmic_addr,
-            )))));
-        } else {
-            self.sbi.reset = None;
-        }
-    }
-
-    fn sbi_ipi_init(&mut self) {
-        let max_hart_id = board_info()
-            .cpu_enabled
-            .as_ref()
-            .and_then(|hart_list| hart_list.iter().rposition(|enabled| *enabled))
-            .unwrap_or(NUM_HART_MAX - 1);
-
-        if let Some(ref aia_info) = board_info().aia {
-            use crate::sbi::features::{Extension, hart_extension_probe};
-            let mut aia_usable = true;
-            if let Some(ref cpu_enabled) = board_info().cpu_enabled {
-                for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
-                    if *enabled {
-                        if !hart_extension_probe(hart_id, Extension::Smaia) {
-                            warn!("AIA: hart {} lacks Smaia, rejecting AIA", hart_id);
-                            aia_usable = false;
-                            break;
-                        }
-                        if !hart_extension_probe(hart_id, Extension::Sstc) {
-                            warn!("AIA: hart {} lacks Sstc, rejecting AIA", hart_id);
-                            aia_usable = false;
-                            break;
-                        }
-                    }
-                }
-            }
-            if aia_usable {
-                let ipi_dev =
-                    aia::ImsicDevice::new(aia_info.firmware_ipi_iid, aia_info.hart_imsic_map);
-                self.sbi.ipi = Some(SbiIpi::new(Mutex::new(Box::new(ipi_dev)), max_hart_id));
-                if board_info().is_qemu_virt() {
-                    aia::init_qemu_m_aplic_delegation(
-                        aia_info.layout.machine_base,
-                        aia_info.layout.hart_index_bits,
-                    );
-                } else {
-                    warn!(
-                        "AIA: skipping QEMU virt M-APLIC setup on '{}'",
-                        board_info().model
-                    );
-                }
-                aia::set_aia_active(true);
-                info!("AIA: IMSIC IPI + Sstc timer backend initialized");
-                return;
-            }
-            warn!("AIA: requirements not met, falling back to CLINT");
-        }
-        if let Some((base, clint_type)) = board_info().ipi {
-            let ipi_dev: Box<dyn crate::sbi::ipi::IpiDevice> = match clint_type {
-                MachineClintType::SiFiveClint => Box::new(SifiveClintWrap::new(base)),
-                MachineClintType::TheadClint => Box::new(THeadClintWrap::new(base)),
-            };
-            self.sbi.ipi = Some(SbiIpi::new(Mutex::new(ipi_dev), max_hart_id));
-        }
-    }
-
-    fn sbi_hsm_init(&mut self) {
-        if self.sbi.ipi.is_some() {
-            self.sbi.hsm = Some(SbiHsm);
-        } else {
-            self.sbi.hsm = None;
-        }
-    }
-
-    fn sbi_rfence_init(&mut self) {
-        if self.sbi.ipi.is_some() {
-            self.sbi.rfence = Some(SbiRFence);
-        } else {
-            self.sbi.rfence = None;
-        }
-    }
-
-    fn sbi_susp_init(&mut self) {
-        if self.sbi.hsm.is_some() {
-            self.sbi.susp = Some(SbiSuspend);
-        } else {
-            self.sbi.susp = None;
-        }
-    }
-
-    pub fn print_board_info(&self) {
-        info!("RustSBI version {}", rustsbi::VERSION);
-        rustsbi::LOGO.lines().for_each(|line| info!("{}", line));
-        info!("Initializing RustSBI machine-mode environment.");
-
-        self.print_platform_info();
-        self.print_cpu_info();
-        self.print_device_info();
-        self.print_memory_info();
-        self.print_additional_info();
-    }
-
-    #[inline]
-    fn print_platform_info(&self) {
-        info!("{:<30}: {}", "Platform Name", board_info().model);
-    }
-
-    fn print_cpu_info(&self) {
+#[inline]
+fn print_clint_info() {
+    if aia::is_aia_active()
+        && let Some(ref aia_info) = board_info().aia
+    {
         info!(
-            "{:<30}: {:?}",
-            "Platform HART Count",
-            board_info().cpu_num.unwrap_or(0)
+            "{:<30}: IMSIC (M-level Base Address: 0x{:x})",
+            "Platform IPI Extension", aia_info.layout.machine_base
         );
-
-        if let Some(cpu_enabled) = &board_info().cpu_enabled {
-            let mut enabled_harts = [0; NUM_HART_MAX];
-            let mut count = 0;
-            for (i, &enabled) in cpu_enabled.iter().enumerate() {
-                if enabled {
-                    enabled_harts[count] = i;
-                    count += 1;
-                }
-            }
-            info!("{:<30}: {:?}", "Enabled HARTs", &enabled_harts[..count]);
-        } else {
-            warn!("{:<30}: Not Available", "Enabled HARTs");
-        }
+        return;
     }
-
-    #[inline]
-    fn print_device_info(&self) {
-        self.print_clint_info();
-        self.print_console_info();
-        self.print_reset_info();
-        self.print_hsm_info();
-        self.print_rfence_info();
-        self.print_susp_info();
-        self.print_pmu_info();
-    }
-
-    #[inline]
-    fn print_clint_info(&self) {
-        if aia::is_aia_active()
-            && let Some(ref aia_info) = board_info().aia
-        {
+    match board_info().ipi {
+        Some((base, device)) => {
             info!(
-                "{:<30}: IMSIC (M-level Base Address: 0x{:x})",
-                "Platform IPI Extension", aia_info.layout.machine_base
-            );
-            return;
-        }
-        match board_info().ipi {
-            Some((base, device)) => {
-                info!(
-                    "{:<30}: {:?} (Base Address: 0x{:x})",
-                    "Platform IPI Extension", device, base
-                );
-            }
-            None => warn!("{:<30}: Not Available", "Platform IPI Device"),
-        }
-    }
-
-    #[inline]
-    fn print_console_info(&self) {
-        match board_info().console {
-            Some((base, device)) => {
-                info!(
-                    "{:<30}: {:?} (Base Address: 0x{:x})",
-                    "Platform Console Extension", device, base
-                );
-            }
-            None => warn!("{:<30}: Not Available", "Platform Console Device"),
-        }
-    }
-
-    #[inline]
-    fn print_reset_info(&self) {
-        if let Some(base) = board_info().reset {
-            info!(
-                "{:<30}: Available (Base Address: 0x{:x})",
-                "Platform Reset Extension", base
-            );
-        } else if let Some((i2c_base, pmic_addr)) = board_info().pmic_reset {
-            info!(
-                "{:<30}: Available (P1 PMIC @ 0x{:02x}, I2C Base: 0x{:x})",
-                "Platform Reset Extension", pmic_addr, i2c_base
-            );
-        } else {
-            warn!("{:<30}: Not Available", "Platform Reset Device");
-        }
-    }
-
-    #[inline]
-    fn print_hsm_info(&self) {
-        if self.have_hsm() {
-            info!("{:<30}: {}", "Platform HSM Extension", "Available");
-        } else {
-            warn!("{:<30}: {}", "Platform HSM Extension", "Not Available");
-        }
-    }
-
-    #[inline]
-    fn print_rfence_info(&self) {
-        if self.have_rfence() {
-            info!("{:<30}: {}", "Platform RFence Extension", "Available");
-        } else {
-            warn!("{:<30}: {}", "Platform RFence Extension", "Not Available");
-        }
-    }
-
-    #[inline]
-    fn print_susp_info(&self) {
-        if self.have_susp() {
-            info!("{:<30}: {}", "Platform SUSP Extension", "Available");
-        } else {
-            warn!("{:<30}: {}", "Platform SUSP Extension", "Not Available");
-        }
-    }
-
-    #[inline]
-    fn print_pmu_info(&self) {
-        if self.have_pmu() {
-            info!("{:<30}: {}", "Platform PMU Extension", "Available");
-        } else {
-            warn!("{:<30}: {}", "Platform PMU Extension", "Not Available");
-        }
-    }
-
-    #[inline]
-    fn print_memory_info(&self) {
-        if let Some(memory_range) = &board_info().memory_range {
-            info!(
-                "{:<30}: 0x{:x} - 0x{:x}",
-                "Memory range", memory_range.start, memory_range.end
-            );
-        } else {
-            warn!("{:<30}: Not Available", "Memory range");
-        }
-    }
-
-    #[inline]
-    fn print_additional_info(&self) {
-        if !READY.load(Ordering::Acquire) {
-            warn!(
-                "{:<30}: Platform initialization is not complete.",
-                "Platform Status"
-            );
-        } else {
-            info!(
-                "{:<30}: Platform initialization complete and ready.",
-                "Platform Status"
+                "{:<30}: {:?} (Base Address: 0x{:x})",
+                "Platform IPI Extension", device, base
             );
         }
+        None => warn!("{:<30}: Not Available", "Platform IPI Device"),
     }
 }
 
-#[allow(unused)]
-impl Platform {
-    pub fn have_console(&self) -> bool {
-        self.sbi.console.is_some()
-    }
-
-    pub fn have_reset(&self) -> bool {
-        self.sbi.reset.is_some()
-    }
-
-    pub fn have_ipi(&self) -> bool {
-        self.sbi.ipi.is_some()
-    }
-
-    pub fn have_hsm(&self) -> bool {
-        self.sbi.hsm.is_some()
-    }
-
-    pub fn have_rfence(&self) -> bool {
-        self.sbi.rfence.is_some()
-    }
-
-    pub fn have_susp(&self) -> bool {
-        self.sbi.susp.is_some()
-    }
-
-    pub fn have_pmu(&self) -> bool {
-        self.sbi.pmu.is_some()
+#[inline]
+fn print_console_info() {
+    match board_info().console {
+        Some((base, device)) => {
+            info!(
+                "{:<30}: {:?} (Base Address: 0x{:x})",
+                "Platform Console Extension", device, base
+            );
+        }
+        None => warn!("{:<30}: Not Available", "Platform Console Device"),
     }
 }
 
-pub(crate) static mut PLATFORM: Platform = Platform::new();
+#[inline]
+fn print_reset_info() {
+    if let Some(base) = board_info().reset {
+        info!(
+            "{:<30}: Available (Base Address: 0x{:x})",
+            "Platform Reset Extension", base
+        );
+    } else if let Some((i2c_base, pmic_addr)) = board_info().pmic_reset {
+        info!(
+            "{:<30}: Available (P1 PMIC @ 0x{:02x}, I2C Base: 0x{:x})",
+            "Platform Reset Extension", pmic_addr, i2c_base
+        );
+    } else {
+        warn!("{:<30}: Not Available", "Platform Reset Device");
+    }
+}
+
+#[inline]
+fn print_hsm_info() {
+    if crate::sbi::hsm().is_some() {
+        info!("{:<30}: {}", "Platform HSM Extension", "Available");
+    } else {
+        warn!("{:<30}: {}", "Platform HSM Extension", "Not Available");
+    }
+}
+
+#[inline]
+fn print_rfence_info() {
+    if crate::sbi::rfence().is_some() {
+        info!("{:<30}: {}", "Platform RFence Extension", "Available");
+    } else {
+        warn!("{:<30}: {}", "Platform RFence Extension", "Not Available");
+    }
+}
+
+#[inline]
+fn print_susp_info() {
+    if crate::sbi::susp().is_some() {
+        info!("{:<30}: {}", "Platform SUSP Extension", "Available");
+    } else {
+        warn!("{:<30}: {}", "Platform SUSP Extension", "Not Available");
+    }
+}
+
+#[inline]
+fn print_pmu_info() {
+    if crate::sbi::pmu().is_some() {
+        info!("{:<30}: {}", "Platform PMU Extension", "Available");
+    } else {
+        warn!("{:<30}: {}", "Platform PMU Extension", "Not Available");
+    }
+}
+
+#[inline]
+fn print_memory_info() {
+    if let Some(memory_range) = &board_info().memory_range {
+        info!(
+            "{:<30}: 0x{:x} - 0x{:x}",
+            "Memory range", memory_range.start, memory_range.end
+        );
+    } else {
+        warn!("{:<30}: Not Available", "Memory range");
+    }
+}
+
+#[inline]
+fn print_additional_info() {
+    if !READY.load(Ordering::Acquire) {
+        warn!(
+            "{:<30}: Platform initialization is not complete.",
+            "Platform Status"
+        );
+    } else {
+        info!(
+            "{:<30}: Platform initialization complete and ready.",
+            "Platform Status"
+        );
+    }
+}

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -62,6 +62,28 @@ pub(crate) static IS_K1_PLATFORM: AtomicBool = AtomicBool::new(false);
 /// Acquire ordering (`wait_until_ready`).
 pub(crate) static READY: AtomicBool = AtomicBool::new(false);
 
+/// Board information discovered from the FDT, owned by the platform layer.
+///
+/// Invariant: written by the boot hart *before* `READY` is released, read
+/// afterwards; `wait_until_ready` (Acquire) is the secondary-hart edge.
+///
+/// Pre-existing exception (preserved, not hardened): `refresh_cpu_features`
+/// rewrites `cpu_enabled` after `READY` while other harts may read it
+/// concurrently (bool array, copied out per call).
+static mut BOARD_INFO: BoardInfo = BoardInfo::new();
+
+/// Returns a shared view of the discovered board information.
+pub(crate) fn board_info() -> &'static BoardInfo {
+    unsafe { &BOARD_INFO }
+}
+
+/// Returns an exclusive view of the board information; used by the discovery
+/// (`BoardInfo::discover_*`) and refresh (`BoardInfo::refresh_cpu_features`)
+/// paths only.
+pub(crate) fn board_info_mut() -> &'static mut BoardInfo {
+    unsafe { &mut BOARD_INFO }
+}
+
 const RISCV_MACHINE_EXTERNAL_IRQ: u32 = 11;
 
 type BaseAddress = usize;
@@ -194,220 +216,51 @@ impl BoardInfo {
     pub fn is_qemu_virt(&self) -> bool {
         self.model == "riscv-virtio,qemu"
     }
-}
 
-pub struct Platform {
-    pub info: BoardInfo,
-    pub sbi: SBI,
-}
-
-impl Platform {
-    pub const fn new() -> Self {
-        Platform {
-            info: BoardInfo::new(),
-            sbi: SBI::new(),
-        }
-    }
-
-    pub fn init(&mut self, fdt_address: usize) {
-        let dtb = parse_device_tree(fdt_address).unwrap_or_else(fail::device_tree_format);
-        let dtb = dtb.share();
-
-        let root: serde_device_tree::buildin::Node = serde_device_tree::from_raw_mut(&dtb)
-            .unwrap_or_else(fail::device_tree_deserialize_root);
-        let tree: Tree = root.deserialize();
-
-        // Get console device, init sbi console and logger.
-        self.sbi_find_and_init_console(&root);
-        // Get other info that later platform initialization depends on.
-        self.sbi_misc_init(&tree);
-        // Get clint and reset device, init sbi ipi, reset, hsm, rfence and susp extension.
-        self.sbi_init_ipi_reset_hsm_rfence(&root);
-        // Initialize pmu extension
-        self.sbi_init_pmu(&root);
-
-        // Record K1 platform detection *before* releasing the ready flag, so
-        // that secondary harts observing `ready()` also observe the flag.
-        // Match the root node's `compatible` strings first (OpenSBI's
-        // spacemit_k1_match[] table), falling back to the model string.
-        let k1_platform = match root.get_prop("compatible") {
-            Some(prop) => {
-                let seq = prop.deserialize::<serde_device_tree::buildin::StrSeq>();
-                spacemit_k1::is_k1_platform(&self.info.model, seq.iter())
-            }
-            None => spacemit_k1::is_k1_platform(&self.info.model, core::iter::empty::<&str>()),
-        };
-        IS_K1_PLATFORM.store(k1_platform, Ordering::Release);
-
-        READY.store(true, Ordering::Release);
-    }
-
-    fn init_sbi_console_and_logger(&mut self) {
-        // init console and logger
-        self.sbi_console_init();
-        logger::Logger::init().unwrap();
-        info!("Hello RustSBI!");
-    }
-
-    fn sbi_find_and_init_console(&mut self, root: &serde_device_tree::buildin::Node) {
+    /// Discovers the console device from the FDT (chosen stdout path).
+    pub(crate) fn discover_console(&mut self, root: &serde_device_tree::buildin::Node) {
         //  Get console device info
         let Some(stdout_path) = root.chosen_stdout_path() else {
-            self.init_sbi_console_and_logger();
             return;
         };
         let Some(node) = root.find(stdout_path) else {
-            self.init_sbi_console_and_logger();
             return;
         };
         let Some((compatible, regs)) = get_compatible_and_range(&node) else {
-            self.init_sbi_console_and_logger();
             return;
         };
 
         for device_id in compatible.iter() {
             if UART16650U8_COMPATIBLE.contains(&device_id) {
-                self.info.console = Some((regs.start, MachineConsoleType::Uart16550U8));
+                self.console = Some((regs.start, MachineConsoleType::Uart16550U8));
             }
             if UART16650U32_COMPATIBLE.contains(&device_id) {
-                self.info.console = Some((regs.start, MachineConsoleType::Uart16550U32));
+                self.console = Some((regs.start, MachineConsoleType::Uart16550U32));
             }
             if UARTAXILITE_COMPATIBLE.contains(&device_id) {
-                self.info.console = Some((regs.start, MachineConsoleType::UartAxiLite));
+                self.console = Some((regs.start, MachineConsoleType::UartAxiLite));
             }
             if UARTBFLB_COMPATIBLE.contains(&device_id) {
-                self.info.console = Some((regs.start, MachineConsoleType::UartBflb));
+                self.console = Some((regs.start, MachineConsoleType::UartBflb));
             }
             if UARTSIFIVE_COMPATIBLE.contains(&device_id) {
-                self.info.console = Some((regs.start, MachineConsoleType::UartSifive));
+                self.console = Some((regs.start, MachineConsoleType::UartSifive));
             }
             if UARTPL011_COMPATIBLE.contains(&device_id) {
-                self.info.console = Some((regs.start, MachineConsoleType::UartPl011));
+                self.console = Some((regs.start, MachineConsoleType::UartPl011));
             }
             if UARTXSCALE_COMPATIBLE.contains(&device_id) {
-                self.info.console = Some((regs.start, MachineConsoleType::UartXscale));
-                self.info.console_clock = node
+                self.console = Some((regs.start, MachineConsoleType::UartXscale));
+                self.console_clock = node
                     .get_prop("clock-frequency")
                     .map(|prop_item| prop_item.deserialize::<u32>());
             }
         }
-
-        self.init_sbi_console_and_logger();
     }
 
-    fn sbi_init_ipi_reset_hsm_rfence(&mut self, root: &serde_device_tree::buildin::Node) {
-        // Get ipi and reset device info
-        let cpu_intc_harts = collect_cpu_intc_harts(root);
-        let mut find_device =
-            |node: &serde_device_tree::buildin::Node,
-             parent: Option<&serde_device_tree::buildin::Node>| {
-                let info = get_compatible_and_ranges(node);
-                if let Some(info) = info {
-                    let (compatible, regs) = info;
-                    let base_address = regs[0].start;
-                    for device_id in compatible.iter() {
-                        // Initialize clint device.
-                        if SIFIVE_CLINT_COMPATIBLE.contains(&device_id) {
-                            if node.get_prop("clint,has-no-64bit-mmio").is_some() {
-                                self.info.ipi = Some((base_address, MachineClintType::TheadClint));
-                            } else {
-                                self.info.ipi = Some((base_address, MachineClintType::SiFiveClint));
-                            }
-                        } else if THEAD_CLINT_COMPATIBLE.contains(&device_id) {
-                            self.info.ipi = Some((base_address, MachineClintType::TheadClint));
-                        }
-                        // Initialize reset device.
-                        if SIFIVETEST_COMPATIBLE.contains(&device_id) {
-                            self.info.reset = Some(base_address);
-                        }
-                        // Initialize P1 PMIC reset device
-                        if P1_PMIC_COMPATIBLE.contains(&device_id) {
-                            // The PMIC's own "reg" property is its 7-bit I2C slave address.
-                            let pmic_addr = regs[0].start as u8;
-                            // The I2C controller is the PMIC's parent node; use the first
-                            // register range of the parent as the controller MMIO base,
-                            // falling back to the PMIC's own reg if no parent is found.
-                            let i2c_base = parent
-                                .and_then(|p| get_compatible_and_ranges(p))
-                                .and_then(|(_, parent_regs)| parent_regs.first().map(|r| r.start))
-                                .unwrap_or(base_address);
-                            self.info.pmic_reset = Some((i2c_base, pmic_addr));
-                        }
-                        // Discover the M-level IMSIC from its CPU interrupt wiring.
-                        if aia::IMSIC_COMPATIBLE.contains(&device_id) && self.info.aia.is_none() {
-                            self.sbi_discover_imsic(node, &regs, &cpu_intc_harts);
-                        }
-                    }
-                }
-            };
-        search_with_parent(root, &mut find_device);
-        self.sbi_ipi_init();
-        self.sbi_hsm_init();
-        self.sbi_reset_init();
-        self.sbi_rfence_init();
-        self.sbi_susp_init();
-    }
-
-    fn sbi_init_pmu(&mut self, root: &serde_device_tree::buildin::Node) {
-        let mut pmu_node: Option<Pmu> = None;
-        let mut find_pmu = |node: &serde_device_tree::buildin::Node| {
-            let info = get_compatible(node);
-            if let Some(compatible_strseq) = info {
-                let compatible_iter = compatible_strseq.iter();
-                for compatible in compatible_iter {
-                    if compatible == "riscv,pmu" {
-                        pmu_node = Some(node.deserialize::<Pmu>());
-                    }
-                }
-            }
-        };
-        root.search(&mut find_pmu);
-
-        if let Some(ref pmu) = pmu_node {
-            let sbi_pmu = self.sbi.pmu.get_or_insert_default();
-            if let Some(ref event_to_mhpmevent) = pmu.event_to_mhpmevent {
-                let len = event_to_mhpmevent.len();
-                for idx in 0..len {
-                    let event = event_to_mhpmevent.get_event_id(idx);
-                    let mhpmevent = event_to_mhpmevent.get_selector_value(idx);
-                    sbi_pmu.insert_event_to_mhpmevent(event, mhpmevent);
-                    debug!(
-                        "pmu: insert event: 0x{:08x}, mhpmevent: {:#016x}",
-                        event, mhpmevent
-                    );
-                }
-            }
-
-            if let Some(ref event_to_mhpmcounters) = pmu.event_to_mhpmcounters {
-                let len = event_to_mhpmcounters.len();
-                for idx in 0..len {
-                    let events = event_to_mhpmcounters.get_event_idx_range(idx);
-                    let mhpmcounters = event_to_mhpmcounters.get_counter_bitmap(idx);
-                    let event_to_counter =
-                        EventToCounterMap::new(mhpmcounters, *events.start(), *events.end());
-                    debug!("pmu: insert event_to_mhpmcounter: {:x?}", event_to_counter);
-                    sbi_pmu.insert_event_to_mhpmcounter(event_to_counter);
-                }
-            }
-
-            if let Some(ref raw_event_to_mhpmcounters) = pmu.raw_event_to_mhpmcounters {
-                let len = raw_event_to_mhpmcounters.len();
-                for idx in 0..len {
-                    let raw_event_select = raw_event_to_mhpmcounters.get_event_idx_base(idx);
-                    let select_mask = raw_event_to_mhpmcounters.get_event_idx_mask(idx);
-                    let counters_mask = raw_event_to_mhpmcounters.get_counter_bitmap(idx);
-                    let raw_event_to_counter =
-                        RawEventToCounterMap::new(counters_mask, raw_event_select, select_mask);
-                    debug!(
-                        "pmu: insert raw_event_to_mhpmcounter: {:x?}",
-                        raw_event_to_counter
-                    );
-                    sbi_pmu.insert_raw_event_to_mhpmcounter(raw_event_to_counter);
-                }
-            }
-        }
-    }
-
-    fn sbi_misc_init(&mut self, tree: &Tree) {
+    /// Discovers miscellaneous board info (memory, cpu number, model, enabled
+    /// harts) that later platform initialization depends on.
+    pub(crate) fn discover_misc(&mut self, tree: &Tree) {
         // Get memory info
         // TODO: More than one memory node or range?
         let memory_reg = tree
@@ -418,18 +271,18 @@ impl Platform {
             .deserialize::<Memory>()
             .reg;
         let memory_range = memory_reg.iter().next().unwrap().0;
-        self.info.memory_range = Some(memory_range);
+        self.memory_range = Some(memory_range);
 
         // Get cpu number info
-        self.info.cpu_num = Some(tree.cpus.cpu.len());
+        self.cpu_num = Some(tree.cpus.cpu.len());
 
         // Get model info
         if let Some(ref model) = tree.model {
             let model = model.iter().next().unwrap_or("<unspecified>");
-            self.info.model = model.to_string();
+            self.model = model.to_string();
         } else {
             let model = "<unspecified>";
-            self.info.model = model.to_string();
+            self.model = model.to_string();
         }
 
         // TODO: Need a better extension initialization method
@@ -450,64 +303,85 @@ impl Platform {
                 );
             }
         }
-        self.info.cpu_enabled = Some(cpu_list);
+        self.cpu_enabled = Some(cpu_list);
     }
 
-    pub fn sbi_cpu_init_with_feature(&mut self) {
-        if let Some(cpu_enabled) = self.info.cpu_enabled.as_mut() {
-            for (hart_id, enabled) in cpu_enabled.iter_mut().enumerate() {
-                if *enabled {
-                    *enabled = CPU_PRIVILEGED_ENABLED[hart_id].load(Ordering::Acquire);
+    /// Discovers the ipi and reset devices (including the M-level IMSIC) from
+    /// the FDT.
+    pub(crate) fn discover_devices(&mut self, root: &serde_device_tree::buildin::Node) {
+        // Get ipi and reset device info
+        let cpu_intc_harts = collect_cpu_intc_harts(root);
+        let mut find_device =
+            |node: &serde_device_tree::buildin::Node,
+             parent: Option<&serde_device_tree::buildin::Node>| {
+                let Some((compatible, regs)) = get_compatible_and_ranges(node) else {
+                    return;
+                };
+                let base_address = regs[0].start;
+                for device_id in compatible.iter() {
+                    self.discover_clint(node, device_id, base_address);
+                    self.discover_reset(device_id, base_address);
+                    self.discover_pmic_reset(device_id, base_address, parent);
+                    // Discover the M-level IMSIC from its CPU interrupt wiring.
+                    if aia::IMSIC_COMPATIBLE.contains(&device_id) && self.aia.is_none() {
+                        self.discover_imsic(node, &regs, &cpu_intc_harts);
+                    }
                 }
-            }
-        }
-    }
-
-    fn sbi_console_init(&mut self) {
-        if let Some((base, console_type)) = self.info.console {
-            self.sbi.console = match console_type {
-                MachineConsoleType::Uart16550U8 => Some(SbiConsole::new(Mutex::new(Box::new(
-                    Uart16550Wrap::<u8>::new(base),
-                )))),
-                MachineConsoleType::Uart16550U32 => Some(SbiConsole::new(Mutex::new(Box::new(
-                    Uart16550Wrap::<u32>::new(base),
-                )))),
-                MachineConsoleType::UartAxiLite => Some(SbiConsole::new(Mutex::new(Box::new(
-                    MmioUartAxiLite::new(base),
-                )))),
-                MachineConsoleType::UartBflb => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartBflbWrap::new(base),
-                )))),
-                MachineConsoleType::UartSifive => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartSifiveWrap::new(base),
-                )))),
-                MachineConsoleType::UartPl011 => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartPl011Wrap::new(base),
-                )))),
-                MachineConsoleType::UartXscale => Some(SbiConsole::new(Mutex::new(Box::new(
-                    UartXscaleWrap::new(base, self.info.console_clock),
-                )))),
             };
-        } else {
-            self.sbi.console = None;
+        search_with_parent(root, &mut find_device);
+    }
+
+    /// Discovers the CLINT device from a `compatible` match.
+    fn discover_clint(
+        &mut self,
+        node: &serde_device_tree::buildin::Node,
+        device_id: &str,
+        base_address: usize,
+    ) {
+        // Initialize clint device.
+        if SIFIVE_CLINT_COMPATIBLE.contains(&device_id) {
+            if node.get_prop("clint,has-no-64bit-mmio").is_some() {
+                self.ipi = Some((base_address, MachineClintType::TheadClint));
+            } else {
+                self.ipi = Some((base_address, MachineClintType::SiFiveClint));
+            }
+        } else if THEAD_CLINT_COMPATIBLE.contains(&device_id) {
+            self.ipi = Some((base_address, MachineClintType::TheadClint));
         }
     }
 
-    fn sbi_reset_init(&mut self) {
-        if let Some(base) = self.info.reset {
-            self.sbi.reset = Some(SbiReset::new(Mutex::new(Box::new(
-                SifiveTestDeviceWrap::new(base),
-            ))));
-        } else if let Some((i2c_base, pmic_addr)) = self.info.pmic_reset {
-            self.sbi.reset = Some(SbiReset::new(Mutex::new(Box::new(P1PmicResetWrap::new(
-                i2c_base, pmic_addr,
-            )))));
-        } else {
-            self.sbi.reset = None;
+    /// Discovers the sifive-test reset device from a `compatible` match.
+    fn discover_reset(&mut self, device_id: &str, base_address: usize) {
+        // Initialize reset device.
+        if SIFIVETEST_COMPATIBLE.contains(&device_id) {
+            self.reset = Some(base_address);
         }
     }
 
-    fn sbi_discover_imsic(
+    /// Discovers the P1 PMIC reset device from a `compatible` match.
+    fn discover_pmic_reset(
+        &mut self,
+        device_id: &str,
+        base_address: usize,
+        parent: Option<&serde_device_tree::buildin::Node>,
+    ) {
+        // Initialize P1 PMIC reset device
+        if !P1_PMIC_COMPATIBLE.contains(&device_id) {
+            return;
+        }
+        // The PMIC's own "reg" property is its 7-bit I2C slave address.
+        let pmic_addr = base_address as u8;
+        // The I2C controller is the PMIC's parent node; use the first
+        // register range of the parent as the controller MMIO base,
+        // falling back to the PMIC's own reg if no parent is found.
+        let i2c_base = parent
+            .and_then(|p| get_compatible_and_ranges(p))
+            .and_then(|(_, parent_regs)| parent_regs.first().map(|r| r.start))
+            .unwrap_or(base_address);
+        self.pmic_reset = Some((i2c_base, pmic_addr));
+    }
+
+    fn discover_imsic(
         &mut self,
         node: &serde_device_tree::buildin::Node,
         reg_ranges: &[Range<usize>],
@@ -674,15 +548,16 @@ impl Platform {
             hart_imsic_map[hart_id] = Some(addr);
         }
 
-        if let Some(ref cpu_enabled) = self.info.cpu_enabled {
-            for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
-                if *enabled && hart_imsic_map[hart_id].is_none() {
-                    warn!(
-                        "IMSIC: enabled hart {} has no M-level IMSIC file, skipping AIA",
-                        hart_id
-                    );
-                    return;
-                }
+        let Some(ref cpu_enabled) = self.cpu_enabled else {
+            return;
+        };
+        for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
+            if *enabled && hart_imsic_map[hart_id].is_none() {
+                warn!(
+                    "IMSIC: enabled hart {} has no M-level IMSIC file, skipping AIA",
+                    hart_id
+                );
+                return;
             }
         }
 
@@ -696,7 +571,7 @@ impl Platform {
             firmware_ipi_iid.number()
         );
 
-        self.info.aia = Some(aia::AiaInfo {
+        self.aia = Some(aia::AiaInfo {
             layout,
             num_ids,
             firmware_ipi_iid,
@@ -704,18 +579,189 @@ impl Platform {
         });
     }
 
+    /// Reconciles the enabled-CPU table with the per-hart privilege checks.
+    pub(crate) fn refresh_cpu_features(&mut self) {
+        let Some(cpu_enabled) = self.cpu_enabled.as_mut() else {
+            return;
+        };
+        for (hart_id, enabled) in cpu_enabled.iter_mut().enumerate() {
+            if *enabled {
+                *enabled = CPU_PRIVILEGED_ENABLED[hart_id].load(Ordering::Acquire);
+            }
+        }
+    }
+}
+
+pub struct Platform {
+    pub sbi: SBI,
+}
+
+impl Platform {
+    pub const fn new() -> Self {
+        Platform { sbi: SBI::new() }
+    }
+
+    pub fn init(&mut self, fdt_address: usize) {
+        let dtb = parse_device_tree(fdt_address).unwrap_or_else(fail::device_tree_format);
+        let dtb = dtb.share();
+
+        let root: serde_device_tree::buildin::Node = serde_device_tree::from_raw_mut(&dtb)
+            .unwrap_or_else(fail::device_tree_deserialize_root);
+        let tree: Tree = root.deserialize();
+
+        // Get console device, init sbi console and logger.
+        board_info_mut().discover_console(&root);
+        self.init_sbi_console_and_logger();
+        // Get other info that later platform initialization depends on.
+        board_info_mut().discover_misc(&tree);
+        // Get clint and reset device, init sbi ipi, reset, hsm, rfence and susp extension.
+        board_info_mut().discover_devices(&root);
+        self.sbi_ipi_init();
+        self.sbi_hsm_init();
+        self.sbi_reset_init();
+        self.sbi_rfence_init();
+        self.sbi_susp_init();
+        // Initialize pmu extension
+        self.sbi_init_pmu(&root);
+
+        // Record K1 platform detection *before* releasing the ready flag, so
+        // that secondary harts observing `READY` also observe the flag.
+        // Match the root node's `compatible` strings first (OpenSBI's
+        // spacemit_k1_match[] table), falling back to the model string.
+        let k1_platform = match root.get_prop("compatible") {
+            Some(prop) => {
+                let seq = prop.deserialize::<serde_device_tree::buildin::StrSeq>();
+                spacemit_k1::is_k1_platform(&board_info().model, seq.iter())
+            }
+            None => spacemit_k1::is_k1_platform(&board_info().model, core::iter::empty::<&str>()),
+        };
+        IS_K1_PLATFORM.store(k1_platform, Ordering::Release);
+
+        READY.store(true, Ordering::Release);
+    }
+
+    fn init_sbi_console_and_logger(&mut self) {
+        // init console and logger
+        self.sbi_console_init();
+        logger::Logger::init().unwrap();
+        info!("Hello RustSBI!");
+    }
+
+    fn sbi_init_pmu(&mut self, root: &serde_device_tree::buildin::Node) {
+        let mut pmu_node: Option<Pmu> = None;
+        let mut find_pmu = |node: &serde_device_tree::buildin::Node| {
+            let info = get_compatible(node);
+            if let Some(compatible_strseq) = info {
+                let compatible_iter = compatible_strseq.iter();
+                for compatible in compatible_iter {
+                    if compatible == "riscv,pmu" {
+                        pmu_node = Some(node.deserialize::<Pmu>());
+                    }
+                }
+            }
+        };
+        root.search(&mut find_pmu);
+
+        if let Some(ref pmu) = pmu_node {
+            let sbi_pmu = self.sbi.pmu.get_or_insert_default();
+            if let Some(ref event_to_mhpmevent) = pmu.event_to_mhpmevent {
+                let len = event_to_mhpmevent.len();
+                for idx in 0..len {
+                    let event = event_to_mhpmevent.get_event_id(idx);
+                    let mhpmevent = event_to_mhpmevent.get_selector_value(idx);
+                    sbi_pmu.insert_event_to_mhpmevent(event, mhpmevent);
+                    debug!(
+                        "pmu: insert event: 0x{:08x}, mhpmevent: {:#016x}",
+                        event, mhpmevent
+                    );
+                }
+            }
+
+            if let Some(ref event_to_mhpmcounters) = pmu.event_to_mhpmcounters {
+                let len = event_to_mhpmcounters.len();
+                for idx in 0..len {
+                    let events = event_to_mhpmcounters.get_event_idx_range(idx);
+                    let mhpmcounters = event_to_mhpmcounters.get_counter_bitmap(idx);
+                    let event_to_counter =
+                        EventToCounterMap::new(mhpmcounters, *events.start(), *events.end());
+                    debug!("pmu: insert event_to_mhpmcounter: {:x?}", event_to_counter);
+                    sbi_pmu.insert_event_to_mhpmcounter(event_to_counter);
+                }
+            }
+
+            if let Some(ref raw_event_to_mhpmcounters) = pmu.raw_event_to_mhpmcounters {
+                let len = raw_event_to_mhpmcounters.len();
+                for idx in 0..len {
+                    let raw_event_select = raw_event_to_mhpmcounters.get_event_idx_base(idx);
+                    let select_mask = raw_event_to_mhpmcounters.get_event_idx_mask(idx);
+                    let counters_mask = raw_event_to_mhpmcounters.get_counter_bitmap(idx);
+                    let raw_event_to_counter =
+                        RawEventToCounterMap::new(counters_mask, raw_event_select, select_mask);
+                    debug!(
+                        "pmu: insert raw_event_to_mhpmcounter: {:x?}",
+                        raw_event_to_counter
+                    );
+                    sbi_pmu.insert_raw_event_to_mhpmcounter(raw_event_to_counter);
+                }
+            }
+        }
+    }
+
+    fn sbi_console_init(&mut self) {
+        if let Some((base, console_type)) = board_info().console {
+            self.sbi.console = match console_type {
+                MachineConsoleType::Uart16550U8 => Some(SbiConsole::new(Mutex::new(Box::new(
+                    Uart16550Wrap::<u8>::new(base),
+                )))),
+                MachineConsoleType::Uart16550U32 => Some(SbiConsole::new(Mutex::new(Box::new(
+                    Uart16550Wrap::<u32>::new(base),
+                )))),
+                MachineConsoleType::UartAxiLite => Some(SbiConsole::new(Mutex::new(Box::new(
+                    MmioUartAxiLite::new(base),
+                )))),
+                MachineConsoleType::UartBflb => Some(SbiConsole::new(Mutex::new(Box::new(
+                    UartBflbWrap::new(base),
+                )))),
+                MachineConsoleType::UartSifive => Some(SbiConsole::new(Mutex::new(Box::new(
+                    UartSifiveWrap::new(base),
+                )))),
+                MachineConsoleType::UartPl011 => Some(SbiConsole::new(Mutex::new(Box::new(
+                    UartPl011Wrap::new(base),
+                )))),
+                MachineConsoleType::UartXscale => Some(SbiConsole::new(Mutex::new(Box::new(
+                    UartXscaleWrap::new(base, board_info().console_clock),
+                )))),
+            };
+        } else {
+            self.sbi.console = None;
+        }
+    }
+
+    fn sbi_reset_init(&mut self) {
+        if let Some(base) = board_info().reset {
+            self.sbi.reset = Some(SbiReset::new(Mutex::new(Box::new(
+                SifiveTestDeviceWrap::new(base),
+            ))));
+        } else if let Some((i2c_base, pmic_addr)) = board_info().pmic_reset {
+            self.sbi.reset = Some(SbiReset::new(Mutex::new(Box::new(P1PmicResetWrap::new(
+                i2c_base, pmic_addr,
+            )))));
+        } else {
+            self.sbi.reset = None;
+        }
+    }
+
     fn sbi_ipi_init(&mut self) {
-        let max_hart_id = self
-            .info
+        let max_hart_id = board_info()
             .cpu_enabled
             .as_ref()
             .and_then(|hart_list| hart_list.iter().rposition(|enabled| *enabled))
             .unwrap_or(NUM_HART_MAX - 1);
 
-        if let Some(ref aia_info) = self.info.aia {
+        if let Some(ref aia_info) = board_info().aia {
             use crate::sbi::features::{Extension, hart_extension_probe};
             let mut aia_usable = true;
-            if let Some(ref cpu_enabled) = self.info.cpu_enabled {
+            if let Some(ref cpu_enabled) = board_info().cpu_enabled {
                 for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
                     if *enabled {
                         if !hart_extension_probe(hart_id, Extension::Smaia) {
@@ -735,7 +781,7 @@ impl Platform {
                 let ipi_dev =
                     aia::ImsicDevice::new(aia_info.firmware_ipi_iid, aia_info.hart_imsic_map);
                 self.sbi.ipi = Some(SbiIpi::new(Mutex::new(Box::new(ipi_dev)), max_hart_id));
-                if self.info.is_qemu_virt() {
+                if board_info().is_qemu_virt() {
                     aia::init_qemu_m_aplic_delegation(
                         aia_info.layout.machine_base,
                         aia_info.layout.hart_index_bits,
@@ -743,7 +789,7 @@ impl Platform {
                 } else {
                     warn!(
                         "AIA: skipping QEMU virt M-APLIC setup on '{}'",
-                        self.info.model
+                        board_info().model
                     );
                 }
                 aia::set_aia_active(true);
@@ -752,7 +798,7 @@ impl Platform {
             }
             warn!("AIA: requirements not met, falling back to CLINT");
         }
-        if let Some((base, clint_type)) = self.info.ipi {
+        if let Some((base, clint_type)) = board_info().ipi {
             let ipi_dev: Box<dyn crate::sbi::ipi::IpiDevice> = match clint_type {
                 MachineClintType::SiFiveClint => Box::new(SifiveClintWrap::new(base)),
                 MachineClintType::TheadClint => Box::new(THeadClintWrap::new(base)),
@@ -799,17 +845,17 @@ impl Platform {
 
     #[inline]
     fn print_platform_info(&self) {
-        info!("{:<30}: {}", "Platform Name", self.info.model);
+        info!("{:<30}: {}", "Platform Name", board_info().model);
     }
 
     fn print_cpu_info(&self) {
         info!(
             "{:<30}: {:?}",
             "Platform HART Count",
-            self.info.cpu_num.unwrap_or(0)
+            board_info().cpu_num.unwrap_or(0)
         );
 
-        if let Some(cpu_enabled) = &self.info.cpu_enabled {
+        if let Some(cpu_enabled) = &board_info().cpu_enabled {
             let mut enabled_harts = [0; NUM_HART_MAX];
             let mut count = 0;
             for (i, &enabled) in cpu_enabled.iter().enumerate() {
@@ -838,7 +884,7 @@ impl Platform {
     #[inline]
     fn print_clint_info(&self) {
         if aia::is_aia_active()
-            && let Some(ref aia_info) = self.info.aia
+            && let Some(ref aia_info) = board_info().aia
         {
             info!(
                 "{:<30}: IMSIC (M-level Base Address: 0x{:x})",
@@ -846,7 +892,7 @@ impl Platform {
             );
             return;
         }
-        match self.info.ipi {
+        match board_info().ipi {
             Some((base, device)) => {
                 info!(
                     "{:<30}: {:?} (Base Address: 0x{:x})",
@@ -859,7 +905,7 @@ impl Platform {
 
     #[inline]
     fn print_console_info(&self) {
-        match self.info.console {
+        match board_info().console {
             Some((base, device)) => {
                 info!(
                     "{:<30}: {:?} (Base Address: 0x{:x})",
@@ -872,12 +918,12 @@ impl Platform {
 
     #[inline]
     fn print_reset_info(&self) {
-        if let Some(base) = self.info.reset {
+        if let Some(base) = board_info().reset {
             info!(
                 "{:<30}: Available (Base Address: 0x{:x})",
                 "Platform Reset Extension", base
             );
-        } else if let Some((i2c_base, pmic_addr)) = self.info.pmic_reset {
+        } else if let Some((i2c_base, pmic_addr)) = board_info().pmic_reset {
             info!(
                 "{:<30}: Available (P1 PMIC @ 0x{:02x}, I2C Base: 0x{:x})",
                 "Platform Reset Extension", pmic_addr, i2c_base
@@ -925,7 +971,7 @@ impl Platform {
 
     #[inline]
     fn print_memory_info(&self) {
-        if let Some(memory_range) = &self.info.memory_range {
+        if let Some(memory_range) = &board_info().memory_range {
             info!(
                 "{:<30}: 0x{:x} - 0x{:x}",
                 "Memory range", memory_range.start, memory_range.end

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -53,9 +53,14 @@ pub(crate) static CPU_PRIVILEGED_ENABLED: [AtomicBool; NUM_HART_MAX] =
 /// Set to true once init detects the platform is a SpacemiT K1 / Ky X1.
 ///
 /// Written in `Platform::init` *before* the ready flag is released, so that a
-/// secondary hart observing `ready() == true` is guaranteed to also observe
+/// secondary hart observing `READY == true` is guaranteed to also observe
 /// this flag (main.rs secondary-hart path).
 pub(crate) static IS_K1_PLATFORM: AtomicBool = AtomicBool::new(false);
+
+/// Boot synchronization flag: set by the boot hart once platform
+/// initialization is complete, spinning secondary harts observe it with
+/// Acquire ordering (`wait_until_ready`).
+pub(crate) static READY: AtomicBool = AtomicBool::new(false);
 
 const RISCV_MACHINE_EXTERNAL_IRQ: u32 = 11;
 
@@ -194,7 +199,6 @@ impl BoardInfo {
 pub struct Platform {
     pub info: BoardInfo,
     pub sbi: SBI,
-    pub ready: AtomicBool,
 }
 
 impl Platform {
@@ -202,7 +206,6 @@ impl Platform {
         Platform {
             info: BoardInfo::new(),
             sbi: SBI::new(),
-            ready: AtomicBool::new(false),
         }
     }
 
@@ -236,7 +239,7 @@ impl Platform {
         };
         IS_K1_PLATFORM.store(k1_platform, Ordering::Release);
 
-        self.ready.swap(true, Ordering::Release);
+        READY.store(true, Ordering::Release);
     }
 
     fn init_sbi_console_and_logger(&mut self) {
@@ -934,7 +937,7 @@ impl Platform {
 
     #[inline]
     fn print_additional_info(&self) {
-        if !self.ready.load(Ordering::Acquire) {
+        if !READY.load(Ordering::Acquire) {
             warn!(
                 "{:<30}: Platform initialization is not complete.",
                 "Platform Status"
@@ -976,10 +979,6 @@ impl Platform {
 
     pub fn have_pmu(&self) -> bool {
         self.sbi.pmu.is_some()
-    }
-
-    pub fn ready(&self) -> bool {
-        self.ready.load(Ordering::Acquire)
     }
 }
 

--- a/prototyper/prototyper/src/platform/reset.rs
+++ b/prototyper/prototyper/src/platform/reset.rs
@@ -30,6 +30,11 @@ impl SifiveTestDeviceWrap {
     }
 }
 
+// SAFETY: `SifiveTestDeviceWrap` holds only a volatile MMIO pointer with
+// no Rust-side mutable state; moving the handle across harts is sound.
+// Access is serialized by the mutex around the published reset device.
+unsafe impl Send for SifiveTestDeviceWrap {}
+
 /// Reset Device: SifiveTestDevice
 impl ResetDevice for SifiveTestDeviceWrap {
     #[inline]
@@ -107,7 +112,7 @@ impl I2cK1Registers {
     /// Read the control register (ICR).
     #[inline]
     fn icr(&self) -> u32 {
-        // Safety: `self` points at MMIO registers; reads are volatile so
+        // SAFETY: `self` points at MMIO registers; reads are volatile so
         // the compiler cannot cache or reorder them.
         unsafe { core::ptr::addr_of!(self.icr).read_volatile() }
     }
@@ -115,7 +120,7 @@ impl I2cK1Registers {
     /// Write the control register (ICR).
     #[inline]
     fn set_icr(&self, val: u32) {
-        // Safety: `self` points at MMIO registers; writes are volatile so
+        // SAFETY: `self` points at MMIO registers; writes are volatile so
         // the compiler cannot elide or reorder them.
         unsafe { core::ptr::addr_of!(self.icr).cast_mut().write_volatile(val) }
     }

--- a/prototyper/prototyper/src/sbi/console.rs
+++ b/prototyper/prototyper/src/sbi/console.rs
@@ -1,9 +1,17 @@
 use alloc::boxed::Box;
 use core::fmt;
 use rustsbi::{Console, Physical, SbiRet};
-use spin::Mutex;
+use spin::{Mutex, Once};
 
-use crate::platform::PLATFORM;
+use crate::platform::BoardInfo;
+use crate::platform::console::MachineConsoleType;
+use crate::platform::console::Uart16550Wrap;
+use crate::platform::console::UartAxiLiteWrap;
+use crate::platform::console::UartBflbWrap;
+use crate::platform::console::UartPl011Wrap;
+use crate::platform::console::UartSifiveWrap;
+use crate::platform::console::UartXscaleWrap;
+use crate::sbi::logger;
 
 // Checks whether `(phys_addr_lo, phys_addr_hi, len)` can be represented
 // as a native address range on this machine.
@@ -27,7 +35,7 @@ fn checked_physical_addr(lo: usize, hi: usize, len: usize) -> Result<usize, SbiR
 }
 
 /// A trait that must be implemented by console devices to provide basic I/O functionality.
-pub trait ConsoleDevice {
+pub trait ConsoleDevice: Send {
     /// Reads bytes from the console into the provided buffer.
     ///
     /// # Returns
@@ -41,21 +49,31 @@ pub trait ConsoleDevice {
     fn write(&self, buf: &[u8]) -> usize;
 }
 
+/// The machine console device, published once by [`init`] when the board
+/// provides a console.
+///
+/// Invariant: published (pre-`READY`) before the logger is brought up, so
+/// that early boot messages are printable; read afterwards by the print
+/// macros and the console ecall paths. Before publication, [`_print`] is a
+/// no-op (matching the previous `have_console` skip).
+static CONSOLE_DEVICE: Once<Mutex<Box<dyn ConsoleDevice>>> = Once::new();
+
 /// An implementation of the SBI console interface that wraps a console device.
 ///
 /// This provides a safe interface for interacting with console hardware through the
-/// SBI specification.
+/// SBI specification. The handle borrows the device published in
+/// [`CONSOLE_DEVICE`]; all I/O goes through the device lock.
 pub struct SbiConsole {
-    inner: Mutex<Box<dyn ConsoleDevice>>,
+    inner: &'static Mutex<Box<dyn ConsoleDevice>>,
 }
 
 impl SbiConsole {
-    /// Creates a new SBI console that wraps the provided locked console device.
+    /// Creates a new SBI console handle over the published console device.
     ///
     /// # Arguments
-    /// * `inner` - A mutex containing the console device implementation
+    /// * `inner` - The published console device, protected by a mutex
     #[inline]
-    pub fn new(inner: Mutex<Box<dyn ConsoleDevice>>) -> Self {
+    pub fn new(inner: &'static Mutex<Box<dyn ConsoleDevice>>) -> Self {
         Self { inner }
     }
 
@@ -67,7 +85,7 @@ impl SbiConsole {
     /// # Returns
     /// Always returns 0 to indicate success
     #[inline]
-    pub fn putchar(&mut self, c: usize) -> usize {
+    pub fn putchar(&self, c: usize) -> usize {
         let byte = [c as u8];
         while self.inner.lock().write(&byte) == 0 {
             core::hint::spin_loop();
@@ -158,30 +176,82 @@ impl Console for SbiConsole {
     }
 }
 
-impl fmt::Write for SbiConsole {
-    /// Implement Write trait for string formatting.
-    #[inline]
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        let mut bytes = s.as_bytes();
-        while !bytes.is_empty() {
-            let count = self.inner.lock().write(bytes);
-            if count == 0 {
-                return Err(fmt::Error);
+/// Prints formatted arguments to the console device, if one is present.
+///
+/// The `print!`/`println!` macros route here; before the console device is
+/// published this is a no-op (matching the previous `have_console` skip).
+/// The chunked-write loop keeps the write semantics of the old
+/// `fmt::Write for SbiConsole` impl: write until the device reports
+/// progress, error on a zero-byte write.
+pub fn _print(args: fmt::Arguments) {
+    use core::fmt::Write as _;
+
+    struct ConsoleWriter<'a> {
+        device: &'a Mutex<Box<dyn ConsoleDevice>>,
+    }
+
+    impl fmt::Write for ConsoleWriter<'_> {
+        #[inline]
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            let mut bytes = s.as_bytes();
+            while !bytes.is_empty() {
+                let count = self.device.lock().write(bytes);
+                if count == 0 {
+                    return Err(fmt::Error);
+                }
+                bytes = &bytes[count..];
             }
-            bytes = &bytes[count..];
+            Ok(())
         }
-        Ok(())
+    }
+
+    if let Some(device) = CONSOLE_DEVICE.get() {
+        ConsoleWriter { device }.write_fmt(args).unwrap();
     }
 }
 
 /// Global function to write a character to the console.
 #[inline]
 pub fn putchar(c: usize) -> usize {
-    unsafe { PLATFORM.sbi.console.as_mut().unwrap().putchar(c) }
+    SbiConsole::new(
+        CONSOLE_DEVICE
+            .get()
+            .expect("console device not initialized"),
+    )
+    .putchar(c)
 }
 
 /// Global function to read a character from the console.
 #[inline]
 pub fn getchar() -> usize {
-    unsafe { PLATFORM.sbi.console.as_mut().unwrap().getchar() }
+    SbiConsole::new(
+        CONSOLE_DEVICE
+            .get()
+            .expect("console device not initialized"),
+    )
+    .getchar()
+}
+
+/// Initializes the SBI console from the discovered board info, then brings up
+/// the logger (bundled, so that early boot messages are printable).
+pub(crate) fn init(board: &BoardInfo) -> Option<SbiConsole> {
+    // init console and logger
+    let console = board.console.map(|(base, console_type)| {
+        let device: Box<dyn ConsoleDevice> = match console_type {
+            MachineConsoleType::Uart16550U8 => Box::new(Uart16550Wrap::<u8>::new(base)),
+            MachineConsoleType::Uart16550U32 => Box::new(Uart16550Wrap::<u32>::new(base)),
+            MachineConsoleType::UartAxiLite => Box::new(UartAxiLiteWrap::new(base)),
+            MachineConsoleType::UartBflb => Box::new(UartBflbWrap::new(base)),
+            MachineConsoleType::UartSifive => Box::new(UartSifiveWrap::new(base)),
+            MachineConsoleType::UartPl011 => Box::new(UartPl011Wrap::new(base)),
+            MachineConsoleType::UartXscale => {
+                Box::new(UartXscaleWrap::new(base, board.console_clock))
+            }
+        };
+        CONSOLE_DEVICE.call_once(|| Mutex::new(device));
+        SbiConsole::new(CONSOLE_DEVICE.get().expect("console device just published"))
+    });
+    logger::Logger::init().unwrap();
+    info!("Hello RustSBI!");
+    console
 }

--- a/prototyper/prototyper/src/sbi/console.rs
+++ b/prototyper/prototyper/src/sbi/console.rs
@@ -89,7 +89,7 @@ impl SbiConsole {
     // Rejects buffers that this firmware cannot safely turn into raw slices.
     //
     // The SBI address tuple may still be valid,
-    // but this implementation only accepts buffers inside `PLATFORM.info.memory_range`.
+    // but this implementation only accepts buffers inside `board_info().memory_range`.
     #[inline]
     fn checked_physical_buffer<P>(&self, bytes: &Physical<P>) -> Result<(usize, usize), SbiRet> {
         let len = bytes.num_bytes();
@@ -102,7 +102,7 @@ impl SbiConsole {
             Err(err) => return Err(err),
         };
 
-        match unsafe { PLATFORM.info.memory_range.as_ref() } {
+        match crate::platform::board_info().memory_range.as_ref() {
             Some(range)
                 if start >= range.start
                     && start.checked_add(len).is_some_and(|end| end <= range.end) => {}

--- a/prototyper/prototyper/src/sbi/hsm.rs
+++ b/prototyper/prototyper/src/sbi/hsm.rs
@@ -6,7 +6,6 @@ use core::{
 use riscv::register::mstatus::MPP;
 use rustsbi::{SbiRet, spec::hsm::hart_state};
 
-use crate::platform::PLATFORM;
 use crate::riscv::current_hartid;
 use crate::sbi::hart_context::NextStage;
 use crate::sbi::trap_stack::ROOT_STACK;
@@ -185,7 +184,7 @@ pub(crate) fn local_hsm() -> LocalHsmCell<'static, NextStage> {
 }
 
 /// Returns a remote-capable view of the current hart's HSM cell.
-pub(crate) fn hsm() -> RemoteHsmCell<'static, NextStage> {
+pub(crate) fn hart_hsm() -> RemoteHsmCell<'static, NextStage> {
     hart_context(current_hartid()).hsm.remote()
 }
 
@@ -218,9 +217,7 @@ impl rustsbi::Hsm for SbiHsm {
                     opaque,
                     next_mode: MPP::Supervisor,
                 }) {
-                    unsafe {
-                        PLATFORM.sbi.ipi.as_ref().unwrap().set_msip(hartid);
-                    }
+                    crate::sbi::ipi().unwrap().set_msip(hartid);
                     SbiRet::success(0)
                 } else {
                     SbiRet::already_available()
@@ -265,14 +262,7 @@ impl rustsbi::Hsm for SbiHsm {
         }
 
         crate::sbi::trap::handler::msoft_ipi_handler();
-        unsafe {
-            PLATFORM
-                .sbi
-                .ipi
-                .as_ref()
-                .unwrap()
-                .clear_msip(current_hartid());
-        }
+        crate::sbi::ipi().unwrap().clear_msip(current_hartid());
         unsafe {
             riscv::register::mie::set_msoft();
         }

--- a/prototyper/prototyper/src/sbi/hsm.rs
+++ b/prototyper/prototyper/src/sbi/hsm.rs
@@ -205,7 +205,7 @@ pub(crate) struct SbiHsm;
 impl rustsbi::Hsm for SbiHsm {
     /// Starts execution on a stopped hart.
     fn hart_start(&self, hartid: usize, start_addr: usize, opaque: usize) -> SbiRet {
-        let hart_enable = unsafe { PLATFORM.info.cpu_enabled.unwrap() };
+        let hart_enable = crate::platform::board_info().cpu_enabled.unwrap();
         let enabled = hart_enable.get(hartid).copied().unwrap_or(false);
         if !enabled {
             return SbiRet::invalid_param();
@@ -244,7 +244,7 @@ impl rustsbi::Hsm for SbiHsm {
     /// Gets the current state of a hart.
     #[inline]
     fn hart_get_status(&self, hartid: usize) -> SbiRet {
-        let hart_enable = unsafe { PLATFORM.info.cpu_enabled.unwrap() };
+        let hart_enable = crate::platform::board_info().cpu_enabled.unwrap();
         let enabled = hart_enable.get(hartid).copied().unwrap_or(false);
         if !enabled {
             return SbiRet::invalid_param();

--- a/prototyper/prototyper/src/sbi/ipi.rs
+++ b/prototyper/prototyper/src/sbi/ipi.rs
@@ -1,5 +1,8 @@
 use super::pmu::pmu_firmware_counter_increment;
-use crate::platform::PLATFORM;
+use crate::cfg::NUM_HART_MAX;
+use crate::platform::BoardInfo;
+use crate::platform::aia;
+use crate::platform::clint::{MachineClintType, SifiveClintWrap, THeadClintWrap};
 use crate::riscv::csr::stimecmp;
 use crate::riscv::current_hartid;
 use crate::sbi::features::{Extension, hart_extension_probe};
@@ -235,7 +238,7 @@ pub fn get_and_reset_ipi_type() -> u8 {
 /// Clear machine software interrupt pending for current hart.
 #[inline]
 pub fn claim_ipi() {
-    match unsafe { PLATFORM.sbi.ipi.as_ref() } {
+    match crate::sbi::ipi() {
         Some(ipi) => ipi.clear_msip(current_hartid()),
         None => error!("SBI or IPI device not initialized"),
     }
@@ -244,7 +247,7 @@ pub fn claim_ipi() {
 /// Clear machine timer interrupt for current hart.
 #[inline]
 pub fn clear_mtime() {
-    match unsafe { PLATFORM.sbi.ipi.as_ref() } {
+    match crate::sbi::ipi() {
         Some(ipi) => ipi.write_mtimecmp(current_hartid(), u64::MAX),
         None => error!("SBI or IPI device not initialized"),
     }
@@ -253,10 +256,69 @@ pub fn clear_mtime() {
 /// Clear all pending interrupts for current hart.
 #[inline]
 pub fn clear_all() {
-    match unsafe { PLATFORM.sbi.ipi.as_ref() } {
+    match crate::sbi::ipi() {
         Some(ipi) => ipi.clear(),
         None => error!("SBI or IPI device not initialized"),
     }
+}
+
+/// Initializes the SBI IPI extension from the discovered board info
+/// (AIA probe with CLINT fallback).
+pub(crate) fn init(board: &BoardInfo) -> Option<SbiIpi> {
+    let max_hart_id = board
+        .cpu_enabled
+        .as_ref()
+        .and_then(|hart_list| hart_list.iter().rposition(|enabled| *enabled))
+        .unwrap_or(NUM_HART_MAX - 1);
+
+    if let Some(ref aia_info) = board.aia {
+        let mut aia_usable = true;
+        if let Some(ref cpu_enabled) = board.cpu_enabled {
+            for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
+                if *enabled && !aia_hart_usable(hart_id) {
+                    aia_usable = false;
+                    break;
+                }
+            }
+        }
+        if aia_usable {
+            let ipi_dev = aia::ImsicDevice::new(aia_info.firmware_ipi_iid, aia_info.hart_imsic_map);
+            if board.is_qemu_virt() {
+                aia::init_qemu_m_aplic_delegation(
+                    aia_info.layout.machine_base,
+                    aia_info.layout.hart_index_bits,
+                );
+            } else {
+                warn!("AIA: skipping QEMU virt M-APLIC setup on '{}'", board.model);
+            }
+            aia::set_aia_active(true);
+            info!("AIA: IMSIC IPI + Sstc timer backend initialized");
+            return Some(SbiIpi::new(Mutex::new(Box::new(ipi_dev)), max_hart_id));
+        }
+        warn!("AIA: requirements not met, falling back to CLINT");
+    }
+    if let Some((base, clint_type)) = board.ipi {
+        let ipi_dev: Box<dyn IpiDevice> = match clint_type {
+            MachineClintType::SiFiveClint => Box::new(SifiveClintWrap::new(base)),
+            MachineClintType::TheadClint => Box::new(THeadClintWrap::new(base)),
+        };
+        return Some(SbiIpi::new(Mutex::new(ipi_dev), max_hart_id));
+    }
+    None
+}
+
+/// Reports whether the hart passes the AIA requirements (Smaia + Sstc),
+/// warning once per missing extension.
+fn aia_hart_usable(hart_id: usize) -> bool {
+    if !hart_extension_probe(hart_id, Extension::Smaia) {
+        warn!("AIA: hart {} lacks Smaia, rejecting AIA", hart_id);
+        return false;
+    }
+    if !hart_extension_probe(hart_id, Extension::Sstc) {
+        warn!("AIA: hart {} lacks Sstc, rejecting AIA", hart_id);
+        return false;
+    }
+    true
 }
 
 fn target_harts(hart_mask: HartMask, max_hart_id: usize) -> Vec<usize> {

--- a/prototyper/prototyper/src/sbi/ipi.rs
+++ b/prototyper/prototyper/src/sbi/ipi.rs
@@ -86,12 +86,10 @@ impl rustsbi::Ipi for SbiIpi {
                 return SbiRet::invalid_param();
             };
 
-            if unsafe {
-                PLATFORM
-                    .info
-                    .cpu_enabled
-                    .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
-            } {
+            if crate::platform::board_info()
+                .cpu_enabled
+                .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
+            {
                 return SbiRet::invalid_param();
             }
 
@@ -145,12 +143,10 @@ impl SbiIpi {
                 return SbiRet::invalid_param();
             };
 
-            if unsafe {
-                PLATFORM
-                    .info
-                    .cpu_enabled
-                    .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
-            } {
+            if crate::platform::board_info()
+                .cpu_enabled
+                .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
+            {
                 return SbiRet::invalid_param();
             }
 

--- a/prototyper/prototyper/src/sbi/mod.rs
+++ b/prototyper/prototyper/src/sbi/mod.rs
@@ -1,4 +1,5 @@
-use rustsbi::RustSBI;
+use rustsbi::{RustSBI, SbiRet};
+use spin::Once;
 
 pub mod console;
 pub mod hsm;
@@ -27,34 +28,94 @@ use suspend::SbiSuspend;
 
 #[derive(RustSBI, Default)]
 #[rustsbi(dynamic)]
-#[allow(clippy::upper_case_acronyms)]
-pub struct SBI {
+pub struct SbiDispatcher {
     #[rustsbi(console)]
-    pub console: Option<SbiConsole>,
+    console: Option<SbiConsole>,
     #[rustsbi(ipi, timer)]
-    pub ipi: Option<SbiIpi>,
+    ipi: Option<SbiIpi>,
     #[rustsbi(hsm)]
-    pub hsm: Option<SbiHsm>,
+    hsm: Option<SbiHsm>,
     #[rustsbi(reset)]
-    pub reset: Option<SbiReset>,
+    reset: Option<SbiReset>,
     #[rustsbi(fence)]
-    pub rfence: Option<SbiRFence>,
+    rfence: Option<SbiRFence>,
     #[rustsbi(pmu)]
-    pub pmu: Option<SbiPmu>,
+    pmu: Option<SbiPmu>,
     #[rustsbi(susp)]
-    pub susp: Option<SbiSuspend>,
+    susp: Option<SbiSuspend>,
 }
 
-impl SBI {
-    pub const fn new() -> Self {
-        SBI {
-            console: None,
-            ipi: None,
-            hsm: None,
-            reset: None,
-            rfence: None,
-            pmu: None,
-            susp: None,
+impl SbiDispatcher {
+    /// Assembles the dispatcher from the constructed extensions; the boot
+    /// composition publishes the result via [`SBI_DISPATCHER`].
+    pub(crate) fn new(
+        console: Option<SbiConsole>,
+        ipi: Option<SbiIpi>,
+        hsm: Option<SbiHsm>,
+        reset: Option<SbiReset>,
+        rfence: Option<SbiRFence>,
+        susp: Option<SbiSuspend>,
+        pmu: Option<SbiPmu>,
+    ) -> Self {
+        SbiDispatcher {
+            console,
+            ipi,
+            hsm,
+            reset,
+            rfence,
+            pmu,
+            susp,
         }
     }
+}
+
+/// The SBI extension set, owned by the sbi layer.
+///
+/// Invariant: published once by the boot composition (`init_board`) after
+/// all extension constructors have run and before `IS_K1_PLATFORM` is
+/// stored and `platform::READY` is released; read afterwards through the
+/// shared accessors below. Publishing and reading go through `spin::Once`,
+/// so this half of the split is fully safe.
+pub(crate) static SBI_DISPATCHER: Once<SbiDispatcher> = Once::new();
+
+/// Dispatches an SBI ecall to the matching extension; the sole
+/// whole-instance user of the dispatcher.
+///
+/// Pre-publish ecalls are unreachable: the trap vector only installs in
+/// main's phase 4, after the dispatcher has been published.
+pub(crate) fn handle_ecall(extension: usize, function: usize, param: [usize; 6]) -> SbiRet {
+    SBI_DISPATCHER
+        .get()
+        .expect("dispatcher published before ecall handling; mtvec installs in main phase 4, after publish")
+        .handle_ecall(extension, function, param)
+}
+
+/// Returns the ipi extension, if present.
+pub(crate) fn ipi() -> Option<&'static SbiIpi> {
+    SBI_DISPATCHER.get().and_then(|sbi| sbi.ipi.as_ref())
+}
+
+/// Returns the hsm extension, if present.
+pub(crate) fn hsm() -> Option<&'static SbiHsm> {
+    SBI_DISPATCHER.get().and_then(|sbi| sbi.hsm.as_ref())
+}
+
+/// Returns the reset extension, if present.
+pub(crate) fn reset() -> Option<&'static SbiReset> {
+    SBI_DISPATCHER.get().and_then(|sbi| sbi.reset.as_ref())
+}
+
+/// Returns the rfence extension, if present.
+pub(crate) fn rfence() -> Option<&'static SbiRFence> {
+    SBI_DISPATCHER.get().and_then(|sbi| sbi.rfence.as_ref())
+}
+
+/// Returns the pmu extension, if present.
+pub(crate) fn pmu() -> Option<&'static SbiPmu> {
+    SBI_DISPATCHER.get().and_then(|sbi| sbi.pmu.as_ref())
+}
+
+/// Returns the susp extension, if present.
+pub(crate) fn susp() -> Option<&'static SbiSuspend> {
+    SBI_DISPATCHER.get().and_then(|sbi| sbi.susp.as_ref())
 }

--- a/prototyper/prototyper/src/sbi/pmu.rs
+++ b/prototyper/prototyper/src/sbi/pmu.rs
@@ -7,7 +7,9 @@ use sbi_spec::pmu::shmem_size::SIZE;
 use sbi_spec::pmu::*;
 
 use crate::riscv::csr::*;
-use crate::{riscv::current_hartid, sbi::features::hart_mhpm_mask};
+use crate::{
+    devicetree, devicetree::get_compatible, riscv::current_hartid, sbi::features::hart_mhpm_mask,
+};
 
 use super::features::{PrivilegedVersion, hart_privileged_version};
 use super::trap_stack::{hart_context, hart_context_mut};
@@ -1204,4 +1206,66 @@ pub fn pmu_firmware_counter_increment(firmware_event: usize) {
             pmu_state.fw_counter[fw_idx] += 1;
         }
     }
+}
+
+/// Initializes the SBI PMU extension from the FDT pmu node.
+pub(crate) fn init(root: &serde_device_tree::buildin::Node) -> Option<SbiPmu> {
+    let mut pmu_node: Option<devicetree::Pmu> = None;
+    let mut find_pmu = |node: &serde_device_tree::buildin::Node| {
+        let Some(compatible_strseq) = get_compatible(node) else {
+            return;
+        };
+        for compatible in compatible_strseq.iter() {
+            if compatible == "riscv,pmu" {
+                pmu_node = Some(node.deserialize::<devicetree::Pmu>());
+            }
+        }
+    };
+    root.search(&mut find_pmu);
+
+    let Some(ref pmu) = pmu_node else {
+        return None;
+    };
+    let mut sbi_pmu = SbiPmu::default();
+    if let Some(ref event_to_mhpmevent) = pmu.event_to_mhpmevent {
+        let len = event_to_mhpmevent.len();
+        for idx in 0..len {
+            let event = event_to_mhpmevent.get_event_id(idx);
+            let mhpmevent = event_to_mhpmevent.get_selector_value(idx);
+            sbi_pmu.insert_event_to_mhpmevent(event, mhpmevent);
+            debug!(
+                "pmu: insert event: 0x{:08x}, mhpmevent: {:#016x}",
+                event, mhpmevent
+            );
+        }
+    }
+
+    if let Some(ref event_to_mhpmcounters) = pmu.event_to_mhpmcounters {
+        let len = event_to_mhpmcounters.len();
+        for idx in 0..len {
+            let events = event_to_mhpmcounters.get_event_idx_range(idx);
+            let mhpmcounters = event_to_mhpmcounters.get_counter_bitmap(idx);
+            let event_to_counter =
+                EventToCounterMap::new(mhpmcounters, *events.start(), *events.end());
+            debug!("pmu: insert event_to_mhpmcounter: {:x?}", event_to_counter);
+            sbi_pmu.insert_event_to_mhpmcounter(event_to_counter);
+        }
+    }
+
+    if let Some(ref raw_event_to_mhpmcounters) = pmu.raw_event_to_mhpmcounters {
+        let len = raw_event_to_mhpmcounters.len();
+        for idx in 0..len {
+            let raw_event_select = raw_event_to_mhpmcounters.get_event_idx_base(idx);
+            let select_mask = raw_event_to_mhpmcounters.get_event_idx_mask(idx);
+            let counters_mask = raw_event_to_mhpmcounters.get_counter_bitmap(idx);
+            let raw_event_to_counter =
+                RawEventToCounterMap::new(counters_mask, raw_event_select, select_mask);
+            debug!(
+                "pmu: insert raw_event_to_mhpmcounter: {:x?}",
+                raw_event_to_counter
+            );
+            sbi_pmu.insert_raw_event_to_mhpmcounter(raw_event_to_counter);
+        }
+    }
+    Some(sbi_pmu)
 }

--- a/prototyper/prototyper/src/sbi/reset.rs
+++ b/prototyper/prototyper/src/sbi/reset.rs
@@ -2,9 +2,10 @@ use alloc::boxed::Box;
 use rustsbi::SbiRet;
 use spin::Mutex;
 
-use crate::platform::PLATFORM;
+use crate::platform::BoardInfo;
+use crate::platform::reset::{P1PmicResetWrap, SifiveTestDeviceWrap};
 
-pub trait ResetDevice {
+pub trait ResetDevice: Send {
     fn fail(&self, code: u16) -> !;
     fn pass(&self) -> !;
     fn reset(&self) -> !;
@@ -48,7 +49,7 @@ impl rustsbi::Reset for SbiReset {
 
 #[allow(unused)]
 pub fn fail() -> ! {
-    match unsafe { PLATFORM.sbi.reset.as_ref() } {
+    match crate::sbi::reset() {
         Some(reset) => reset.fail(),
         None => {
             trace!("test fail, begin dead loop");
@@ -56,5 +57,20 @@ pub fn fail() -> ! {
                 core::hint::spin_loop()
             }
         }
+    }
+}
+
+/// Initializes the SBI reset extension from the discovered board info.
+pub(crate) fn init(board: &BoardInfo) -> Option<SbiReset> {
+    if let Some(base) = board.reset {
+        Some(SbiReset::new(Mutex::new(Box::new(
+            SifiveTestDeviceWrap::new(base),
+        ))))
+    } else if let Some((i2c_base, pmic_addr)) = board.pmic_reset {
+        Some(SbiReset::new(Mutex::new(Box::new(P1PmicResetWrap::new(
+            i2c_base, pmic_addr,
+        )))))
+    } else {
+        None
     }
 }

--- a/prototyper/prototyper/src/sbi/rfence.rs
+++ b/prototyper/prototyper/src/sbi/rfence.rs
@@ -3,7 +3,6 @@ use sbi_spec::pmu::firmware_event;
 use spin::Mutex;
 
 use crate::cfg::{PAGE_SIZE, TLB_FLUSH_LIMIT};
-use crate::platform::PLATFORM;
 use crate::riscv::current_hartid;
 use crate::sbi::fifo::{Fifo, FifoError};
 use crate::sbi::trap_stack::ROOT_STACK;
@@ -195,7 +194,7 @@ fn validate_address_range(start_addr: usize, size: usize) -> Result<usize, SbiRe
 
 /// Processes a remote fence operation by sending IPI to target harts.
 fn remote_fence_process(rfence_ctx: RFenceContext, hart_mask: HartMask) -> SbiRet {
-    let sbi_ret = unsafe { PLATFORM.sbi.ipi.as_ref() }
+    let sbi_ret = crate::sbi::ipi()
         .unwrap()
         .send_ipi_by_fence(hart_mask, rfence_ctx);
 

--- a/prototyper/prototyper/src/sbi/suspend.rs
+++ b/prototyper/prototyper/src/sbi/suspend.rs
@@ -23,7 +23,8 @@ impl rustsbi::Susp for SbiSuspend {
         }
 
         // Check if all harts except the current hart are stopped
-        let hart_enable_map = if let Some(hart_enable_map) = unsafe { PLATFORM.info.cpu_enabled } {
+        let hart_enable_map = if let Some(hart_enable_map) = crate::platform::board_info().cpu_enabled
+        {
             hart_enable_map
         } else {
             return SbiRet::failed();

--- a/prototyper/prototyper/src/sbi/suspend.rs
+++ b/prototyper/prototyper/src/sbi/suspend.rs
@@ -2,7 +2,7 @@ use riscv::register::mstatus;
 use rustsbi::{Hsm, SbiRet};
 use sbi_spec::hsm::{hart_state::STOPPED, suspend_type::NON_RETENTIVE};
 
-use crate::{platform::PLATFORM, riscv::current_hartid};
+use crate::riscv::current_hartid;
 
 use super::hsm::remote_hsm;
 
@@ -23,12 +23,12 @@ impl rustsbi::Susp for SbiSuspend {
         }
 
         // Check if all harts except the current hart are stopped
-        let hart_enable_map = if let Some(hart_enable_map) = crate::platform::board_info().cpu_enabled
-        {
-            hart_enable_map
-        } else {
-            return SbiRet::failed();
-        };
+        let hart_enable_map =
+            if let Some(hart_enable_map) = crate::platform::board_info().cpu_enabled {
+                hart_enable_map
+            } else {
+                return SbiRet::failed();
+            };
         for (hartid, hart_enable) in hart_enable_map.iter().enumerate() {
             if *hart_enable && hartid != current_hartid() {
                 match remote_hsm(hartid) {
@@ -45,7 +45,7 @@ impl rustsbi::Susp for SbiSuspend {
         // TODO: The validity of `resume_addr` should be checked.
         // If it is invalid, `SBI_ERR_INVALID_ADDRESS` should be returned.
 
-        match unsafe { &PLATFORM.sbi.hsm } {
+        match crate::sbi::hsm() {
             Some(hsm) => hsm.hart_suspend(NON_RETENTIVE, resume_addr, opaque),
             None => SbiRet::not_supported(),
         }

--- a/prototyper/prototyper/src/sbi/trap/handler.rs
+++ b/prototyper/prototyper/src/sbi/trap/handler.rs
@@ -1,10 +1,8 @@
 use fast_trap::{EntireContext, EntireContextSeparated, EntireResult, FastContext, FastResult};
 use riscv::register::{mepc, mie, mstatus, mtval, satp, sstatus};
 use riscv_decode::{Instruction, decode};
-use rustsbi::RustSBI;
 use sbi_spec::pmu::firmware_event;
 
-use crate::platform::PLATFORM;
 use crate::riscv::csr::{CSR_TIME, CSR_TIMEH};
 use crate::riscv::current_hartid;
 use crate::sbi::console;
@@ -166,11 +164,7 @@ pub fn sbi_call_handler(
     a7: usize,
 ) -> FastResult {
     use sbi_spec::{base, hsm, legacy};
-    let mut ret = unsafe {
-        PLATFORM
-            .sbi
-            .handle_ecall(a7, a6, [ctx.a0(), a1, a2, a3, a4, a5])
-    };
+    let mut ret = crate::sbi::handle_ecall(a7, a6, [ctx.a0(), a1, a2, a3, a4, a5]);
     if ret.is_ok() {
         match (a7, a6) {
             (hsm::EID_HSM, hsm::HART_SUSPEND)
@@ -180,7 +174,7 @@ pub fn sbi_call_handler(
             }
             (base::EID_BASE, base::PROBE_EXTENSION) => match ctx.a0() {
                 legacy::LEGACY_SET_TIMER => {
-                    ret.value = unsafe { PLATFORM.sbi.ipi.is_some() } as usize;
+                    ret.value = crate::sbi::ipi().is_some() as usize;
                 }
                 legacy::LEGACY_CONSOLE_PUTCHAR | legacy::LEGACY_CONSOLE_GETCHAR => {
                     ret.value = 1;
@@ -192,7 +186,7 @@ pub fn sbi_call_handler(
     } else {
         match a7 {
             legacy::LEGACY_SET_TIMER => {
-                if let Some(ipi) = unsafe { PLATFORM.sbi.ipi.as_ref() } {
+                if let Some(ipi) = crate::sbi::ipi() {
                     rustsbi::Timer::set_timer(ipi, ctx.a0() as u64);
                     ret.error = 0;
                     ret.value = a1;
@@ -244,14 +238,14 @@ pub extern "C" fn illegal_instruction_handler(raw_ctx: EntireContext) -> EntireR
                 save_reg_x(
                     &mut ctx,
                     csr.rd() as usize,
-                    unsafe { PLATFORM.sbi.ipi.as_ref() }.unwrap().get_time(),
+                    crate::sbi::ipi().unwrap().get_time(),
                 );
             }
             CSR_TIMEH => {
                 save_reg_x(
                     &mut ctx,
                     csr.rd() as usize,
-                    unsafe { PLATFORM.sbi.ipi.as_ref() }.unwrap().get_timeh(),
+                    crate::sbi::ipi().unwrap().get_timeh(),
                 );
             }
             _ => {

--- a/prototyper/prototyper/src/sbi/trap/handler.rs
+++ b/prototyper/prototyper/src/sbi/trap/handler.rs
@@ -102,8 +102,10 @@ pub fn mext_handler(ctx: FastContext) -> FastResult {
         return ctx.restore();
     }
 
-    let Some(firmware_ipi_iid) =
-        (unsafe { PLATFORM.info.aia.as_ref().map(|a| a.firmware_ipi_iid) })
+    let Some(firmware_ipi_iid) = crate::platform::board_info()
+        .aia
+        .as_ref()
+        .map(|a| a.firmware_ipi_iid)
     else {
         warn!("MachineExternal: missing AIA platform info");
         return ctx.restore();


### PR DESCRIPTION
The prototyper's `Platform` struct fuses three unrelated concerns in
one global: board discovery from the FDT (`info: BoardInfo`), the SBI
extension set (`sbi: SBI`), and the boot-sync flag (`ready`). Every
layer reaches through `static mut PLATFORM` — the sbi layer included,
which has to walk a platform global just to find its own extensions.
The fused `Platform::init` likewise mixes FDT discovery with the
construction of every SBI extension, so neither half can be read or
changed without the other.

This splits them by ownership:

- `platform` keeps board discovery: FDT parsing fills `BOARD_INFO`
  behind `board_info()`, and the boot-sync flag becomes a plain
  `READY: AtomicBool`.
- the sbi layer owns its extension set: `SbiDispatcher` (was `SBI`)
  is constructed from the discovered board info and published once
  via `spin::Once`, with safe fine-grained accessors; this half now
  carries zero unsafe.
- `platform/boot.rs::init_board` sequences the phases (discovery and
  construction interleave as before, e.g. the console and logger come
  up before the discovery steps whose panics need printing).

Consumer sites are migrated off `PLATFORM` accordingly, and the CI
boot gate learns to assert the dispatcher-backed extension lines so a
regression in the new construction path fails loudly instead of
booting green with silently absent extensions.

Wire ABI, init ordering, and the boot log are unchanged — verified
with the full local QEMU matrix (payload/dynamic/jump × test/bench)
and a byte-identical boot log on `aia=aplic-imsic`.

`BOARD_INFO` intentionally stays `static mut` for now (confined to
its accessors); hardening it is the planned next step.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
