### PR TITLE
refactor(prototyper): publish board facts via Once, split runtime CPU table

### DIFF
--- a/prototyper/prototyper/src/main.rs
+++ b/prototyper/prototyper/src/main.rs
@@ -2,7 +2,6 @@
 #![feature(fn_align)]
 #![no_std]
 #![no_main]
-#![allow(static_mut_refs)]
 
 extern crate alloc;
 #[macro_use]
@@ -56,7 +55,7 @@ fn boot_hart(boot: &BootInfo) {
     let mut next = boot.next_stage();
     check_privilege(next.next_mode);
 
-    platform::refresh_enabled_cpus();
+    platform::refresh_cpu_features();
     next.opaque = firmware::patch_device_tree(boot.fdt_address());
     info!(
         "Redirecting hart {} to {:#016x} in {:?} mode.",

--- a/prototyper/prototyper/src/platform/boot.rs
+++ b/prototyper/prototyper/src/platform/boot.rs
@@ -3,7 +3,9 @@
 use core::ops::Range;
 use core::sync::atomic::Ordering;
 
-use super::{IS_K1_PLATFORM, READY, board_info, board_info_mut, print_board_info};
+use super::{
+    BOARD_INFO, BoardInfo, IS_K1_PLATFORM, READY, board_info, print_board_info, publish_cpu_enabled,
+};
 use crate::devicetree::{Tree, parse_device_tree};
 use crate::fail;
 use crate::riscv::spacemit_k1;
@@ -23,16 +25,18 @@ pub fn init_board(fdt_address: usize) {
         serde_device_tree::from_raw_mut(&dtb).unwrap_or_else(fail::device_tree_deserialize_root);
     let tree: Tree = root.deserialize();
 
+    let mut board = BoardInfo::new();
     // Get console device, init sbi console and logger.
-    board_info_mut().discover_console(&root);
-    let console = sbi::console::init(board_info());
+    board.discover_console(&root);
+    let console = sbi::console::init(&board);
     // Get other info that later platform initialization depends on.
-    board_info_mut().discover_misc(&tree);
+    let cpu_list = board.discover_misc(&tree);
+    publish_cpu_enabled(cpu_list);
     // Get clint and reset device, init sbi ipi, reset, hsm, rfence and susp extension.
-    board_info_mut().discover_devices(&root);
-    let ipi = sbi::ipi::init(board_info());
+    board.discover_devices(&root);
+    let ipi = sbi::ipi::init(&board);
     let hsm = ipi.as_ref().map(|_| SbiHsm);
-    let reset = sbi::reset::init(board_info());
+    let reset = sbi::reset::init(&board);
     let rfence = ipi.as_ref().map(|_| SbiRFence);
     let susp = hsm.as_ref().map(|_| SbiSuspend);
     // Initialize pmu extension
@@ -42,6 +46,10 @@ pub fn init_board(fdt_address: usize) {
     // so that harts observing `READY` also observe the published dispatcher.
     sbi::SBI_DISPATCHER
         .call_once(|| SbiDispatcher::new(console, ipi, hsm, reset, rfence, susp, pmu));
+
+    // Publish the board facts before the K1 detect / READY release, so that
+    // harts observing `READY` (Acquire) also observe the published board.
+    BOARD_INFO.call_once(move || board);
 
     // Record K1 platform detection *before* releasing the ready flag, so
     // that secondary harts observing `READY` also observe the flag.
@@ -90,9 +98,4 @@ pub fn wait_until_ready() {
 /// Returns the board's memory range (set during `init_board`).
 pub fn memory_range() -> Range<usize> {
     board_info().memory_range.as_ref().unwrap().clone()
-}
-
-/// Reconciles the enabled-CPU table with the per-hart privilege checks.
-pub fn refresh_enabled_cpus() {
-    board_info_mut().refresh_cpu_features();
 }

--- a/prototyper/prototyper/src/platform/mod.rs
+++ b/prototyper/prototyper/src/platform/mod.rs
@@ -15,6 +15,7 @@ use crate::platform::console::{
 use crate::platform::reset::P1_PMIC_COMPATIBLE;
 use crate::platform::reset::SIFIVETEST_COMPATIBLE;
 use crate::sbi::features::extension_detection;
+use spin::{Once, RwLock};
 
 pub(crate) mod aia;
 mod boot;
@@ -22,9 +23,7 @@ pub(crate) mod clint;
 pub(crate) mod console;
 pub(crate) mod reset;
 
-pub use boot::{
-    init_board, memory_range, refresh_enabled_cpus, secondary_hart_init, wait_until_ready,
-};
+pub use boot::{init_board, memory_range, secondary_hart_init, wait_until_ready};
 
 pub(crate) static CPU_PRIVILEGED_ENABLED: [AtomicBool; NUM_HART_MAX] =
     [const { AtomicBool::new(false) }; NUM_HART_MAX];
@@ -41,26 +40,50 @@ pub(crate) static IS_K1_PLATFORM: AtomicBool = AtomicBool::new(false);
 /// Acquire ordering (`wait_until_ready`).
 pub(crate) static READY: AtomicBool = AtomicBool::new(false);
 
-/// Board information discovered from the FDT, owned by the platform layer.
-///
-/// Invariant: written by the boot hart *before* `READY` is released, read
-/// afterwards; `wait_until_ready` (Acquire) is the secondary-hart edge.
-///
-/// Pre-existing exception (preserved, not hardened): `refresh_cpu_features`
-/// rewrites `cpu_enabled` after `READY` while other harts may read it
-/// concurrently (bool array, copied out per call).
-static mut BOARD_INFO: BoardInfo = BoardInfo::new();
+/// Board facts discovered from the FDT.
+static BOARD_INFO: Once<BoardInfo> = Once::new();
 
-/// Returns a shared view of the discovered board information.
+/// Enabled-hart table; rewritten once post-`READY` by `refresh_cpu_features`.
+static CPU_ENABLED: RwLock<Option<CpuEnableList>> = RwLock::new(None);
+
+/// Returns the published board information.
+///
+/// # Panics
+///
+/// Panics if called before `init_board` publishes the board; publication
+/// precedes the `READY` release, so runtime readers gated on `READY`
+/// cannot race it.
 pub(crate) fn board_info() -> &'static BoardInfo {
-    unsafe { &BOARD_INFO }
+    BOARD_INFO
+        .get()
+        .expect("board published before any runtime reader")
 }
 
-/// Returns an exclusive view of the board information; used by the discovery
-/// (`BoardInfo::discover_*`) and refresh (`BoardInfo::refresh_cpu_features`)
-/// paths only.
-pub(crate) fn board_info_mut() -> &'static mut BoardInfo {
-    unsafe { &mut BOARD_INFO }
+/// Returns a copy of the enabled-CPU table (`None` before `init_board`
+/// publishes it).
+pub(crate) fn cpu_enabled() -> Option<CpuEnableList> {
+    *CPU_ENABLED.read()
+}
+
+/// Publishes the enabled-CPU list (initial, during `init_board`).
+pub(crate) fn publish_cpu_enabled(cpu_list: Option<CpuEnableList>) {
+    *CPU_ENABLED.write() = cpu_list;
+}
+
+/// Reconciles the enabled-CPU table with the per-hart privilege checks.
+///
+/// Runs post-`READY` on the boot hart while other harts may read the table;
+/// the write lock makes their copies atomic snapshots of the whole list.
+pub fn refresh_cpu_features() {
+    let mut cpu_enabled = CPU_ENABLED.write();
+    let Some(cpu_enabled) = cpu_enabled.as_mut() else {
+        return;
+    };
+    for (hart_id, enabled) in cpu_enabled.iter_mut().enumerate() {
+        if *enabled {
+            *enabled = CPU_PRIVILEGED_ENABLED[hart_id].load(Ordering::Acquire);
+        }
+    }
 }
 
 const RISCV_MACHINE_EXTERNAL_IRQ: u32 = 11;
@@ -170,7 +193,6 @@ pub struct BoardInfo {
     pub ipi: Option<(BaseAddress, MachineClintType)>,
     pub aia: Option<aia::AiaInfo>,
     pub cpu_num: Option<usize>,
-    pub cpu_enabled: Option<CpuEnableList>,
     pub model: String,
     /// P1 PMIC reset info: (I2C controller base, PMIC address)
     pub pmic_reset: Option<(usize, u8)>,
@@ -185,7 +207,6 @@ impl BoardInfo {
             reset: None,
             ipi: None,
             aia: None,
-            cpu_enabled: None,
             cpu_num: None,
             model: String::new(),
             pmic_reset: None,
@@ -238,8 +259,9 @@ impl BoardInfo {
     }
 
     /// Discovers miscellaneous board info (memory, cpu number, model, enabled
-    /// harts) that later platform initialization depends on.
-    pub(crate) fn discover_misc(&mut self, tree: &Tree) {
+    /// harts) that later platform initialization depends on; returns the
+    /// enabled-hart list for the caller to publish (`publish_cpu_enabled`).
+    pub(crate) fn discover_misc(&mut self, tree: &Tree) -> Option<CpuEnableList> {
         // Get memory info
         // TODO: More than one memory node or range?
         let memory_reg = tree
@@ -282,7 +304,7 @@ impl BoardInfo {
                 );
             }
         }
-        self.cpu_enabled = Some(cpu_list);
+        Some(cpu_list)
     }
 
     /// Discovers the ipi and reset devices (including the M-level IMSIC) from
@@ -527,7 +549,7 @@ impl BoardInfo {
             hart_imsic_map[hart_id] = Some(addr);
         }
 
-        let Some(ref cpu_enabled) = self.cpu_enabled else {
+        let Some(cpu_enabled) = cpu_enabled() else {
             return;
         };
         for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
@@ -557,18 +579,6 @@ impl BoardInfo {
             hart_imsic_map,
         });
     }
-
-    /// Reconciles the enabled-CPU table with the per-hart privilege checks.
-    pub(crate) fn refresh_cpu_features(&mut self) {
-        let Some(cpu_enabled) = self.cpu_enabled.as_mut() else {
-            return;
-        };
-        for (hart_id, enabled) in cpu_enabled.iter_mut().enumerate() {
-            if *enabled {
-                *enabled = CPU_PRIVILEGED_ENABLED[hart_id].load(Ordering::Acquire);
-            }
-        }
-    }
 }
 
 pub(crate) fn print_board_info() {
@@ -595,7 +605,7 @@ fn print_cpu_info() {
         board_info().cpu_num.unwrap_or(0)
     );
 
-    let Some(cpu_enabled) = &board_info().cpu_enabled else {
+    let Some(cpu_enabled) = cpu_enabled() else {
         warn!("{:<30}: Not Available", "Enabled HARTs");
         return;
     };

--- a/prototyper/prototyper/src/sbi/heap.rs
+++ b/prototyper/prototyper/src/sbi/heap.rs
@@ -1,3 +1,7 @@
+//! SBI heap backing store; the raw pool stays a `static mut` (its address
+//! is handed to the allocator once at init).
+#![allow(static_mut_refs)]
+
 use crate::cfg::HEAP_SIZE;
 use buddy_system_allocator::LockedHeap;
 

--- a/prototyper/prototyper/src/sbi/hsm.rs
+++ b/prototyper/prototyper/src/sbi/hsm.rs
@@ -1,3 +1,7 @@
+//! HSM extension; `remote_hsm` indexes the per-hart trap stack array
+//! (`ROOT_STACK`), which stays a `static mut`.
+#![allow(static_mut_refs)]
+
 use core::{
     cell::UnsafeCell,
     hint::spin_loop,
@@ -204,7 +208,7 @@ pub(crate) struct SbiHsm;
 impl rustsbi::Hsm for SbiHsm {
     /// Starts execution on a stopped hart.
     fn hart_start(&self, hartid: usize, start_addr: usize, opaque: usize) -> SbiRet {
-        let hart_enable = crate::platform::board_info().cpu_enabled.unwrap();
+        let hart_enable = crate::platform::cpu_enabled().unwrap();
         let enabled = hart_enable.get(hartid).copied().unwrap_or(false);
         if !enabled {
             return SbiRet::invalid_param();
@@ -241,7 +245,7 @@ impl rustsbi::Hsm for SbiHsm {
     /// Gets the current state of a hart.
     #[inline]
     fn hart_get_status(&self, hartid: usize) -> SbiRet {
-        let hart_enable = crate::platform::board_info().cpu_enabled.unwrap();
+        let hart_enable = crate::platform::cpu_enabled().unwrap();
         let enabled = hart_enable.get(hartid).copied().unwrap_or(false);
         if !enabled {
             return SbiRet::invalid_param();

--- a/prototyper/prototyper/src/sbi/ipi.rs
+++ b/prototyper/prototyper/src/sbi/ipi.rs
@@ -89,8 +89,7 @@ impl rustsbi::Ipi for SbiIpi {
                 return SbiRet::invalid_param();
             };
 
-            if crate::platform::board_info()
-                .cpu_enabled
+            if crate::platform::cpu_enabled()
                 .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
             {
                 return SbiRet::invalid_param();
@@ -146,8 +145,7 @@ impl SbiIpi {
                 return SbiRet::invalid_param();
             };
 
-            if crate::platform::board_info()
-                .cpu_enabled
+            if crate::platform::cpu_enabled()
                 .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
             {
                 return SbiRet::invalid_param();
@@ -265,15 +263,14 @@ pub fn clear_all() {
 /// Initializes the SBI IPI extension from the discovered board info
 /// (AIA probe with CLINT fallback).
 pub(crate) fn init(board: &BoardInfo) -> Option<SbiIpi> {
-    let max_hart_id = board
-        .cpu_enabled
+    let max_hart_id = crate::platform::cpu_enabled()
         .as_ref()
         .and_then(|hart_list| hart_list.iter().rposition(|enabled| *enabled))
         .unwrap_or(NUM_HART_MAX - 1);
 
     if let Some(ref aia_info) = board.aia {
         let mut aia_usable = true;
-        if let Some(ref cpu_enabled) = board.cpu_enabled {
+        if let Some(cpu_enabled) = crate::platform::cpu_enabled() {
             for (hart_id, enabled) in cpu_enabled.iter().enumerate() {
                 if *enabled && !aia_hart_usable(hart_id) {
                     aia_usable = false;

--- a/prototyper/prototyper/src/sbi/rfence.rs
+++ b/prototyper/prototyper/src/sbi/rfence.rs
@@ -1,3 +1,7 @@
+//! RFence extension; `local_rfence`/`remote_rfence` index the per-hart
+//! trap stack array (`ROOT_STACK`), which stays a `static mut`.
+#![allow(static_mut_refs)]
+
 use rustsbi::{HartMask, SbiRet};
 use sbi_spec::pmu::firmware_event;
 use spin::Mutex;

--- a/prototyper/prototyper/src/sbi/suspend.rs
+++ b/prototyper/prototyper/src/sbi/suspend.rs
@@ -23,12 +23,11 @@ impl rustsbi::Susp for SbiSuspend {
         }
 
         // Check if all harts except the current hart are stopped
-        let hart_enable_map =
-            if let Some(hart_enable_map) = crate::platform::board_info().cpu_enabled {
-                hart_enable_map
-            } else {
-                return SbiRet::failed();
-            };
+        let hart_enable_map = if let Some(hart_enable_map) = crate::platform::cpu_enabled() {
+            hart_enable_map
+        } else {
+            return SbiRet::failed();
+        };
         for (hartid, hart_enable) in hart_enable_map.iter().enumerate() {
             if *hart_enable && hartid != current_hartid() {
                 match remote_hsm(hartid) {

--- a/prototyper/prototyper/src/sbi/trap_stack.rs
+++ b/prototyper/prototyper/src/sbi/trap_stack.rs
@@ -1,3 +1,7 @@
+//! Per-hart trap stacks and contexts, indexed by hart id from
+//! hardware-entered paths; `ROOT_STACK` stays a `static mut`.
+#![allow(static_mut_refs)]
+
 use crate::cfg::{NUM_HART_MAX, STACK_SIZE_PER_HART};
 use crate::riscv::current_hartid;
 use crate::sbi::hart_context::HartContext;


### PR DESCRIPTION
`BOARD_INFO` was the last user-code `static mut` from #235, with one
documented race: `refresh_cpu_features` rewrites `cpu_enabled` after
`READY`, so concurrent readers could see a torn table.

Six of seven `BoardInfo` fields are freeze-after-discovery facts;
only `cpu_enabled` is rewritten. The containers now match:

- `BOARD_INFO` becomes `spin::Once<BoardInfo>`, published in
  `init_board` before the `READY` release (same pattern as
  `SBI_DISPATCHER`); `board_info()` still returns `&'static
  BoardInfo`, so fact readers are unchanged.
- `cpu_enabled` becomes `CPU_ENABLED: RwLock<Option<_>>`; the
  post-`READY` refresh rewrites it under the write lock, so readers
  take atomic snapshots — the race is closed.

The platform module now has zero `static mut` and zero `unsafe`, and
the crate-level `#![allow(static_mut_refs)]` is narrowed to the four
modules that still touch the trap-stack array and heap pool.

Verified with the full QEMU matrix; boot logs byte-identical.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
