### PR TITLE
refactor(prototyper): publish the heap backing store via Once

### DIFF
--- a/firmware/prototyper/src/sbi/heap.rs
+++ b/firmware/prototyper/src/sbi/heap.rs
@@ -1,24 +1,32 @@
-//! SBI heap backing store; the raw pool stays a `static mut` (its address
-//! is handed to the allocator once at init).
-#![allow(static_mut_refs)]
+//! Firmware heap allocator.
 
 use crate::cfg::HEAP_SIZE;
 use buddy_system_allocator::LockedHeap;
+use spin::Once;
 
 #[unsafe(link_section = ".bss.heap")]
-static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+static RAW_HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 
 const BUDDY_MAX_ORDER: usize = 20;
 #[global_allocator]
 static HEAP_ALLOCATOR: LockedHeap<BUDDY_MAX_ORDER> = LockedHeap::<BUDDY_MAX_ORDER>::empty();
 
-/// Initializes the global SBI heap allocator.
+static HEAP_INIT: Once<()> = Once::new();
+
+/// Initializes the global heap allocator.
+///
+/// Must be called exactly once, on the boot hart, before any allocation.
 pub fn init() {
-    unsafe {
-        HEAP_ALLOCATOR
-            .lock()
-            .init(HEAP.as_ptr() as usize, HEAP_SIZE);
-    }
+    HEAP_INIT.call_once(|| {
+        // SAFETY: `RAW_HEAP` is a BSS array whose address is handed to the
+        // allocator exactly once; after this call the allocator owns the
+        // region and no Rust reference to it is created again.
+        unsafe { HEAP_ALLOCATOR.lock().init(raw_heap_addr(), HEAP_SIZE) };
+    });
+}
+
+fn raw_heap_addr() -> usize {
+    core::ptr::addr_of!(RAW_HEAP) as usize
 }
 
 #[alloc_error_handler]


### PR DESCRIPTION
The heap backing store is a `static mut` array that gets its address
handed to the allocator at init — a `static mut` is the wrong type
for that, because the array is never mutated through a reference;
it is raw memory whose ownership moves once, to the allocator.

Use a read-only static whose address is taken via `addr_of!`, and
gate the init behind `spin::Once` so it happens exactly once. The
`static_mut_refs` allow is no longer needed.

Verified with the full QEMU matrix; boot logs byte-identical.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
