### PR TITLE
fix(prototyper): implement FWFT feature locking

### DIFF
--- a/firmware/prototyper/src/sbi/fwft.rs
+++ b/firmware/prototyper/src/sbi/fwft.rs
@@ -1,7 +1,7 @@
 use rustsbi::SbiRet;
 use sbi_spec::fwft::feature_type;
 
-use crate::riscv::csr::CSR_MENVCFG;
+use crate::riscv::csr::{self, CSR_MENVCFG};
 use crate::sbi::early_trap::{TrapInfo, csr_read_allow, csr_write_allow};
 use crate::sbi::trap_stack::with_current;
 
@@ -47,6 +47,13 @@ impl FwftState {
     fn lock(&mut self, feature_id: u32) {
         self.locked |= Self::mask(feature_id);
     }
+
+    pub(crate) fn reset(&mut self) {
+        // FWFT locks survive non-retentive suspend/resume. Probe results are
+        // cheap to rebuild and may depend on the resumed hart's CSR state.
+        self.probed = 0;
+        self.supported = 0;
+    }
 }
 
 /// Firmware Features extension backed by `medeleg` and `menvcfg`.
@@ -62,7 +69,7 @@ impl SbiFwft {
             return;
         };
         let controlled = ENVCFG_LPE | ENVCFG_SSE | ENVCFG_PMM | ENVCFG_DTE | ENVCFG_ADUE;
-        let _ = Self::menvcfg_write(current & !controlled);
+        let _ = Self::menvcfg_write(current, current & !controlled);
     }
 
     fn has_s_mode() -> bool {
@@ -95,11 +102,23 @@ impl SbiFwft {
         (trap.mcause == usize::MAX).then_some(value)
     }
 
-    fn menvcfg_write(value: usize) -> bool {
+    fn menvcfg_write(previous: usize, value: usize) -> bool {
         let mut trap = TrapInfo::default();
         // SAFETY: firmware runs in M-mode, and `trap` remains valid for the call.
         unsafe { csr_write_allow::<CSR_MENVCFG>(&mut trap, value) };
-        trap.mcause == usize::MAX
+        if trap.mcause != usize::MAX {
+            return false;
+        }
+        if (previous ^ value) & ENVCFG_ADUE != 0 {
+            // The ADUE transition must be ordered before S-mode can use the
+            // changed interpretation of page-table A/D bits.
+            csr::fence::sfence_vma_all();
+            #[cfg(feature = "hypervisor")]
+            if riscv::register::misa::read().has_extension('H') {
+                csr::fence::hfence_gvma_all();
+            }
+        }
+        true
     }
 
     fn menvcfg_bit(feature_id: usize) -> Option<usize> {
@@ -121,7 +140,7 @@ impl SbiFwft {
         } else {
             current & !bit
         };
-        if !Self::menvcfg_write(next) {
+        if !Self::menvcfg_write(current, next) {
             return SbiRet::not_supported();
         }
         let Some(read_back) = Self::menvcfg_read() else {
@@ -145,7 +164,7 @@ impl SbiFwft {
             return SbiRet::not_supported();
         };
         let next = (current & !ENVCFG_PMM) | (encoding << ENVCFG_PMM_SHIFT);
-        if !Self::menvcfg_write(next) {
+        if !Self::menvcfg_write(current, next) {
             return SbiRet::not_supported();
         }
         let Some(read_back) = Self::menvcfg_read() else {
@@ -164,14 +183,14 @@ impl SbiFwft {
         };
         let test_bits = if current & mask == 0 { mask } else { 0 };
         let test_value = (current & !mask) | test_bits;
-        if !Self::menvcfg_write(test_value) {
+        if !Self::menvcfg_write(current, test_value) {
             return false;
         }
         let Some(probed) = Self::menvcfg_read() else {
-            let _ = Self::menvcfg_write(current);
+            let _ = Self::menvcfg_write(test_value, current);
             return false;
         };
-        if !Self::menvcfg_write(current) {
+        if !Self::menvcfg_write(probed, current) {
             return false;
         }
         let Some(restored) = Self::menvcfg_read() else {

--- a/firmware/prototyper/src/sbi/fwft.rs
+++ b/firmware/prototyper/src/sbi/fwft.rs
@@ -3,18 +3,51 @@ use sbi_spec::fwft::feature_type;
 
 use crate::riscv::csr::CSR_MENVCFG;
 use crate::sbi::early_trap::{TrapInfo, csr_read_allow, csr_write_allow};
+use crate::sbi::trap_stack::with_current;
 
 // Misaligned load/store exception cause codes 4 and 6 from the RISC-V
 // privileged architecture.
 const MIS_DELEG: usize = (1 << 4) | (1 << 6);
 
 // `menvcfg` fields defined by the corresponding RISC-V extensions.
-const ENVCFG_LPE: usize = 1 << 0; // Landing pad (Zicfilp)
-const ENVCFG_DTE: usize = 1 << 1; // Double trap (Smdbltrp)
-const ENVCFG_ADUE: usize = 1 << 5; // PTE A/D hardware updating (SVADU)
-const ENVCFG_SSE: usize = 1 << 8; // Shadow stack (Zicfiss)
-const ENVCFG_PMM_SHIFT: usize = 9; // Pointer masking tag length (Smnpm)
+const ENVCFG_LPE: usize = 1 << 2; // Landing pad (Zicfilp)
+const ENVCFG_SSE: usize = 1 << 3; // Shadow stack (Zicfiss)
+const ENVCFG_PMM_SHIFT: usize = 32; // Pointer masking tag length (Smnpm)
 const ENVCFG_PMM: usize = 0b11 << ENVCFG_PMM_SHIFT;
+const ENVCFG_DTE: usize = 1 << 59; // Double trap (Smdbltrp)
+const ENVCFG_ADUE: usize = 1 << 61; // PTE A/D hardware updating (SVADU)
+
+const FWFT_LOCK: usize = 1;
+const LAST_STANDARD_FEATURE: u32 = feature_type::POINTER_MASKING_PMLEN as u32;
+
+#[derive(Clone, Copy)]
+pub(crate) struct FwftState {
+    locked: u8,
+    probed: u8,
+    supported: u8,
+}
+
+impl FwftState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            locked: 0,
+            probed: 0,
+            supported: 0,
+        }
+    }
+
+    fn mask(feature_id: u32) -> u8 {
+        1 << feature_id
+    }
+
+    fn is_locked(&self, feature_id: u32) -> bool {
+        self.locked & Self::mask(feature_id) != 0
+    }
+
+    fn lock(&mut self, feature_id: u32) {
+        self.locked |= Self::mask(feature_id);
+    }
+}
 
 /// Firmware Features extension backed by `medeleg` and `menvcfg`.
 ///
@@ -24,6 +57,14 @@ const ENVCFG_PMM: usize = 0b11 << ENVCFG_PMM_SHIFT;
 pub(crate) struct SbiFwft;
 
 impl SbiFwft {
+    pub(crate) fn reset_current() {
+        let Some(current) = Self::menvcfg_read() else {
+            return;
+        };
+        let controlled = ENVCFG_LPE | ENVCFG_SSE | ENVCFG_PMM | ENVCFG_DTE | ENVCFG_ADUE;
+        let _ = Self::menvcfg_write(current & !controlled);
+    }
+
     fn has_s_mode() -> bool {
         riscv::register::misa::read().has_extension('S')
     }
@@ -72,9 +113,6 @@ impl SbiFwft {
     }
 
     fn set_menvcfg_bit(bit: usize, value: usize) -> SbiRet {
-        if value > 1 {
-            return SbiRet::invalid_param();
-        }
         let Some(current) = Self::menvcfg_read() else {
             return SbiRet::not_supported();
         };
@@ -97,13 +135,16 @@ impl SbiFwft {
     }
 
     fn set_pmm(value: usize) -> SbiRet {
-        if value > 3 {
-            return SbiRet::invalid_param();
-        }
+        let encoding = match value {
+            0 => 0,
+            7 => 0b10,
+            16 => 0b11,
+            _ => return SbiRet::invalid_param(),
+        };
         let Some(current) = Self::menvcfg_read() else {
             return SbiRet::not_supported();
         };
-        let next = (current & !ENVCFG_PMM) | (value << ENVCFG_PMM_SHIFT);
+        let next = (current & !ENVCFG_PMM) | (encoding << ENVCFG_PMM_SHIFT);
         if !Self::menvcfg_write(next) {
             return SbiRet::not_supported();
         }
@@ -117,79 +158,150 @@ impl SbiFwft {
         SbiRet::success(0)
     }
 
-    // Probe whether WARL fields retain set bits, then attempt to restore
-    // the original value.
-    fn menvcfg_bits_supported(mask: usize) -> bool {
+    fn probe_menvcfg_bits(mask: usize) -> bool {
         let Some(current) = Self::menvcfg_read() else {
             return false;
         };
-        if !Self::menvcfg_write(current | mask) {
+        let test_bits = if current & mask == 0 { mask } else { 0 };
+        let test_value = (current & !mask) | test_bits;
+        if !Self::menvcfg_write(test_value) {
             return false;
         }
         let Some(probed) = Self::menvcfg_read() else {
             let _ = Self::menvcfg_write(current);
             return false;
         };
-        let _ = Self::menvcfg_write(current);
-        (probed & mask) != 0
+        if !Self::menvcfg_write(current) {
+            return false;
+        }
+        let Some(restored) = Self::menvcfg_read() else {
+            return false;
+        };
+        probed & mask == test_bits && restored & mask == current & mask
+    }
+
+    fn feature_supported(state: &mut FwftState, feature_id: u32, mask: usize) -> bool {
+        let feature_mask = FwftState::mask(feature_id);
+        if state.probed & feature_mask == 0 {
+            state.probed |= feature_mask;
+            if Self::probe_menvcfg_bits(mask) {
+                state.supported |= feature_mask;
+            }
+        }
+        state.supported & feature_mask != 0
+    }
+
+    fn read_feature(state: &mut FwftState, feature_id: u32) -> Result<usize, SbiRet> {
+        if feature_id > LAST_STANDARD_FEATURE {
+            return Err(SbiRet::denied());
+        }
+
+        match feature_id as usize {
+            feature_type::MISALIGNED_EXC_DELEG => {
+                if !Self::has_s_mode() {
+                    return Err(SbiRet::not_supported());
+                }
+                Ok(Self::misaligned_delegated() as usize)
+            }
+            feature_type::POINTER_MASKING_PMLEN => {
+                if !Self::feature_supported(state, feature_id, ENVCFG_PMM) {
+                    return Err(SbiRet::not_supported());
+                }
+                let value = Self::menvcfg_read().ok_or_else(SbiRet::not_supported)?;
+                match (value & ENVCFG_PMM) >> ENVCFG_PMM_SHIFT {
+                    0 => Ok(0),
+                    0b10 => Ok(7),
+                    0b11 => Ok(16),
+                    _ => Err(SbiRet::failed()),
+                }
+            }
+            _ => {
+                let bit =
+                    Self::menvcfg_bit(feature_id as usize).ok_or_else(SbiRet::not_supported)?;
+                if !Self::feature_supported(state, feature_id, bit) {
+                    return Err(SbiRet::not_supported());
+                }
+                let value = Self::menvcfg_read().ok_or_else(SbiRet::not_supported)?;
+                Ok(((value & bit) != 0) as usize)
+            }
+        }
+    }
+
+    fn valid_value(feature_id: u32, value: usize) -> bool {
+        match feature_id as usize {
+            feature_type::MISALIGNED_EXC_DELEG
+            | feature_type::LANDING_PAD
+            | feature_type::SHADOW_STACK
+            | feature_type::DOUBLE_TRAP
+            | feature_type::PTE_AD_HW_UPDATING => value <= 1,
+            feature_type::POINTER_MASKING_PMLEN => matches!(value, 0 | 7 | 16),
+            _ => true,
+        }
     }
 }
 
 impl rustsbi::Fwft for SbiFwft {
     fn set(&self, feature_id: u32, value: usize, flags: usize) -> SbiRet {
-        // The LOCK flag is not supported: locked features can never be
-        // modified again, which would prevent firmware reconfiguration.
-        if flags != 0 {
+        if flags & !FWFT_LOCK != 0 {
             return SbiRet::invalid_param();
         }
-        match feature_id as usize {
-            feature_type::MISALIGNED_EXC_DELEG => {
-                if !Self::has_s_mode() {
-                    return SbiRet::not_supported();
-                }
-                if Self::set_misaligned_delegation(value) {
-                    SbiRet::success(0)
-                } else {
-                    SbiRet::invalid_param()
-                }
-            }
-            feature_type::POINTER_MASKING_PMLEN => Self::set_pmm(value),
-            _ => match Self::menvcfg_bit(feature_id as usize) {
-                Some(bit) => Self::set_menvcfg_bit(bit, value),
-                None => SbiRet::not_supported(),
-            },
+        if feature_id > LAST_STANDARD_FEATURE {
+            return SbiRet::denied();
         }
+        if !Self::valid_value(feature_id, value) {
+            return SbiRet::invalid_param();
+        }
+
+        with_current(|local| {
+            let state = &mut local.fwft_state;
+            let current = match Self::read_feature(state, feature_id) {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+
+            // SBI v3.0 requires an idempotent set to succeed even after the
+            // feature has been locked.
+            if current == value {
+                if flags & FWFT_LOCK != 0 {
+                    state.lock(feature_id);
+                }
+                return SbiRet::success(0);
+            }
+
+            if state.is_locked(feature_id) {
+                return SbiRet::denied_locked();
+            }
+
+            let ret = match feature_id as usize {
+                feature_type::MISALIGNED_EXC_DELEG => {
+                    if Self::set_misaligned_delegation(value) {
+                        SbiRet::success(0)
+                    } else {
+                        SbiRet::invalid_param()
+                    }
+                }
+                feature_type::POINTER_MASKING_PMLEN => Self::set_pmm(value),
+                _ => match Self::menvcfg_bit(feature_id as usize) {
+                    Some(bit) => Self::set_menvcfg_bit(bit, value),
+                    None => SbiRet::not_supported(),
+                },
+            };
+            if ret.is_ok() && flags & FWFT_LOCK != 0 {
+                state.lock(feature_id);
+            }
+            ret
+        })
     }
 
     fn get(&self, feature_id: u32) -> SbiRet {
-        match feature_id as usize {
-            feature_type::MISALIGNED_EXC_DELEG => {
-                if !Self::has_s_mode() {
-                    return SbiRet::not_supported();
-                }
-                SbiRet::success(Self::misaligned_delegated() as usize)
-            }
-            feature_type::POINTER_MASKING_PMLEN => {
-                if !Self::menvcfg_bits_supported(ENVCFG_PMM) {
-                    return SbiRet::not_supported();
-                }
-                match Self::menvcfg_read() {
-                    Some(value) => SbiRet::success((value & ENVCFG_PMM) >> ENVCFG_PMM_SHIFT),
-                    None => SbiRet::not_supported(),
-                }
-            }
-            _ => match Self::menvcfg_bit(feature_id as usize) {
-                Some(bit) => {
-                    if !Self::menvcfg_bits_supported(bit) {
-                        return SbiRet::not_supported();
-                    }
-                    match Self::menvcfg_read() {
-                        Some(value) => SbiRet::success(((value & bit) != 0) as usize),
-                        None => SbiRet::not_supported(),
-                    }
-                }
-                None => SbiRet::not_supported(),
-            },
+        if feature_id > LAST_STANDARD_FEATURE {
+            return SbiRet::denied();
         }
+        with_current(
+            |local| match Self::read_feature(&mut local.fwft_state, feature_id) {
+                Ok(value) => SbiRet::success(value),
+                Err(error) => error,
+            },
+        )
     }
 }

--- a/firmware/prototyper/src/sbi/hart_context.rs
+++ b/firmware/prototyper/src/sbi/hart_context.rs
@@ -6,6 +6,7 @@ use core::sync::atomic::Ordering;
 use fast_trap::FlowContext;
 use riscv::register::mstatus;
 
+use super::fwft::FwftState;
 use super::pmu::PmuState;
 use super::trap_stack::{HsmCell, RFenceCell};
 
@@ -54,6 +55,8 @@ pub struct HartLocal {
     pub features: HartFeatures,
     /// PMU State
     pub pmu_state: PmuState,
+    /// Per-hart FWFT lock and feature-probe state.
+    pub(crate) fwft_state: FwftState,
 }
 
 // HartContext sits at the bottom of each HartStack slot, so the slot size
@@ -75,6 +78,7 @@ impl HartLocal {
         self.hsm = HsmCell::new();
         self.rfence = RFenceCell::new();
         self.pmu_state = PmuState::new();
+        self.fwft_state = FwftState::new();
     }
 
     #[inline]
@@ -82,6 +86,7 @@ impl HartLocal {
         self.ipi_reset();
         self.rfence_reset();
         self.pmu_state_reset();
+        self.fwft_state = FwftState::new();
     }
 
     #[inline]

--- a/firmware/prototyper/src/sbi/hart_context.rs
+++ b/firmware/prototyper/src/sbi/hart_context.rs
@@ -86,7 +86,7 @@ impl HartLocal {
         self.ipi_reset();
         self.rfence_reset();
         self.pmu_state_reset();
-        self.fwft_state = FwftState::new();
+        self.fwft_state.reset();
     }
 
     #[inline]

--- a/firmware/prototyper/src/sbi/trap_stack.rs
+++ b/firmware/prototyper/src/sbi/trap_stack.rs
@@ -85,12 +85,13 @@ pub(crate) fn prepare_for_trap() {
     // SAFETY: the current hart id always indexes `ROOT_STACK`.
     let slot: &'static HartStack = unsafe { ROOT_STACK.get_unchecked(current_hartid()) };
     HartStack::load_as_stack(slot);
+    super::fwft::SbiFwft::reset_current();
 }
 
 /// Runs `f` with exclusive access to the current hart's hart-local state.
 ///
 /// SAFETY (mechanism contract): each slot is owned by exactly one hart, so
-/// borrowing that hart's `HartLocal` is exclusive while `f` runs — M-mode
+/// borrowing that hart's `HartLocal` is exclusive while `f` runs; M-mode
 /// trap entry clears MIE and trap/interrupt handlers never call this, so
 /// no second borrow can go live. The [`TrapFrame`] part of the slot is
 /// unreachable through the given reference.
@@ -419,7 +420,7 @@ pub fn remote_rfence(hart_id: usize) -> Option<RemoteRFenceCell<'static>> {
 /// `hart_id`; the trap frame is untouched, as in the pre-split reset.
 ///
 /// SAFETY: the target hart is being resumed via the HSM path, and this
-/// reset runs before that hart next touches its `HartLocal` — its wake
+/// reset runs before that hart next touches its `HartLocal`; its wake
 /// path is `boot()`, which does not.
 pub fn reset_hart(hart_id: usize) {
     with_hart(hart_id, HartLocal::reset);


### PR DESCRIPTION
Track FWFT probe and lock state per hart, validate standard feature values, and preserve idempotent set behavior after locking. Restore controlled menvcfg fields when a hart context is reset.

Also correct the standard FWFT feature ID and value bit assignments required by the SBI 3.0 specification.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
