### PR TITLE
refactor(prototyper): wrap CSR and fence programming behind safe APIs

### DIFF
--- a/prototyper/prototyper/src/platform/boot.rs
+++ b/prototyper/prototyper/src/platform/boot.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Safe boot entry points over the global platform state.
 
 use core::ops::Range;
@@ -69,14 +71,7 @@ pub fn init_board(fdt_address: usize) {
     print_board_info();
 
     if IS_K1_PLATFORM.load(Ordering::Acquire) {
-        // Configure ML2SETUP for the boot hart
-        spacemit_k1::cold_boot_allowed(crate::riscv::current_hartid());
-
-        unsafe {
-            // Use the SBI link address as the warmboot entry
-            let warmboot_addr = crate::cfg::SBI_LINK_START_ADDRESS as u64;
-            spacemit_k1::early_init(true, warmboot_addr);
-        }
+        spacemit_k1::cold_boot_init();
         info!("SpacemiT K1: early init done (MSETUP + CCI-550)");
     }
 }

--- a/prototyper/prototyper/src/riscv/csr.rs
+++ b/prototyper/prototyper/src/riscv/csr.rs
@@ -1,7 +1,13 @@
 #![allow(unused)]
 
+use core::arch::asm;
+
 use pastey::paste;
 use seq_macro::seq;
+
+use crate::sbi::early_trap::{
+    TrapInfo, csr_read_allow, csr_swap, csr_write_allow, light_expected_trap,
+};
 
 // Supervisor Timer Register (Sstc extension)
 pub const CSR_STIMECMP: u16 = 0x14D;
@@ -54,30 +60,53 @@ seq!(N in 3..32 {
     paste!{ pub const [<CSR_HPMCOUNTER ~N H>]: u16 = 0xc80 + N; }
 });
 
-#[macro_export]
-#[allow(unused)]
-macro_rules! has_csr {
-    ($($x: expr)*) => {{
-            use core::arch::asm;
-            use ::riscv::register::mtvec;
-            use $crate::sbi::early_trap::light_expected_trap;
-            let res: usize;
-            unsafe {
-                // Backup old mtvec
-                let mtvec = mtvec::read().bits();
-                // Write expected_trap
-                mtvec::write(mtvec::Mtvec::new(light_expected_trap as *const () as _, mtvec::TrapMode::Direct));
-                asm!("addi a0, zero, 0",
-                    "addi a1, zero, 0",
-                    "csrr a2, {}",
-                    "mv {}, a0",
-                    const $($x)*,
-                    out(reg) res,
-                    options(nomem));
-                asm!("csrw mtvec, {}", in(reg) mtvec);
+/// Probes whether the CSR selected by `CSR` is implemented on this hart.
+pub fn has_csr<const CSR: u16>() -> bool {
+    use riscv::register::mtvec;
+
+    let res: usize;
+    // SAFETY: `mtvec` is backed up and restored around the probe, and
+    // `light_expected_trap` skips the faulting `csrr`, so touching an
+    // unimplemented CSR cannot escape into firmware. The a0-a2 clobbers are
+    // part of the probe contract; this runs at init time only.
+    unsafe {
+        // Backup old mtvec
+        let mtvec = mtvec::read().bits();
+        // Write expected_trap
+        mtvec::write(mtvec::Mtvec::new(
+            light_expected_trap as *const () as _,
+            mtvec::TrapMode::Direct,
+        ));
+        asm!("addi a0, zero, 0",
+            "addi a1, zero, 0",
+            "csrr a2, {}",
+            "mv {}, a0",
+            const CSR,
+            out(reg) res,
+            options(nomem));
+        asm!("csrw mtvec, {}", in(reg) mtvec);
+    }
+    res == 0
+}
+
+/// Probes whether the `mhpmcounter` CSR selected by `CSR_NUM` (0xb03..=0xb1f)
+/// exists and is writable, setting its bit in `mhpm_mask` when it does.
+pub fn probe_mhpm_csr<const CSR_NUM: u16>(trap_info: &mut TrapInfo, mhpm_mask: &mut u32) {
+    let trap_info = trap_info as *mut TrapInfo;
+    // SAFETY: `trap_info` points to a live, owned `TrapInfo` for the whole
+    // call; `csr_read_allow`/`csr_write_allow` install the expected-trap
+    // vector in `mtvec` and restore the old vector before returning, so
+    // touching a missing CSR is contained. `CSR_NUM` is a compile-time
+    // mhpmcounter selector from the caller's `seq!` range.
+    unsafe {
+        let old_value = csr_read_allow::<CSR_NUM>(trap_info);
+        if (*trap_info).mcause == usize::MAX {
+            csr_write_allow::<CSR_NUM>(trap_info, 1);
+            if (*trap_info).mcause == usize::MAX && csr_swap::<CSR_NUM>(old_value) == 1 {
+                (*mhpm_mask) |= 1 << (CSR_NUM - CSR_MCYCLE);
             }
-            res == 0
-    }};
+        }
+    }
 }
 
 /// Machine environment configuration register (menvcfg) bit fields.
@@ -181,5 +210,312 @@ pub mod minstret {
         unsafe {
             asm!("csrrw zero, minstret, {}", in(reg) value, options(nomem));
         }
+    }
+}
+
+/// Machine interrupt-enable (`mie`) bit operations.
+pub mod mie {
+    use riscv::register::mie;
+
+    /// Enables the machine software interrupt.
+    pub fn enable_msoft() {
+        // SAFETY: M-mode firmware toggling its own interrupt-enable bits.
+        unsafe { mie::set_msoft() }
+    }
+
+    /// Disables the machine software interrupt.
+    pub fn disable_msoft() {
+        // SAFETY: M-mode firmware toggling its own interrupt-enable bits.
+        unsafe { mie::clear_msoft() }
+    }
+
+    /// Enables the machine timer interrupt.
+    pub fn set_mtimer() {
+        // SAFETY: M-mode firmware toggling its own interrupt-enable bits.
+        unsafe { mie::set_mtimer() }
+    }
+
+    /// Disables the machine timer interrupt.
+    pub fn clear_mtimer() {
+        // SAFETY: M-mode firmware toggling its own interrupt-enable bits.
+        unsafe { mie::clear_mtimer() }
+    }
+}
+
+/// Machine interrupt-pending (`mip`) bit operations.
+pub mod mip {
+    use riscv::register::mip;
+
+    /// Sets the supervisor software interrupt pending bit.
+    pub fn set_ssoft() {
+        // SAFETY: M-mode firmware; pending bits are a control-flow signal.
+        unsafe { mip::set_ssoft() }
+    }
+
+    /// Sets the supervisor timer interrupt pending bit.
+    pub fn set_stimer() {
+        // SAFETY: M-mode firmware; pending bits are a control-flow signal.
+        unsafe { mip::set_stimer() }
+    }
+
+    /// Clears the supervisor timer interrupt pending bit.
+    pub fn clear_stimer() {
+        // SAFETY: M-mode firmware; pending bits are a control-flow signal.
+        unsafe { mip::clear_stimer() }
+    }
+}
+
+/// Machine counter-inhibit (`mcountinhibit`) operations.
+pub mod mcountinhibit {
+    use core::arch::asm;
+    use riscv::register::mcountinhibit;
+
+    /// Reads the raw `mcountinhibit` value.
+    pub fn read() -> usize {
+        mcountinhibit::read().bits()
+    }
+
+    /// Overwrites `mcountinhibit` with `bits`.
+    pub fn write_raw(bits: usize) {
+        // SAFETY: M-mode init; inhibit bits only gate PMU accounting.
+        unsafe { asm!("csrw mcountinhibit, {}", in(reg) bits) };
+    }
+
+    /// Inhibits the cycle counter.
+    pub fn set_cy() {
+        // SAFETY: M-mode; inhibit bits only gate PMU accounting.
+        unsafe { mcountinhibit::set_cy() }
+    }
+
+    /// Re-enables the cycle counter.
+    pub fn clear_cy() {
+        // SAFETY: M-mode; inhibit bits only gate PMU accounting.
+        unsafe { mcountinhibit::clear_cy() }
+    }
+
+    /// Inhibits the instret counter.
+    pub fn set_ir() {
+        // SAFETY: M-mode; inhibit bits only gate PMU accounting.
+        unsafe { mcountinhibit::set_ir() }
+    }
+
+    /// Re-enables the instret counter.
+    pub fn clear_ir() {
+        // SAFETY: M-mode; inhibit bits only gate PMU accounting.
+        unsafe { mcountinhibit::clear_ir() }
+    }
+
+    /// Inhibits `mhpmcounterN`.
+    pub fn set_hpm(index: usize) {
+        // SAFETY: M-mode; the index precondition above is checked by callers.
+        unsafe { mcountinhibit::set_hpm(index) }
+    }
+
+    /// Re-enables `mhpmcounterN`.
+    pub fn clear_hpm(index: usize) {
+        // SAFETY: M-mode; the index precondition above is checked by callers.
+        unsafe { mcountinhibit::clear_hpm(index) }
+    }
+}
+
+/// Writes `mhpmeventN` for the counter at `mhpm_offset` (3..=31).
+pub fn write_mhpmevent(mhpm_offset: u16, mhpmevent_val: u64) {
+    use riscv::register::*;
+
+    let csr = CSR_MHPMEVENT3 + mhpm_offset - 3;
+
+    // Handle MHPMEVENT3-31
+    if csr >= CSR_MHPMEVENT3 && csr <= CSR_MHPMEVENT31 {
+        // Convert CSR value to register index (3-31)
+        let idx = csr - CSR_MHPMEVENT3 + 3;
+
+        // Use seq_macro to generate all valid indices from 3 to 31
+        seq_macro::seq!(N in 3..=31 {
+            match idx {
+                #(
+                    // SAFETY: M-mode; `idx` is in 3..=31 and the probed
+                    // `mhpm_mask` guarantees the selector exists on this hart.
+                    N => unsafe {
+                        pastey::paste!{ [<mhpmevent ~N>]::write(mhpmevent_val as usize) }
+                    },
+                )*
+                _ =>{}
+            }
+        });
+    }
+}
+
+/// Writes `mhpmcounterN` (or `mcycle`/`minstret`) for `mhpm_offset`.
+pub fn write_mhpmcounter(mhpm_offset: u16, mhpmcounter_val: u64) {
+    use riscv::register::*;
+
+    let counter_idx = mhpm_offset;
+
+    let csr = CSR_MHPMCOUNTER3 + mhpm_offset - 3;
+    // Special cases for cycle and instret
+    if csr == CSR_MCYCLE {
+        self::mcycle::write(mhpmcounter_val);
+        return;
+    } else if csr == CSR_MINSTRET {
+        self::minstret::write(mhpmcounter_val);
+        return;
+    }
+
+    // Only handle valid counter indices (3-31)
+    if counter_idx >= 3 && counter_idx <= 31 {
+        // Call the macro with all valid indices
+        seq_macro::seq!(N in 3..=31 {
+            match counter_idx {
+                #(
+                    // SAFETY: M-mode; `counter_idx` is in 3..=31 and the probed
+                    // `mhpm_mask` guarantees the counter exists on this hart.
+                    N => pastey::paste!{ unsafe {
+                        [<mhpmcounter ~N>]::write(mhpmcounter_val as usize) }
+                    },
+                )*
+                _ =>{}
+            }
+        });
+    }
+}
+
+/// Delegates interrupts, exceptions, and counters to supervisor mode, while
+/// keeping supervisor ecalls and misaligned/illegal instructions in M-mode.
+///
+/// The body is the firmware's fixed delegation policy; it runs once per hart
+/// during M-mode init, before any supervisor code executes.
+pub fn configure_delegation() {
+    use riscv::register::medeleg;
+
+    // SAFETY: M-mode init on the current hart; the written values are the
+    // firmware's fixed delegation policy and have no memory-safety impact.
+    unsafe {
+        // Delegate all interrupts and exceptions to supervisor mode.
+        asm!("csrw mideleg,    {}", in(reg) !0);
+        asm!("csrw medeleg,    {}", in(reg) !0);
+        asm!("csrw mcounteren, {}", in(reg) !0);
+        asm!("csrw scounteren, {}", in(reg) !0);
+        // Keep supervisor environment calls and illegal instructions in M-mode.
+        medeleg::clear_supervisor_env_call();
+        medeleg::clear_load_misaligned();
+        medeleg::clear_store_misaligned();
+        medeleg::clear_illegal_instruction();
+    }
+}
+
+/// Installs the fast-trap entry as the machine trap vector (direct mode).
+///
+/// Runs once per hart during M-mode init, after delegation is configured.
+pub fn install_trap_vector() {
+    use riscv::register::mtvec;
+
+    // Set up trap handling.
+    let val = mtvec::Mtvec::new(
+        fast_trap::trap_entry as *const () as _,
+        mtvec::TrapMode::Direct,
+    );
+    // SAFETY: `fast_trap::trap_entry` is a valid, aligned M-mode trap entry
+    // for direct mode.
+    unsafe { mtvec::write(val) }
+}
+
+/// Fence instruction family (`fence.i`, `sfence.vma`, and the
+/// hypervisor-gated `hfence.gvma` / `hfence.vvma`).
+pub mod fence {
+    use core::arch::asm;
+
+    /// Fences instruction fetch for the current hart (`fence.i`).
+    pub fn fence_i() {
+        // SAFETY: instruction-fetch ordering on the local hart only.
+        unsafe { asm!("fence.i") };
+    }
+
+    /// Invalidates all supervisor TLB entries (`sfence.vma`).
+    pub fn sfence_vma_all() {
+        // SAFETY: full TLB invalidate; requested by a validated SBI rfence call.
+        unsafe { asm!("sfence.vma") };
+    }
+
+    /// Invalidates supervisor TLB entries for `addr` (`sfence.vma addr`).
+    pub fn sfence_vma_addr(addr: usize) {
+        // SAFETY: single-page TLB invalidate; the caller validated that the
+        // address range is page-aligned.
+        unsafe { asm!("sfence.vma {}", in(reg) addr) };
+    }
+
+    /// Invalidates all supervisor TLB entries for `asid`
+    /// (`sfence.vma x0, asid`).
+    pub fn sfence_vma_asid(asid: usize) {
+        // SAFETY: per-ASID TLB invalidate; requested by a validated SBI rfence call.
+        unsafe { asm!("sfence.vma x0, {}", in(reg) asid) };
+    }
+
+    /// Invalidates supervisor TLB entries for (`addr`, `asid`)
+    /// (`sfence.vma addr, asid`).
+    pub fn sfence_vma_addr_asid(addr: usize, asid: usize) {
+        // SAFETY: as above, with both operands.
+        unsafe { asm!("sfence.vma {}, {}", in(reg) addr, in(reg) asid) };
+    }
+
+    /// Invalidates all guest TLB entries (`hfence.gvma x0, x0`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_gvma_all() {
+        // SAFETY: guest-TLB invalidate; the hypervisor extension probe gates
+        // every call site.
+        unsafe { asm!("hfence.gvma x0, x0") };
+    }
+
+    /// Invalidates guest TLB entries for `addr` (`hfence.gvma addr, x0`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_gvma_addr(addr: usize) {
+        // SAFETY: as above, for a single guest-physical page.
+        unsafe { asm!("hfence.gvma {}, x0", in(reg) addr) };
+    }
+
+    /// Invalidates all guest TLB entries for `vmid` (`hfence.gvma x0, vmid`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_gvma_vmid(vmid: usize) {
+        // SAFETY: as above, for one VMID.
+        unsafe { asm!("hfence.gvma x0, {}", in(reg) vmid) };
+    }
+
+    /// Invalidates guest TLB entries for (`addr`, `vmid`)
+    /// (`hfence.gvma addr, vmid`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_gvma_addr_vmid(addr: usize, vmid: usize) {
+        // SAFETY: as above, with both operands.
+        unsafe { asm!("hfence.gvma {}, {}", in(reg) addr, in(reg) vmid) };
+    }
+
+    /// Invalidates all guest supervisor TLB entries (`hfence.vvma x0, x0`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_vvma_all() {
+        // SAFETY: guest-TLB invalidate; the hypervisor extension probe gates
+        // every call site.
+        unsafe { asm!("hfence.vvma x0, x0") };
+    }
+
+    /// Invalidates guest supervisor TLB entries for `addr`
+    /// (`hfence.vvma addr, x0`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_vvma_addr(addr: usize) {
+        // SAFETY: as above, for a single guest virtual page.
+        unsafe { asm!("hfence.vvma {}, x0", in(reg) addr) };
+    }
+
+    /// Invalidates all guest supervisor TLB entries for `asid`
+    /// (`hfence.vvma x0, asid`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_vvma_asid(asid: usize) {
+        // SAFETY: as above, for one ASID.
+        unsafe { asm!("hfence.vvma x0, {}", in(reg) asid) };
+    }
+
+    /// Invalidates guest supervisor TLB entries for (`addr`, `asid`)
+    /// (`hfence.vvma addr, asid`).
+    #[cfg(feature = "hypervisor")]
+    pub fn hfence_vvma_addr_asid(addr: usize, asid: usize) {
+        // SAFETY: as above, with both operands.
+        unsafe { asm!("hfence.vvma {}, {}", in(reg) addr, in(reg) asid) };
     }
 }

--- a/prototyper/prototyper/src/riscv/spacemit_k1.rs
+++ b/prototyper/prototyper/src/riscv/spacemit_k1.rs
@@ -252,6 +252,27 @@ pub fn cold_boot_allowed(hart_id: usize) -> bool {
     hart_id == 0
 }
 
+/// Runs the K1 cold-boot sequence on the boot hart: claims this hart's L2
+/// setup bit (ML2SETUP), then programs MSETUP / I-cache invalidation and the
+/// warmboot (RVBADDR) + CCI-550 interconnect state via [`early_init`].
+///
+/// Safe wrapper: the caller (the platform boot path) has already verified
+/// from the device tree that this is a K1 platform, so the K1-specific
+/// CSR/MMIO addresses used here are valid, and the sequence runs exactly
+/// once on the M-mode boot hart.
+pub fn cold_boot_init() {
+    // Configure ML2SETUP for the boot hart
+    cold_boot_allowed(current_hartid());
+    // SAFETY: K1 platform verified by the caller; single execution on the
+    // M-mode boot hart. The warmboot entry is this firmware's own link
+    // address.
+    unsafe {
+        // Use the SBI link address as the warmboot entry
+        let warmboot_addr = crate::cfg::SBI_LINK_START_ADDRESS as u64;
+        early_init(true, warmboot_addr);
+    }
+}
+
 /// Get the maximum number of CPUs supported by this platform.
 #[inline]
 pub const fn max_cpus() -> usize {

--- a/prototyper/prototyper/src/sbi/features.rs
+++ b/prototyper/prototyper/src/sbi/features.rs
@@ -1,23 +1,19 @@
+#![forbid(unsafe_code)]
+
 use ::riscv::register::mstatus::MPP;
 use riscv::register::misa;
 use seq_macro::seq;
 use serde_device_tree::buildin::NodeSeq;
 
-use core::arch::asm;
 use core::sync::atomic::Ordering;
 
 use crate::fail;
-use crate::has_csr;
 use crate::platform::CPU_PRIVILEGED_ENABLED;
 use crate::platform::aia::is_aia_active;
 use crate::riscv::csr::*;
 use crate::riscv::current_hartid;
-use crate::sbi::early_trap::{TrapInfo, csr_read_allow, csr_write_allow};
+use crate::sbi::early_trap::TrapInfo;
 use crate::sbi::trap_stack::{hart_local, with_current, with_hart};
-
-use super::early_trap::csr_swap;
-
-use riscv::register::{medeleg, mtvec};
 
 pub struct HartFeatures {
     extensions: [bool; Extension::COUNT],
@@ -135,11 +131,11 @@ fn check_extension_in_device_tree(ext: &str, cpu: &crate::devicetree::Cpu) -> bo
 fn privileged_version_detection() {
     let mut current_priv_ver = PrivilegedVersion::Unknown;
     {
-        if has_csr!(CSR_MCOUNTEREN) {
+        if has_csr::<CSR_MCOUNTEREN>() {
             current_priv_ver = PrivilegedVersion::Version1_10;
-            if has_csr!(CSR_MCOUNTINHIBIT) {
+            if has_csr::<CSR_MCOUNTINHIBIT>() {
                 current_priv_ver = PrivilegedVersion::Version1_11;
-                if has_csr!(CSR_MENVCFG) {
+                if has_csr::<CSR_MENVCFG>() {
                     current_priv_ver = PrivilegedVersion::Version1_12;
                 }
             }
@@ -153,28 +149,16 @@ fn mhpm_detection() {
     let mut current_mhpm_mask: u32 = 0b111;
     let mut trap_info: TrapInfo = TrapInfo::default();
 
-    fn check_mhpm_csr<const CSR_NUM: u16>(trap_info: *mut TrapInfo, mhpm_mask: &mut u32) {
-        unsafe {
-            let old_value = csr_read_allow::<CSR_NUM>(trap_info);
-            if (*trap_info).mcause == usize::MAX {
-                csr_write_allow::<CSR_NUM>(trap_info, 1);
-                if (*trap_info).mcause == usize::MAX && csr_swap::<CSR_NUM>(old_value) == 1 {
-                    (*mhpm_mask) |= 1 << (CSR_NUM - CSR_MCYCLE);
-                }
-            }
-        }
-    }
-
-    macro_rules! m_check_mhpm_csr {
+    macro_rules! m_probe_mhpm_csr {
         ($csr_num:expr, $trap_info:expr, $value:expr) => {
-            check_mhpm_csr::<$csr_num>($trap_info, $value)
+            probe_mhpm_csr::<$csr_num>($trap_info, $value)
         };
     }
 
     // CSR_MHPMCOUNTER3:   0xb03
     // CSR_MHPMCOUNTER31:  0xb1f
     seq!(csr_num in 0xb03..=0xb1f{
-        m_check_mhpm_csr!(csr_num, &mut trap_info, &mut current_mhpm_mask);
+        m_probe_mhpm_csr!(csr_num, &mut trap_info, &mut current_mhpm_mask);
     });
 
     with_current(|local| {
@@ -229,48 +213,33 @@ pub fn check_privilege(mpp: MPP) {
 /// Returns whether the `mstateen0` CSR is implemented (trap-tolerant probe).
 #[inline(always)]
 fn has_mstateen0() -> bool {
-    has_csr!(CSR_MSTATEEN0)
+    has_csr::<CSR_MSTATEEN0>()
 }
 
 /// Configures per-hart delegation and trap CSRs for supervisor hand-off.
 pub fn configure_delegation_and_trap() {
-    unsafe {
-        // Delegate all interrupts and exceptions to supervisor mode.
-        asm!("csrw mideleg,    {}", in(reg) !0);
-        asm!("csrw medeleg,    {}", in(reg) !0);
-        asm!("csrw mcounteren, {}", in(reg) !0);
-        asm!("csrw scounteren, {}", in(reg) !0);
-        // Keep supervisor environment calls and illegal instructions in M-mode.
-        medeleg::clear_supervisor_env_call();
-        medeleg::clear_load_misaligned();
-        medeleg::clear_store_misaligned();
-        medeleg::clear_illegal_instruction();
+    // Delegate all interrupts and exceptions to supervisor mode.
+    configure_delegation();
 
-        let hart_priv_version = hart_privileged_version(current_hartid());
-        if hart_priv_version >= PrivilegedVersion::Version1_11 {
-            asm!("csrw mcountinhibit, {}", in(reg) !0b111usize);
-        }
-        if hart_priv_version >= PrivilegedVersion::Version1_12 {
-            // Configure environment features based on available extensions.
-            if hart_extension_probe(current_hartid(), Extension::Sstc) {
-                menvcfg::set_bits(
-                    menvcfg::STCE | menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE,
-                );
-            } else {
-                menvcfg::set_bits(menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE);
-            }
-            if is_aia_active()
-                && hart_extension_probe(current_hartid(), Extension::Smaia)
-                && has_mstateen0()
-            {
-                mstateen::enable_smode_aia();
-            }
-        }
-        // Set up trap handling.
-        let val = mtvec::Mtvec::new(
-            fast_trap::trap_entry as *const () as _,
-            mtvec::TrapMode::Direct,
-        );
-        mtvec::write(val);
+    let hart_priv_version = hart_privileged_version(current_hartid());
+    if hart_priv_version >= PrivilegedVersion::Version1_11 {
+        mcountinhibit::write_raw(!0b111usize);
     }
+    if hart_priv_version >= PrivilegedVersion::Version1_12 {
+        // Configure environment features based on available extensions.
+        if hart_extension_probe(current_hartid(), Extension::Sstc) {
+            menvcfg::set_bits(
+                menvcfg::STCE | menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE,
+            );
+        } else {
+            menvcfg::set_bits(menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE);
+        }
+        if is_aia_active()
+            && hart_extension_probe(current_hartid(), Extension::Smaia)
+            && has_mstateen0()
+        {
+            mstateen::enable_smode_aia();
+        }
+    }
+    install_trap_vector();
 }

--- a/prototyper/prototyper/src/sbi/hsm.rs
+++ b/prototyper/prototyper/src/sbi/hsm.rs
@@ -1,8 +1,11 @@
+#![forbid(unsafe_code)]
+
 //! SBI HSM (Hart State Management) extension.
 
 use riscv::register::mstatus::MPP;
 use rustsbi::SbiRet;
 
+use crate::riscv::csr::mie;
 use crate::riscv::current_hartid;
 use crate::sbi::hart_context::NextStage;
 
@@ -53,9 +56,7 @@ impl rustsbi::Hsm for SbiHsm {
     #[inline]
     fn hart_stop(&self) -> SbiRet {
         local_hsm().stop();
-        unsafe {
-            riscv::register::mie::clear_msoft();
-        }
+        mie::disable_msoft();
         riscv::asm::wfi();
         SbiRet::success(0)
     }
@@ -85,9 +86,7 @@ impl rustsbi::Hsm for SbiHsm {
 
         crate::sbi::trap::handler::msoft_ipi_handler();
         crate::sbi::ipi().unwrap().clear_msip(current_hartid());
-        unsafe {
-            riscv::register::mie::set_msoft();
-        }
+        mie::enable_msoft();
         local_hsm().suspend();
         riscv::asm::wfi();
         crate::sbi::trap::handler::msoft_ipi_handler();
@@ -116,9 +115,7 @@ impl SbiHsm {
                     // reset the hart local context to prevent the hart context from being polluted
                     reset_hart(hartid);
                     // boot resume hart from resume addr
-                    unsafe {
-                        boot();
-                    }
+                    boot();
                 } else {
                     SbiRet::failed()
                 }

--- a/prototyper/prototyper/src/sbi/ipi.rs
+++ b/prototyper/prototyper/src/sbi/ipi.rs
@@ -1,9 +1,11 @@
+#![forbid(unsafe_code)]
+
 use super::pmu::pmu_firmware_counter_increment;
 use crate::cfg::NUM_HART_MAX;
 use crate::platform::BoardInfo;
 use crate::platform::aia;
 use crate::platform::clint::{MachineClintType, SifiveClintWrap, THeadClintWrap};
-use crate::riscv::csr::stimecmp;
+use crate::riscv::csr::{mie, mip, stimecmp};
 use crate::riscv::current_hartid;
 use crate::sbi::features::{Extension, hart_extension_probe};
 use crate::sbi::hsm::remote_hsm;
@@ -60,10 +62,8 @@ impl rustsbi::Timer for SbiIpi {
             stimecmp::set(stime_value);
         } else {
             self.write_mtimecmp(hart_id, stime_value);
-            unsafe {
-                riscv::register::mip::clear_stimer();
-                riscv::register::mie::set_mtimer();
-            }
+            mip::clear_stimer();
+            mie::set_mtimer();
         }
     }
 }

--- a/prototyper/prototyper/src/sbi/pmu.rs
+++ b/prototyper/prototyper/src/sbi/pmu.rs
@@ -1,6 +1,7 @@
+#![forbid(unsafe_code)]
+
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use riscv::register::*;
 use rustsbi::{Pmu, SbiRet};
 use sbi_spec::binary::SharedPtr;
 use sbi_spec::pmu::shmem_size::SIZE;
@@ -86,8 +87,9 @@ impl PmuState {
             return None;
         }
         let fw_idx = counter_idx - self.hw_counters_num;
-        // Safety: fw_idx is guaranteed to be within bounds (0..FIRMWARE_COUNTER_MAX)
-        unsafe { Some(*self.fw_counter.get_unchecked(fw_idx)) }
+        // fw_idx is guaranteed to be within bounds (0..FIRMWARE_COUNTER_MAX)
+        // by the range check above.
+        Some(self.fw_counter[fw_idx])
     }
 
     /// start a firmware counter with a optional new value.
@@ -529,8 +531,8 @@ impl SbiPmu {
             }
             // If the counter idx corresponding to the hardware counter index has already started counting, skip the counter
             if hart_privileged_version(current_hartid()) >= PrivilegedVersion::Version1_11 {
-                let inhibit = riscv::register::mcountinhibit::read();
-                if (inhibit.bits() & (1 << mhpm_offset)) == 0 {
+                let inhibit = mcountinhibit::read();
+                if (inhibit & (1 << mhpm_offset)) == 0 {
                     continue;
                 }
             }
@@ -712,21 +714,21 @@ impl HardwareCounter {
     }
 
     #[inline]
-    unsafe fn start(self) {
+    fn start(self) {
         match self {
-            Self::Cycle => unsafe { mcountinhibit::clear_cy() },
-            Self::Instret => unsafe { mcountinhibit::clear_ir() },
-            Self::Hpm(offset) => unsafe { mcountinhibit::clear_hpm(offset as usize) },
+            Self::Cycle => mcountinhibit::clear_cy(),
+            Self::Instret => mcountinhibit::clear_ir(),
+            Self::Hpm(offset) => mcountinhibit::clear_hpm(offset as usize),
         }
         self.sync_shadow();
     }
 
     #[inline]
-    unsafe fn stop(self) {
+    fn stop(self) {
         match self {
-            Self::Cycle => unsafe { mcountinhibit::set_cy() },
-            Self::Instret => unsafe { mcountinhibit::set_ir() },
-            Self::Hpm(offset) => unsafe { mcountinhibit::set_hpm(offset as usize) },
+            Self::Cycle => mcountinhibit::set_cy(),
+            Self::Instret => mcountinhibit::set_ir(),
+            Self::Hpm(offset) => mcountinhibit::set_hpm(offset as usize),
         }
         self.sync_shadow();
     }
@@ -769,7 +771,7 @@ fn start_hardware_counter(
 
     // Check if counter is already running by testing the inhibit bit
     // A zero bit in mcountinhibit means the counter is running
-    if mcountinhibit::read().bits() & counter.inhibit_mask() == 0 {
+    if mcountinhibit::read() & counter.inhibit_mask() == 0 {
         return Err(StartCounterErr::AlreadyStart);
     }
 
@@ -777,9 +779,7 @@ fn start_hardware_counter(
         write_mhpmcounter(mhpm_offset, new_value);
     }
 
-    unsafe {
-        counter.start();
-    }
+    counter.start();
     Ok(())
 }
 
@@ -803,66 +803,12 @@ fn stop_hardware_counter(mhpm_offset: u16, is_reset: bool) -> Result<(), StopCou
         return Ok(());
     }
 
-    if mcountinhibit::read().bits() & counter.inhibit_mask() != 0 {
+    if mcountinhibit::read() & counter.inhibit_mask() != 0 {
         return Err(StopCounterErr::AlreadyStop);
     }
 
-    unsafe {
-        counter.stop();
-    }
+    counter.stop();
     Ok(())
-}
-
-/// Write MHPMEVENT or MHPMCOUNTER
-fn write_mhpmevent(mhpm_offset: u16, mhpmevent_val: u64) {
-    let csr = CSR_MHPMEVENT3 + mhpm_offset - 3;
-
-    // Handle MHPMEVENT3-31
-    if csr >= CSR_MHPMEVENT3 && csr <= CSR_MHPMEVENT31 {
-        // Convert CSR value to register index (3-31)
-        let idx = csr - CSR_MHPMEVENT3 + 3;
-
-        // Use seq_macro to generate all valid indices from 3 to 31
-        seq_macro::seq!(N in 3..=31 {
-            match idx {
-                #(
-                    N => unsafe {
-                        pastey::paste!{ [<mhpmevent ~N>]::write(mhpmevent_val as usize) }
-                    },
-                )*
-                _ =>{}
-            }
-        });
-    }
-}
-
-fn write_mhpmcounter(mhpm_offset: u16, mhpmcounter_val: u64) {
-    let counter_idx = mhpm_offset;
-
-    let csr = CSR_MHPMCOUNTER3 + mhpm_offset - 3;
-    // Special cases for cycle and instret
-    if csr == CSR_MCYCLE {
-        crate::riscv::csr::mcycle::write(mhpmcounter_val);
-        return;
-    } else if csr == CSR_MINSTRET {
-        crate::riscv::csr::minstret::write(mhpmcounter_val);
-        return;
-    }
-
-    // Only handle valid counter indices (3-31)
-    if counter_idx >= 3 && counter_idx <= 31 {
-        // Call the macro with all valid indices
-        seq_macro::seq!(N in 3..=31 {
-            match counter_idx {
-                #(
-                    N => pastey::paste!{ unsafe {
-                        [<mhpmcounter ~N>]::write(mhpmcounter_val as usize) }
-                    },
-                )*
-                _ =>{}
-            }
-        });
-    }
 }
 
 /// Wrap for counter info

--- a/prototyper/prototyper/src/sbi/rfence.rs
+++ b/prototyper/prototyper/src/sbi/rfence.rs
@@ -1,11 +1,13 @@
+#![forbid(unsafe_code)]
+
 //! SBI RFence (Remote Fence) extension.
 
 use rustsbi::{HartMask, SbiRet};
 use sbi_spec::pmu::firmware_event;
 
 use crate::cfg::{PAGE_SIZE, TLB_FLUSH_LIMIT};
+use crate::riscv::csr::fence;
 use crate::riscv::current_hartid;
-use core::arch::asm;
 
 use super::pmu::pmu_firmware_counter_increment;
 use super::trap_stack::{FifoError, LocalRFenceCell, RemoteRFenceCell};
@@ -306,17 +308,17 @@ pub fn rfence_single_handler() {
         match ctx.op {
             RFenceType::FenceI => {
                 pmu_firmware_counter_increment(firmware_event::FENCE_I_RECEIVED);
-                unsafe { asm!("fence.i") };
+                fence::fence_i();
                 remote_rfence(source_hart_id).unwrap().sub();
             }
             RFenceType::SFenceVma => {
                 pmu_firmware_counter_increment(firmware_event::SFENCE_VMA_RECEIVED);
                 if full_flush {
-                    unsafe { asm!("sfence.vma") };
+                    fence::sfence_vma_all();
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {
                         let addr = ctx.start_addr.wrapping_add(offset);
-                        unsafe { asm!("sfence.vma {}", in(reg) addr) };
+                        fence::sfence_vma_addr(addr);
                     }
                 }
                 if let Some(remote_cell) = remote_rfence(source_hart_id) {
@@ -327,11 +329,11 @@ pub fn rfence_single_handler() {
                 pmu_firmware_counter_increment(firmware_event::SFENCE_VMA_ASID_RECEIVED);
                 let asid = ctx.asid;
                 if full_flush {
-                    unsafe { asm!("sfence.vma x0, {}", in(reg) asid) };
+                    fence::sfence_vma_asid(asid);
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {
                         let addr = ctx.start_addr.wrapping_add(offset);
-                        unsafe { asm!("sfence.vma {}, {}", in(reg) addr, in(reg) asid) };
+                        fence::sfence_vma_addr_asid(addr, asid);
                     }
                 }
                 if let Some(remote_cell) = remote_rfence(source_hart_id) {
@@ -343,11 +345,11 @@ pub fn rfence_single_handler() {
                 pmu_firmware_counter_increment(firmware_event::HFENCE_GVMA_VMID_RECEIVED);
                 let vmid = ctx.vmid;
                 if full_flush {
-                    unsafe { asm!("hfence.gvma x0, {}", in(reg) vmid) };
+                    fence::hfence_gvma_vmid(vmid);
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {
                         let addr = ctx.start_addr.wrapping_add(offset);
-                        unsafe { asm!("hfence.gvma {}, {}", in(reg) addr, in(reg) vmid) };
+                        fence::hfence_gvma_addr_vmid(addr, vmid);
                     }
                 }
                 if let Some(remote_cell) = remote_rfence(source_hart_id) {
@@ -358,11 +360,11 @@ pub fn rfence_single_handler() {
             RFenceType::HFenceGvma => {
                 pmu_firmware_counter_increment(firmware_event::HFENCE_GVMA_RECEIVED);
                 if full_flush {
-                    unsafe { asm!("hfence.gvma x0, x0") };
+                    fence::hfence_gvma_all();
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {
                         let addr = ctx.start_addr.wrapping_add(offset);
-                        unsafe { asm!("hfence.gvma {}, x0", in(reg) addr) };
+                        fence::hfence_gvma_addr(addr);
                     }
                 }
                 if let Some(remote_cell) = remote_rfence(source_hart_id) {
@@ -374,11 +376,11 @@ pub fn rfence_single_handler() {
                 pmu_firmware_counter_increment(firmware_event::HFENCE_VVMA_ASID_RECEIVED);
                 let asid = ctx.asid;
                 if full_flush {
-                    unsafe { asm!("hfence.vvma x0, {}", in(reg) asid) };
+                    fence::hfence_vvma_asid(asid);
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {
                         let addr = ctx.start_addr.wrapping_add(offset);
-                        unsafe { asm!("hfence.vvma {}, {}", in(reg) addr, in(reg) asid) };
+                        fence::hfence_vvma_addr_asid(addr, asid);
                     }
                 }
                 if let Some(remote_cell) = remote_rfence(source_hart_id) {
@@ -389,11 +391,11 @@ pub fn rfence_single_handler() {
             RFenceType::HFenceVvma => {
                 pmu_firmware_counter_increment(firmware_event::HFENCE_VVMA_RECEIVED);
                 if full_flush {
-                    unsafe { asm!("hfence.vvma x0, x0") };
+                    fence::hfence_vvma_all();
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {
                         let addr = ctx.start_addr.wrapping_add(offset);
-                        unsafe { asm!("hfence.vvma {}, x0", in(reg) addr) };
+                        fence::hfence_vvma_addr(addr);
                     }
                 }
                 if let Some(remote_cell) = remote_rfence(source_hart_id) {

--- a/prototyper/prototyper/src/sbi/trap/boot.rs
+++ b/prototyper/prototyper/src/sbi/trap/boot.rs
@@ -6,11 +6,22 @@ use crate::sbi::trap_stack;
 use core::arch::naked_asm;
 use riscv::register::{mie, mstatus, satp, sstatus};
 
+/// Boots the next stage on the current hart; never returns.
+///
+/// Safe wrapper over the naked [`boot_entry`]: the entry diverges (its final
+/// `mret` drops to the staged next-mode PC instead of returning), and the
+/// staged start address / mode validity is the HSM cell's contract — the
+/// HSM cell accepted them before this call.
+pub fn boot() -> ! {
+    // SAFETY: divergent entry; target validity is the HSM cell's contract.
+    unsafe { boot_entry() }
+}
+
 /// Boot Function.
 /// After boot, this flow will never back again,
 /// so we can store a0, a1 and mepc only.
 #[unsafe(naked)]
-pub unsafe extern "C" fn boot() -> ! {
+unsafe extern "C" fn boot_entry() -> ! {
     naked_asm!(
         ".align 2",
         // Reset hart local stack


### PR DESCRIPTION
Business modules called `riscv`-crate unsafe fns (mie/mip writes, fence asm) at 30 sites. Each site moves into a wrapper in `riscv/csr.rs` whose SAFETY comment names the verified precondition once; callers then carry no unsafe, and six business modules (hsm, rfence, pmu, features, ipi, platform/boot) gain `#![forbid(unsafe_code)]`.

Stacked on #248.