### PR TITLE
refactor(prototyper): put the hart-local base behind a safe API

### DIFF
--- a/prototyper/prototyper/src/sbi/features.rs
+++ b/prototyper/prototyper/src/sbi/features.rs
@@ -13,7 +13,7 @@ use crate::platform::aia::is_aia_active;
 use crate::riscv::csr::*;
 use crate::riscv::current_hartid;
 use crate::sbi::early_trap::{TrapInfo, csr_read_allow, csr_write_allow};
-use crate::sbi::trap_stack::{hart_context, hart_context_mut};
+use crate::sbi::trap_stack::{hart_local, with_current, with_hart};
 
 use super::early_trap::csr_swap;
 
@@ -72,19 +72,19 @@ impl Extension {
 /// Probes if a specific extension is supported for the given hart.
 #[inline]
 pub fn hart_extension_probe(hart_id: usize, ext: Extension) -> bool {
-    hart_context(hart_id).features.extensions[ext.index()]
+    hart_local(hart_id).features.extensions[ext.index()]
 }
 
 /// Gets the privileged version for the given hart.
 #[inline]
 pub fn hart_privileged_version(hart_id: usize) -> PrivilegedVersion {
-    hart_context(hart_id).features.privileged_version
+    hart_local(hart_id).features.privileged_version
 }
 
 /// Gets the MHPM mask for the given hart.
 #[inline]
 pub fn hart_mhpm_mask(hart_id: usize) -> u32 {
-    hart_context(hart_id).features.mhpm_mask
+    hart_local(hart_id).features.mhpm_mask
 }
 
 /// Detects RISC-V extensions from the device tree for all harts.
@@ -110,7 +110,7 @@ pub fn extension_detection(cpus: &NodeSeq) {
             };
         }
 
-        hart_context_mut(hart_id).features.extensions = extensions;
+        with_hart(hart_id, |local| local.features.extensions = extensions);
     }
 }
 
@@ -145,9 +145,7 @@ fn privileged_version_detection() {
             }
         }
     }
-    hart_context_mut(current_hartid())
-        .features
-        .privileged_version = current_priv_ver;
+    with_current(|local| local.features.privileged_version = current_priv_ver);
 }
 
 fn mhpm_detection() {
@@ -179,9 +177,11 @@ fn mhpm_detection() {
         m_check_mhpm_csr!(csr_num, &mut trap_info, &mut current_mhpm_mask);
     });
 
-    hart_context_mut(current_hartid()).features.mhpm_mask = current_mhpm_mask;
-    // TODO: at present, rustsbi prptotyper only supports 64bit.
-    hart_context_mut(current_hartid()).features.mhpm_bits = 64;
+    with_current(|local| {
+        local.features.mhpm_mask = current_mhpm_mask;
+        // TODO: at present, rustsbi prptotyper only supports 64bit.
+        local.features.mhpm_bits = 64;
+    });
 }
 
 /// Detects the current hart's ISA extensions and privileged version.
@@ -195,7 +195,7 @@ pub fn init(cpus: &NodeSeq) {
     for hart_id in 0..cpus.len() {
         let mut hart_exts = [false; Extension::COUNT];
         hart_exts[Extension::Sstc.index()] = true;
-        hart_context(hart_id).features = HartFeatures {
+        hart_local(hart_id).features = HartFeatures {
             extension: hart_exts,
             privileged_version: PrivilegedVersion::Version1_12,
         }

--- a/prototyper/prototyper/src/sbi/hart_context.rs
+++ b/prototyper/prototyper/src/sbi/hart_context.rs
@@ -10,10 +10,41 @@ use riscv::register::mstatus;
 
 use super::pmu::PmuState;
 
-/// Context for managing hart (hardware thread) state and operations.
+/// Raw per-hart context sitting at the bottom of each trap stack slot.
+///
+/// This composition keeps the pre-split `HartContext` layout byte-identical:
+/// `repr(C)` with `frame` first leaves the trap [`FlowContext`] at offset 0,
+/// where the naked entry and the trap framework address it, with the
+/// sbi-visible [`HartLocal`] state directly behind it.
+#[repr(C)]
 pub(crate) struct HartContext {
+    /// Trap frame; the only part the trap path touches.
+    pub(crate) frame: TrapFrame,
+    /// Hart-local state consumed by the sbi extension layer.
+    pub(crate) local: HartLocal,
+}
+
+/// The part of a hart's slot owned by the trap path.
+pub(crate) struct TrapFrame {
     /// Trap context for handling exceptions and interrupts.
-    trap: FlowContext,
+    pub(crate) trap: FlowContext,
+}
+
+impl TrapFrame {
+    /// Get a non-null pointer to the trap context.
+    #[inline]
+    pub(crate) fn context_ptr(&mut self) -> NonNull<FlowContext> {
+        unsafe { NonNull::new_unchecked(&mut self.trap) }
+    }
+}
+
+/// Hart-local state, consumed by the sbi extension layer.
+///
+/// Reached only through the safe accessors of [`crate::sbi::trap_stack`]
+/// (`with_current`/`hart_local` and the cell projections); it is kept in a
+/// separate type from [`TrapFrame`] so an exclusive borrow here can never
+/// alias the trap framework's view of the same stack slot.
+pub struct HartLocal {
     /// Hart state management cell containing next stage boot info.
     pub hsm: HsmCell<NextStage>,
     /// Remote fence synchronization cell.
@@ -26,26 +57,25 @@ pub(crate) struct HartContext {
     pub pmu_state: PmuState,
 }
 
-// Make sure HartContext is aligned.
-//
-// HartContext will always at the end of Stack, so we should make sure
-// STACK_SIZE_PER_HART is a multiple of b.
+// HartContext sits at the bottom of each HartStack slot, so the slot size
+// must be a multiple of its alignment; same for the two members.
 use crate::cfg::STACK_SIZE_PER_HART;
-const _: () = assert!(STACK_SIZE_PER_HART % core::mem::align_of::<HartContext>() == 0);
+const _: () = assert!(STACK_SIZE_PER_HART.is_multiple_of(core::mem::align_of::<HartContext>()));
+const _: () = assert!(STACK_SIZE_PER_HART.is_multiple_of(core::mem::align_of::<TrapFrame>()));
+const _: () = assert!(STACK_SIZE_PER_HART.is_multiple_of(core::mem::align_of::<HartLocal>()));
 
-impl HartContext {
-    /// Initialize the hart context by creating new HSM and RFence cells
+// Layout preservation across the TrapFrame/HartLocal split: `trap` was the
+// first field of the pre-split `HartContext`, and `repr(C)` with `frame`
+// first keeps it at offset 0.
+const _: () = assert!(core::mem::offset_of!(HartContext, frame) == 0);
+
+impl HartLocal {
+    /// Initialize the hart-local state by creating new HSM and RFence cells
     #[inline]
     pub fn init(&mut self) {
         self.hsm = HsmCell::new();
         self.rfence = RFenceCell::new();
         self.pmu_state = PmuState::new();
-    }
-
-    /// Get a non-null pointer to the trap context.
-    #[inline]
-    pub fn context_ptr(&mut self) -> NonNull<FlowContext> {
-        unsafe { NonNull::new_unchecked(&mut self.trap) }
     }
 
     #[inline]

--- a/prototyper/prototyper/src/sbi/hsm.rs
+++ b/prototyper/prototyper/src/sbi/hsm.rs
@@ -1,6 +1,5 @@
-//! HSM extension; `remote_hsm` indexes the per-hart trap stack array
-//! (`ROOT_STACK`), which stays a `static mut`.
-#![allow(static_mut_refs)]
+//! HSM extension; the per-hart cell views (`local_hsm`/`remote_hsm`,
+//! re-exported below) come from the safe accessors in [`super::trap_stack`].
 
 use core::{
     cell::UnsafeCell,
@@ -12,10 +11,9 @@ use rustsbi::{SbiRet, spec::hsm::hart_state};
 
 use crate::riscv::current_hartid;
 use crate::sbi::hart_context::NextStage;
-use crate::sbi::trap_stack::ROOT_STACK;
-use crate::sbi::trap_stack::hart_context_mut;
 
-use super::{trap::boot::boot, trap_stack::hart_context};
+use super::trap::boot::boot;
+use super::trap_stack::{hart_local, reset_hart};
 
 /// Special state indicating a hart is in the process of starting.
 const HART_STATE_START_PENDING_EXT: usize = usize::MAX;
@@ -183,23 +181,14 @@ impl<T: core::fmt::Debug> RemoteHsmCell<'_, T> {
 }
 
 /// Gets the local HSM cell for the current hart.
-pub(crate) fn local_hsm() -> LocalHsmCell<'static, NextStage> {
-    unsafe { hart_context(current_hartid()).hsm.local() }
-}
+pub(crate) use super::trap_stack::local_hsm;
+
+/// Gets a remote view of any hart's HSM cell.
+pub(crate) use super::trap_stack::remote_hsm;
 
 /// Returns a remote-capable view of the current hart's HSM cell.
 pub(crate) fn hart_hsm() -> RemoteHsmCell<'static, NextStage> {
-    hart_context(current_hartid()).hsm.remote()
-}
-
-/// Gets a remote view of any hart's HSM cell.
-#[allow(unused)]
-pub(crate) fn remote_hsm(hart_id: usize) -> Option<RemoteHsmCell<'static, NextStage>> {
-    unsafe {
-        ROOT_STACK
-            .get_mut(hart_id)
-            .map(|x| x.hart_context().hsm.remote())
-    }
+    hart_local(current_hartid()).hsm.remote()
 }
 
 /// Implementation of SBI HSM (Hart State Management) extension.
@@ -296,7 +285,7 @@ impl SbiHsm {
                     next_mode: MPP::Supervisor,
                 }) {
                     // reset the hart local context to prevent the hart context from being polluted
-                    hart_context_mut(hartid).reset();
+                    reset_hart(hartid);
                     // boot resume hart from resume addr
                     unsafe {
                         boot();

--- a/prototyper/prototyper/src/sbi/ipi.rs
+++ b/prototyper/prototyper/src/sbi/ipi.rs
@@ -8,7 +8,7 @@ use crate::riscv::current_hartid;
 use crate::sbi::features::{Extension, hart_extension_probe};
 use crate::sbi::hsm::remote_hsm;
 use crate::sbi::rfence;
-use crate::sbi::trap_stack::hart_context;
+use crate::sbi::trap_stack::hart_local;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::sync::atomic::Ordering::Relaxed;
@@ -225,12 +225,12 @@ impl SbiIpi {
 
 /// Set IPI type for specified hart.
 pub fn set_ipi_type(hart_id: usize, event_id: u8) -> u8 {
-    hart_context(hart_id).ipi_type.fetch_or(event_id, Relaxed)
+    hart_local(hart_id).ipi_type.fetch_or(event_id, Relaxed)
 }
 
 /// Get and reset IPI type for current hart.
 pub fn get_and_reset_ipi_type() -> u8 {
-    hart_context(current_hartid()).ipi_type.swap(0, Relaxed)
+    hart_local(current_hartid()).ipi_type.swap(0, Relaxed)
 }
 
 /// Clear machine software interrupt pending for current hart.

--- a/prototyper/prototyper/src/sbi/pmu.rs
+++ b/prototyper/prototyper/src/sbi/pmu.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::features::{PrivilegedVersion, hart_privileged_version};
-use super::trap_stack::{hart_context, hart_context_mut};
+use super::trap_stack::{hart_local, with_current};
 
 /// Maximum number of hardware performance counters supported.
 const PMU_HARDWARE_COUNTER_MAX: usize = 32;
@@ -159,7 +159,7 @@ impl Pmu for SbiPmu {
     /// Implements SBI PMU extension function (FID #0)
     #[inline]
     fn num_counters(&self) -> usize {
-        hart_context(current_hartid())
+        hart_local(current_hartid())
             .pmu_state
             .get_total_counters_num()
     }
@@ -172,7 +172,7 @@ impl Pmu for SbiPmu {
             return SbiRet::invalid_param();
         }
 
-        let pmu_state = &hart_context(current_hartid()).pmu_state;
+        let pmu_state = &hart_local(current_hartid()).pmu_state;
         if counter_idx < pmu_state.get_hw_counter_num() {
             let mask = hart_mhpm_mask(current_hartid());
 
@@ -214,64 +214,67 @@ impl Pmu for SbiPmu {
         };
 
         let event = EventIdx::new(event_idx);
-        let pmu_state = &mut hart_context_mut(current_hartid()).pmu_state;
         let is_firmware_event = event.is_firmware_event();
 
-        if counter_idx_base >= pmu_state.total_counters_num
-            || (counter_idx_mask & ((1 << pmu_state.total_counters_num) - 1)) == 0
-            || !event.check_event_type()
-            || (is_firmware_event && !event.firmware_event_valid())
-        {
-            return SbiRet::invalid_param();
-        }
+        with_current(|local| {
+            let pmu_state = &mut local.pmu_state;
 
-        let skip_match = flags.contains(flags::ConfigFlags::SKIP_MATCH);
-
-        let counter_idx;
-
-        if skip_match {
-            // If SKIP_MATCH is set, use the first counter in the mask without searching
-            if let Some(ctr_idx) = CounterMask::new(counter_idx_base, counter_idx_mask).next() {
-                if pmu_state.active_event[ctr_idx] == PMU_EVENT_IDX_INVALID {
-                    return SbiRet::invalid_param();
-                }
-                counter_idx = ctr_idx;
-            } else {
+            if counter_idx_base >= pmu_state.total_counters_num
+                || (counter_idx_mask & ((1 << pmu_state.total_counters_num) - 1)) == 0
+                || !event.check_event_type()
+                || (is_firmware_event && !event.firmware_event_valid())
+            {
                 return SbiRet::invalid_param();
             }
-        } else {
-            let match_result: Result<usize, SbiRet>;
-            if event.is_firmware_event() {
-                match_result = self.find_firmware_counter(
-                    counter_idx_base,
-                    counter_idx_mask,
-                    event_idx,
-                    pmu_state,
-                );
-            } else {
-                match_result = self.find_hardware_counter(
-                    counter_idx_base,
-                    counter_idx_mask,
-                    event_idx,
-                    event_data,
-                    pmu_state,
-                );
-            }
-            match match_result {
-                Ok(ctr_idx) => {
-                    counter_idx = ctr_idx;
-                }
-                Err(err) => {
-                    return err;
-                }
-            }
-            pmu_state.active_event[counter_idx] = event_idx;
-        }
 
-        match configure_counter(pmu_state, counter_idx, event, flags) {
-            Ok(_) => SbiRet::success(counter_idx),
-            Err(e) => e,
-        }
+            let skip_match = flags.contains(flags::ConfigFlags::SKIP_MATCH);
+
+            let counter_idx;
+
+            if skip_match {
+                // If SKIP_MATCH is set, use the first counter in the mask without searching
+                if let Some(ctr_idx) = CounterMask::new(counter_idx_base, counter_idx_mask).next() {
+                    if pmu_state.active_event[ctr_idx] == PMU_EVENT_IDX_INVALID {
+                        return SbiRet::invalid_param();
+                    }
+                    counter_idx = ctr_idx;
+                } else {
+                    return SbiRet::invalid_param();
+                }
+            } else {
+                let match_result: Result<usize, SbiRet>;
+                if event.is_firmware_event() {
+                    match_result = self.find_firmware_counter(
+                        counter_idx_base,
+                        counter_idx_mask,
+                        event_idx,
+                        pmu_state,
+                    );
+                } else {
+                    match_result = self.find_hardware_counter(
+                        counter_idx_base,
+                        counter_idx_mask,
+                        event_idx,
+                        event_data,
+                        pmu_state,
+                    );
+                }
+                match match_result {
+                    Ok(ctr_idx) => {
+                        counter_idx = ctr_idx;
+                    }
+                    Err(err) => {
+                        return err;
+                    }
+                }
+                pmu_state.active_event[counter_idx] = event_idx;
+            }
+
+            match configure_counter(pmu_state, counter_idx, event, flags) {
+                Ok(_) => SbiRet::success(counter_idx),
+                Err(e) => e,
+            }
+        })
     }
 
     /// Start one or more counters (FID #3)
@@ -289,41 +292,43 @@ impl Pmu for SbiPmu {
             None => return SbiRet::invalid_param(),
         };
 
-        let pmu_state = &mut hart_context_mut(current_hartid()).pmu_state;
-        let is_update_value = flags.contains(flags::StartFlags::INIT_VALUE);
+        with_current(|local| {
+            let pmu_state = &mut local.pmu_state;
+            let is_update_value = flags.contains(flags::StartFlags::INIT_VALUE);
 
-        if counter_idx_base >= pmu_state.total_counters_num
-            || (counter_idx_mask & ((1 << pmu_state.total_counters_num) - 1)) == 0
-        {
-            return SbiRet::invalid_param();
-        }
-
-        if flags.contains(flags::StartFlags::INIT_SNAPSHOT) {
-            return SbiRet::no_shmem();
-        }
-
-        for counter_idx in CounterMask::new(counter_idx_base, counter_idx_mask) {
-            if counter_idx >= pmu_state.total_counters_num {
+            if counter_idx_base >= pmu_state.total_counters_num
+                || (counter_idx_mask & ((1 << pmu_state.total_counters_num) - 1)) == 0
+            {
                 return SbiRet::invalid_param();
             }
 
-            let start_result = if counter_idx >= pmu_state.get_hw_counter_num() {
-                pmu_state.start_fw_counter(counter_idx, initial_value, is_update_value)
-            } else {
-                let mhpm_offset = get_mhpm_csr_offset(counter_idx).unwrap();
-                start_hardware_counter(mhpm_offset, initial_value, is_update_value)
-            };
-            match start_result {
-                Ok(_) => {}
-                Err(StartCounterErr::AlreadyStart) => {
-                    return SbiRet::already_started();
-                }
-                Err(StartCounterErr::OffsetInvalid) => {
+            if flags.contains(flags::StartFlags::INIT_SNAPSHOT) {
+                return SbiRet::no_shmem();
+            }
+
+            for counter_idx in CounterMask::new(counter_idx_base, counter_idx_mask) {
+                if counter_idx >= pmu_state.total_counters_num {
                     return SbiRet::invalid_param();
                 }
+
+                let start_result = if counter_idx >= pmu_state.get_hw_counter_num() {
+                    pmu_state.start_fw_counter(counter_idx, initial_value, is_update_value)
+                } else {
+                    let mhpm_offset = get_mhpm_csr_offset(counter_idx).unwrap();
+                    start_hardware_counter(mhpm_offset, initial_value, is_update_value)
+                };
+                match start_result {
+                    Ok(_) => {}
+                    Err(StartCounterErr::AlreadyStart) => {
+                        return SbiRet::already_started();
+                    }
+                    Err(StartCounterErr::OffsetInvalid) => {
+                        return SbiRet::invalid_param();
+                    }
+                }
             }
-        }
-        SbiRet::success(0)
+            SbiRet::success(0)
+        })
     }
 
     /// Stop one or more counters (FID #4)
@@ -339,48 +344,50 @@ impl Pmu for SbiPmu {
             None => return SbiRet::invalid_param(),
         };
 
-        let pmu_state = &mut hart_context_mut(current_hartid()).pmu_state;
-        let is_reset = flags.contains(flags::StopFlags::RESET);
+        with_current(|local| {
+            let pmu_state = &mut local.pmu_state;
+            let is_reset = flags.contains(flags::StopFlags::RESET);
 
-        if counter_idx_base >= pmu_state.total_counters_num
-            || (counter_idx_mask & ((1 << pmu_state.total_counters_num) - 1)) == 0
-        {
-            return SbiRet::invalid_param();
-        }
-
-        if flags.contains(flags::StopFlags::TAKE_SNAPSHOT) {
-            return SbiRet::no_shmem();
-        }
-
-        for counter_idx in CounterMask::new(counter_idx_base, counter_idx_mask) {
-            if counter_idx >= pmu_state.total_counters_num {
+            if counter_idx_base >= pmu_state.total_counters_num
+                || (counter_idx_mask & ((1 << pmu_state.total_counters_num) - 1)) == 0
+            {
                 return SbiRet::invalid_param();
             }
 
-            let stop_result = if counter_idx >= pmu_state.get_hw_counter_num() {
-                pmu_state.stop_fw_counter(counter_idx, is_reset)
-            } else {
-                // If RESET flag is set, mark the counter as inactive
-                if is_reset {
-                    pmu_state.active_event[counter_idx] = PMU_EVENT_IDX_INVALID;
-                }
-                let mhpm_offset = get_mhpm_csr_offset(counter_idx).unwrap();
-                stop_hardware_counter(mhpm_offset, is_reset)
-            };
-            match stop_result {
-                Ok(_) => {}
-                Err(StopCounterErr::OffsetInvalid) => return SbiRet::invalid_param(),
-                Err(StopCounterErr::AlreadyStop) => return SbiRet::already_stopped(),
+            if flags.contains(flags::StopFlags::TAKE_SNAPSHOT) {
+                return SbiRet::no_shmem();
             }
-        }
-        SbiRet::success(0)
+
+            for counter_idx in CounterMask::new(counter_idx_base, counter_idx_mask) {
+                if counter_idx >= pmu_state.total_counters_num {
+                    return SbiRet::invalid_param();
+                }
+
+                let stop_result = if counter_idx >= pmu_state.get_hw_counter_num() {
+                    pmu_state.stop_fw_counter(counter_idx, is_reset)
+                } else {
+                    // If RESET flag is set, mark the counter as inactive
+                    if is_reset {
+                        pmu_state.active_event[counter_idx] = PMU_EVENT_IDX_INVALID;
+                    }
+                    let mhpm_offset = get_mhpm_csr_offset(counter_idx).unwrap();
+                    stop_hardware_counter(mhpm_offset, is_reset)
+                };
+                match stop_result {
+                    Ok(_) => {}
+                    Err(StopCounterErr::OffsetInvalid) => return SbiRet::invalid_param(),
+                    Err(StopCounterErr::AlreadyStop) => return SbiRet::already_stopped(),
+                }
+            }
+            SbiRet::success(0)
+        })
     }
 
     /// Reads a firmware counter value
     /// Function: Read a firmware counter (FID #5).
     #[inline]
     fn counter_fw_read(&self, counter_idx: usize) -> SbiRet {
-        let pmu_state = &hart_context(current_hartid()).pmu_state;
+        let pmu_state = &hart_local(current_hartid()).pmu_state;
         match pmu_state.get_event_idx(counter_idx, true) {
             Some(event_id) if event_id.firmware_event_valid() => {
                 if event_id.event_code() == firmware_event::PLATFORM {
@@ -1195,17 +1202,19 @@ cfg_if::cfg_if! {
 }
 
 pub fn pmu_firmware_counter_increment(firmware_event: usize) {
-    let pmu_state = &mut hart_context_mut(current_hartid()).pmu_state;
-    let counter_idx_start = pmu_state.hw_counters_num;
-    for counter_idx in counter_idx_start..counter_idx_start + PMU_FIRMWARE_COUNTER_MAX {
-        let fw_idx = counter_idx - counter_idx_start;
-        if pmu_state.active_event[counter_idx]
-            == EventIdx::from_firmware_event(firmware_event).raw()
-            && pmu_state.is_firmware_event_start(counter_idx)
-        {
-            pmu_state.fw_counter[fw_idx] += 1;
+    with_current(|local| {
+        let pmu_state = &mut local.pmu_state;
+        let counter_idx_start = pmu_state.hw_counters_num;
+        for counter_idx in counter_idx_start..counter_idx_start + PMU_FIRMWARE_COUNTER_MAX {
+            let fw_idx = counter_idx - counter_idx_start;
+            if pmu_state.active_event[counter_idx]
+                == EventIdx::from_firmware_event(firmware_event).raw()
+                && pmu_state.is_firmware_event_start(counter_idx)
+            {
+                pmu_state.fw_counter[fw_idx] += 1;
+            }
         }
-    }
+    });
 }
 
 /// Initializes the SBI PMU extension from the FDT pmu node.

--- a/prototyper/prototyper/src/sbi/rfence.rs
+++ b/prototyper/prototyper/src/sbi/rfence.rs
@@ -1,6 +1,6 @@
-//! RFence extension; `local_rfence`/`remote_rfence` index the per-hart
-//! trap stack array (`ROOT_STACK`), which stays a `static mut`.
-#![allow(static_mut_refs)]
+//! RFence extension; the per-hart fence cell views (`local_rfence`/
+//! `remote_rfence`, re-exported below) come from the safe accessors in
+//! [`super::trap_stack`].
 
 use rustsbi::{HartMask, SbiRet};
 use sbi_spec::pmu::firmware_event;
@@ -9,7 +9,6 @@ use spin::Mutex;
 use crate::cfg::{PAGE_SIZE, TLB_FLUSH_LIMIT};
 use crate::riscv::current_hartid;
 use crate::sbi::fifo::{Fifo, FifoError};
-use crate::sbi::trap_stack::ROOT_STACK;
 use core::arch::asm;
 
 use core::sync::atomic::{AtomicU32, Ordering};
@@ -97,22 +96,9 @@ pub struct LocalRFenceCell<'a>(&'a RFenceCell);
 pub struct RemoteRFenceCell<'a>(&'a RFenceCell);
 
 /// Gets the local fence context for the current hart.
-pub(crate) fn local_rfence() -> Option<LocalRFenceCell<'static>> {
-    unsafe {
-        ROOT_STACK
-            .get_mut(current_hartid())
-            .map(|x| x.hart_context().rfence.local())
-    }
-}
-
+pub(crate) use super::trap_stack::local_rfence;
 /// Gets the remote fence context for a specific hart.
-pub(crate) fn remote_rfence(hart_id: usize) -> Option<RemoteRFenceCell<'static>> {
-    unsafe {
-        ROOT_STACK
-            .get_mut(hart_id)
-            .map(|x| x.hart_context().rfence.remote())
-    }
-}
+pub(crate) use super::trap_stack::remote_rfence;
 
 #[allow(unused)]
 impl LocalRFenceCell<'_> {

--- a/prototyper/prototyper/src/sbi/trap_stack.rs
+++ b/prototyper/prototyper/src/sbi/trap_stack.rs
@@ -1,20 +1,60 @@
-//! Per-hart trap stacks and contexts, indexed by hart id from
-//! hardware-entered paths; `ROOT_STACK` stays a `static mut`.
-#![allow(static_mut_refs)]
+//! Mechanism module owning the per-hart raw stack array: `ROOT_STACK` is
+//! externally-addressed raw memory (the naked trap entry reaches it by
+//! `sym ROOT_STACK`), so the slots are `UnsafeCell` storage instead of a
+//! `static mut`. Rust code only ever reaches a hart's [`HartLocal`] state
+//! through the safe accessors below; references are formed per call and
+//! never escape as long-lived `&mut`.
 
 use crate::cfg::{NUM_HART_MAX, STACK_SIZE_PER_HART};
 use crate::riscv::current_hartid;
-use crate::sbi::hart_context::HartContext;
+use crate::sbi::hart_context::{HartContext, HartLocal, NextStage};
+use crate::sbi::hsm::{LocalHsmCell, RemoteHsmCell};
+use crate::sbi::rfence::{LocalRFenceCell, RemoteRFenceCell};
 use crate::sbi::trap::fast_handler;
+use core::cell::UnsafeCell;
 use core::mem::forget;
+use core::ptr::{addr_of, addr_of_mut};
 use fast_trap::FreeTrapStack;
 
-/// Root stack array for all harts, placed in BSS Stack section.
+/// Raw stack slot for each hart.
+///
+/// Memory layout:
+/// - Bottom: HartContext (trap frame + hart-local state).
+/// - Middle: Stack space for the hart.
+/// - Top: Trap handling space.
+#[repr(C, align(128))]
+struct HartStack(UnsafeCell<[u8; STACK_SIZE_PER_HART]>);
+
+// SAFETY: `HartStack` is raw storage addressed by hart id: the naked entry
+// (`locate`) reaches it via `sym ROOT_STACK` and the trap framework via the
+// frame pointer installed by `load_as_stack`. Rust references are only
+// formed for the caller's own slot inside `with_current`/`with_hart`, or as
+// shared references through `hart_local`; cross-hart sharing goes through
+// the atomics and cells stored in `HartLocal`.
+unsafe impl Sync for HartStack {}
+
+/// Root stack array for all harts, placed in BSS stack section.
+#[used]
 #[unsafe(link_section = ".bss.stack")]
-pub(crate) static mut ROOT_STACK: [Stack; NUM_HART_MAX] = [Stack::ZERO; NUM_HART_MAX];
+static ROOT_STACK: [HartStack; NUM_HART_MAX] = [const { HartStack::zero() }; NUM_HART_MAX];
 
 // Make sure stack address can be aligned.
-const _: () = assert!(STACK_SIZE_PER_HART % core::mem::align_of::<Stack>() == 0);
+const _: () = assert!(STACK_SIZE_PER_HART.is_multiple_of(core::mem::align_of::<HartStack>()));
+
+/// Returns the raw slot of `hart_id`, or `None` when out of range.
+#[inline]
+fn slot(hart_id: usize) -> Option<&'static HartStack> {
+    ROOT_STACK.get(hart_id)
+}
+
+/// Forms a shared reference to the hart-local state behind a raw slot.
+#[inline]
+fn local_of(slot: &'static HartStack) -> &'static HartLocal {
+    // SAFETY: the slot memory is bounds-checked and static; the resulting
+    // shared reference is only used for atomics and interior-mutable cells,
+    // matching the pre-split `hart_context()` projection.
+    unsafe { &*addr_of!((*slot.0.get().cast::<HartContext>()).local) }
+}
 
 /// Locates and initializes stack for each hart.
 ///
@@ -40,57 +80,99 @@ pub(crate) unsafe extern "C" fn locate() {
 
 /// Prepares trap stack for current hart
 pub(crate) fn prepare_for_trap() {
-    unsafe {
-        ROOT_STACK
-            .get_unchecked_mut(current_hartid())
-            .load_as_stack()
-    };
+    // SAFETY: the current hart id always indexes `ROOT_STACK`.
+    let slot: &'static HartStack = unsafe { ROOT_STACK.get_unchecked(current_hartid()) };
+    HartStack::load_as_stack(slot);
 }
 
-pub fn hart_context_mut(hart_id: usize) -> &'static mut HartContext {
-    unsafe { ROOT_STACK.get_mut(hart_id).unwrap().hart_context_mut() }
-}
-
-pub fn hart_context(hart_id: usize) -> &'static HartContext {
-    unsafe { ROOT_STACK.get(hart_id).unwrap().hart_context() }
-}
-
-/// Stack type for each hart.
+/// Runs `f` with exclusive access to the current hart's hart-local state.
 ///
-/// Memory layout:
-/// - Bottom: HartContext struct.
-/// - Middle: Stack space for the hart.
-/// - Top: Trap handling space.
+/// SAFETY (mechanism contract): each slot is owned by exactly one hart, so
+/// borrowing that hart's `HartLocal` is exclusive while `f` runs — M-mode
+/// trap entry clears MIE and trap/interrupt handlers never call this, so
+/// no second borrow can go live. The [`TrapFrame`] part of the slot is
+/// unreachable through the given reference.
 ///
-/// Each hart has a single stack that contains both its context and working space.
-#[repr(C, align(128))]
-pub(crate) struct Stack([u8; STACK_SIZE_PER_HART]);
+/// [`TrapFrame`]: crate::sbi::hart_context::TrapFrame
+pub fn with_current<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut HartLocal) -> R,
+{
+    with_hart(current_hartid(), f)
+}
 
-impl Stack {
-    const ZERO: Self = Self([0; STACK_SIZE_PER_HART]);
+/// Runs `f` with exclusive access to an arbitrary hart's hart-local state.
+///
+/// SAFETY (mechanism contract): the caller must guarantee the target hart
+/// does not concurrently touch its own slot while `f` runs (parked in
+/// firmware entry, or not yet released). Used by `with_current` and by the
+/// boot-time feature seeding in `features::extension_detection`.
+pub fn with_hart<F, R>(hart_id: usize, f: F) -> R
+where
+    F: FnOnce(&mut HartLocal) -> R,
+{
+    let slot = slot(hart_id).expect("hart id within ROOT_STACK bounds");
+    // SAFETY: exclusive to this slot per the contract above; the memory is
+    // bounds-checked, static, and disjoint from the trap frame at offset 0.
+    let local = unsafe { &mut *addr_of_mut!((*slot.0.get().cast::<HartContext>()).local) };
+    f(local)
+}
 
-    /// Gets mutable reference to hart context at bottom of stack.
-    #[inline]
-    pub fn hart_context_mut(&mut self) -> &mut HartContext {
-        unsafe { &mut *self.0.as_mut_ptr().cast() }
-    }
+/// Shared projection of any hart's hart-local state.
+pub fn hart_local(hart_id: usize) -> &'static HartLocal {
+    local_of(slot(hart_id).expect("hart id within ROOT_STACK bounds"))
+}
 
-    /// Gets immutable reference to hart context at bottom of stack.
-    #[inline]
-    pub fn hart_context(&self) -> &HartContext {
-        unsafe { &*self.0.as_ptr().cast() }
+/// Gets the local HSM cell for the current hart.
+pub fn local_hsm() -> LocalHsmCell<'static, NextStage> {
+    // SAFETY: the cell belongs to the current hart by construction.
+    unsafe { hart_local(current_hartid()).hsm.local() }
+}
+
+/// Gets a remote view of any hart's HSM cell.
+pub fn remote_hsm(hart_id: usize) -> Option<RemoteHsmCell<'static, NextStage>> {
+    slot(hart_id).map(local_of).map(|local| local.hsm.remote())
+}
+
+/// Gets the local fence context for the current hart.
+pub fn local_rfence() -> Option<LocalRFenceCell<'static>> {
+    slot(current_hartid())
+        .map(local_of)
+        .map(|local| local.rfence.local())
+}
+
+/// Gets the remote fence context for a specific hart.
+pub fn remote_rfence(hart_id: usize) -> Option<RemoteRFenceCell<'static>> {
+    slot(hart_id)
+        .map(local_of)
+        .map(|local| local.rfence.remote())
+}
+
+/// Resets the hart-local bookkeeping (ipi type, fence cell, pmu state) of
+/// `hart_id`; the trap frame is untouched, as in the pre-split reset.
+pub fn reset_hart(hart_id: usize) {
+    with_hart(hart_id, HartLocal::reset);
+}
+
+impl HartStack {
+    /// All-zero slot, usable as an array repeat operand (const fn form;
+    /// a `const` item would carry interior mutability).
+    const fn zero() -> Self {
+        Self(UnsafeCell::new([0; STACK_SIZE_PER_HART]))
     }
 
     /// Initializes stack for trap handling.
     /// - Sets up hart context.
     /// - Creates and loads FreeTrapStack with the stack range.
-    fn load_as_stack(&'static mut self) {
-        let hart = self.hart_context_mut();
-        let context_ptr = hart.context_ptr();
-        hart.init();
+    fn load_as_stack(slot: &'static Self) {
+        let context = slot.0.get().cast::<HartContext>();
+        // SAFETY: this hart owns `slot`, and the trap entry starts using the
+        // installed frame pointer only once `FreeTrapStack::load` runs below.
+        let context_ptr = unsafe { (*addr_of_mut!((*context).frame)).context_ptr() };
+        unsafe { (*addr_of_mut!((*context).local)).init() };
 
         // Get stack memory range.
-        let range = self.0.as_ptr_range();
+        let range = unsafe { (*slot.0.get()).as_ptr_range() };
 
         // Create and load trap stack, forgetting it to avoid drop
         forget(


### PR DESCRIPTION
PR #238 drew the first safe/mechanism markers. This PR closes the
base layer: the per-hart slot storage (`ROOT_STACK`) is raw memory
addressed by the naked entry and the fast-trap framework, not ordinary
shared mutable state — a `static mut` was a type-level lie.

The container becomes an `UnsafeCell` newtype with an explicit `Sync`
argument, and `HartContext` splits along its two disjoint consumers:
`TrapFrame` (the trap path's register file, reached only via
`context_ptr`) and `HartLocal` (hsm/rfence/ipi/features/pmu state).
Access now goes through `with_current`/`with_hart` closures and the
read projections — the extension layer's `&mut HartLocal` cannot even
name the trap frame, so the user-side aliasing window is closed at
the type level, not by convention. The local/remote cell views move
into `trap_stack`, absorbing the unsafe wrappers hsm/rfence used to
carry; `static_mut_refs` stays allowed only in `heap.rs`.

Layout is byte-preserved (`offset_of!(HartContext, frame) == 0`;
alignment asserts extended); boot logs byte-identical on the QEMU
matrix.

Stacked after #238 (merged).

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
