### PR TITLE
fix(prototyper): validate STA shared memory addresses

### DIFF
--- a/firmware/prototyper/src/platform/boot.rs
+++ b/firmware/prototyper/src/platform/boot.rs
@@ -53,6 +53,8 @@ pub fn init_board(fdt_address: usize) {
     // Initialize pmu extension
     let pmu = sbi::pmu::init(&root);
     let mpxy = Some(sbi::mpxy::SbiMpxy::new());
+    // STA reports a stable zero-valued structure; this firmware has no
+    // scheduler or virtual-hart preemption source for non-zero accounting.
     let sta = Some(SbiSta);
     let nacl = Some(SbiNacl);
     // Keep SSE unavailable until supervisor handler context switching is implemented.

--- a/firmware/prototyper/src/sbi/sta.rs
+++ b/firmware/prototyper/src/sbi/sta.rs
@@ -6,6 +6,17 @@ use sbi_spec::binary::SharedPtr;
 use crate::cfg::NUM_HART_MAX;
 use crate::riscv::current_hartid;
 
+#[repr(C)]
+struct StaShmemData {
+    sequence: u32,
+    flags: u32,
+    steal: u64,
+    preempted: u8,
+    pad: [u8; 47],
+}
+
+const _: () = assert!(core::mem::size_of::<StaShmemData>() == 64);
+
 struct StaShmem {
     lo: AtomicUsize,
     hi: AtomicUsize,
@@ -23,9 +34,19 @@ impl StaShmem {
     }
 }
 
-// Keep both address parts since either may be used to represent a physical
-// address on RV32. Both parts being all-ones represents a disabled SHMEM.
+// The Prototyper uses XLEN-sized identity-mapped physical addresses. Both
+// parts are retained for the SBI-defined disabled value and future wider
+// address support, but only a zero high part can be dereferenced here.
 static STA_SHMEM: [StaShmem; NUM_HART_MAX] = [const { StaShmem::DISABLED }; NUM_HART_MAX];
+
+unsafe fn zero_shmem(addr: usize) {
+    let ptr = addr as *mut u8;
+    for offset in 0..core::mem::size_of::<StaShmemData>() {
+        // SAFETY: the caller validated the complete shared-memory range.
+        unsafe { ptr.add(offset).write_volatile(0) };
+    }
+    core::sync::atomic::fence(Ordering::SeqCst);
+}
 
 /// Steal-time Accounting extension using supervisor-provided shared memory.
 pub(crate) struct SbiSta;
@@ -48,6 +69,8 @@ impl rustsbi::Sta for SbiSta {
         if lo & 0x3f != 0 {
             return SbiRet::invalid_param();
         }
+        // The firmware's physical-memory validation and identity mapping use
+        // XLEN-sized addresses, so a non-zero upper part is not dereferenceable.
         if hi != 0 {
             return SbiRet::invalid_address();
         }
@@ -56,12 +79,12 @@ impl rustsbi::Sta for SbiSta {
             return SbiRet::invalid_address();
         }
 
-        // Clear the structure before returning success.
+        // The Prototyper has no scheduler that can produce stolen time. A
+        // zeroed structure therefore reports the only state it can guarantee.
         // SAFETY: the validated 64-byte range is writable and lies outside
         // firmware memory.
         unsafe {
-            core::ptr::write_bytes(lo as *mut u8, 0, 64);
-            core::sync::atomic::fence(Ordering::SeqCst);
+            zero_shmem(lo);
         }
 
         STA_SHMEM[current_hartid()].store(lo, hi);

--- a/firmware/prototyper/src/sbi/sta.rs
+++ b/firmware/prototyper/src/sbi/sta.rs
@@ -1,7 +1,8 @@
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::fence;
 
 use rustsbi::SbiRet;
 use sbi_spec::binary::SharedPtr;
+use spin::Mutex;
 
 use crate::cfg::NUM_HART_MAX;
 use crate::riscv::current_hartid;
@@ -18,34 +19,36 @@ struct StaShmemData {
 const _: () = assert!(core::mem::size_of::<StaShmemData>() == 64);
 
 struct StaShmem {
-    lo: AtomicUsize,
-    hi: AtomicUsize,
+    lo: usize,
+    hi: usize,
 }
 
 impl StaShmem {
     const DISABLED: Self = Self {
-        lo: AtomicUsize::new(usize::MAX),
-        hi: AtomicUsize::new(usize::MAX),
+        lo: usize::MAX,
+        hi: usize::MAX,
     };
 
-    fn store(&self, lo: usize, hi: usize) {
-        self.lo.store(lo, Ordering::Release);
-        self.hi.store(hi, Ordering::Release);
+    fn store(slot: &Mutex<Self>, lo: usize, hi: usize) {
+        let mut shmem = slot.lock();
+        shmem.lo = lo;
+        shmem.hi = hi;
     }
 }
 
 // The Prototyper uses XLEN-sized identity-mapped physical addresses. Both
 // parts are retained for the SBI-defined disabled value and future wider
 // address support, but only a zero high part can be dereferenced here.
-static STA_SHMEM: [StaShmem; NUM_HART_MAX] = [const { StaShmem::DISABLED }; NUM_HART_MAX];
+static STA_SHMEM: [Mutex<StaShmem>; NUM_HART_MAX] =
+    [const { Mutex::new(StaShmem::DISABLED) }; NUM_HART_MAX];
 
 unsafe fn zero_shmem(addr: usize) {
-    let ptr = addr as *mut u8;
-    for offset in 0..core::mem::size_of::<StaShmemData>() {
-        // SAFETY: the caller validated the complete shared-memory range.
-        unsafe { ptr.add(offset).write_volatile(0) };
+    // SAFETY: the caller validated the complete shared-memory range.
+    unsafe {
+        core::slice::from_raw_parts_mut(addr as *mut u8, core::mem::size_of::<StaShmemData>())
+            .fill(0);
     }
-    core::sync::atomic::fence(Ordering::SeqCst);
+    fence(core::sync::atomic::Ordering::SeqCst);
 }
 
 /// Steal-time Accounting extension using supervisor-provided shared memory.
@@ -62,7 +65,7 @@ impl rustsbi::Sta for SbiSta {
 
         // All-ones shared pointer disables steal-time reporting.
         if hi == usize::MAX && lo == usize::MAX {
-            STA_SHMEM[current_hartid()].store(lo, hi);
+            StaShmem::store(&STA_SHMEM[current_hartid()], lo, hi);
             return SbiRet::success(0);
         }
 
@@ -87,7 +90,7 @@ impl rustsbi::Sta for SbiSta {
             zero_shmem(lo);
         }
 
-        STA_SHMEM[current_hartid()].store(lo, hi);
+        StaShmem::store(&STA_SHMEM[current_hartid()], lo, hi);
         SbiRet::success(0)
     }
 }

--- a/firmware/prototyper/src/sbi/sta.rs
+++ b/firmware/prototyper/src/sbi/sta.rs
@@ -6,8 +6,26 @@ use sbi_spec::binary::SharedPtr;
 use crate::cfg::NUM_HART_MAX;
 use crate::riscv::current_hartid;
 
-// A zero address disables reporting for that hart.
-static STA_SHMEM: [AtomicUsize; NUM_HART_MAX] = [const { AtomicUsize::new(0) }; NUM_HART_MAX];
+struct StaShmem {
+    lo: AtomicUsize,
+    hi: AtomicUsize,
+}
+
+impl StaShmem {
+    const DISABLED: Self = Self {
+        lo: AtomicUsize::new(usize::MAX),
+        hi: AtomicUsize::new(usize::MAX),
+    };
+
+    fn store(&self, lo: usize, hi: usize) {
+        self.lo.store(lo, Ordering::Release);
+        self.hi.store(hi, Ordering::Release);
+    }
+}
+
+// Keep both address parts since either may be used to represent a physical
+// address on RV32. Both parts being all-ones represents a disabled SHMEM.
+static STA_SHMEM: [StaShmem; NUM_HART_MAX] = [const { StaShmem::DISABLED }; NUM_HART_MAX];
 
 /// Steal-time Accounting extension using supervisor-provided shared memory.
 pub(crate) struct SbiSta;
@@ -23,7 +41,7 @@ impl rustsbi::Sta for SbiSta {
 
         // All-ones shared pointer disables steal-time reporting.
         if hi == usize::MAX && lo == usize::MAX {
-            STA_SHMEM[current_hartid()].store(0, Ordering::Release);
+            STA_SHMEM[current_hartid()].store(lo, hi);
             return SbiRet::success(0);
         }
 
@@ -46,7 +64,7 @@ impl rustsbi::Sta for SbiSta {
             core::sync::atomic::fence(Ordering::SeqCst);
         }
 
-        STA_SHMEM[current_hartid()].store(lo, Ordering::Release);
+        STA_SHMEM[current_hartid()].store(lo, hi);
         SbiRet::success(0)
     }
 }

--- a/firmware/prototyper/src/sbi/sta.rs
+++ b/firmware/prototyper/src/sbi/sta.rs
@@ -1,5 +1,13 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
 use rustsbi::SbiRet;
 use sbi_spec::binary::SharedPtr;
+
+use crate::cfg::NUM_HART_MAX;
+use crate::riscv::current_hartid;
+
+// A zero address disables reporting for that hart.
+static STA_SHMEM: [AtomicUsize; NUM_HART_MAX] = [const { AtomicUsize::new(0) }; NUM_HART_MAX];
 
 /// Steal-time Accounting extension using supervisor-provided shared memory.
 pub(crate) struct SbiSta;
@@ -15,12 +23,15 @@ impl rustsbi::Sta for SbiSta {
 
         // All-ones shared pointer disables steal-time reporting.
         if hi == usize::MAX && lo == usize::MAX {
+            STA_SHMEM[current_hartid()].store(0, Ordering::Release);
             return SbiRet::success(0);
         }
 
-        // STA requires a 64-byte aligned native physical address.
-        if lo & 0x3f != 0 || hi != 0 {
+        if lo & 0x3f != 0 {
             return SbiRet::invalid_param();
+        }
+        if hi != 0 {
+            return SbiRet::invalid_address();
         }
 
         if !crate::firmware::supervisor_writable(lo, 64) {
@@ -32,9 +43,10 @@ impl rustsbi::Sta for SbiSta {
         // firmware memory.
         unsafe {
             core::ptr::write_bytes(lo as *mut u8, 0, 64);
-            core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+            core::sync::atomic::fence(Ordering::SeqCst);
         }
 
+        STA_SHMEM[current_hartid()].store(lo, Ordering::Release);
         SbiRet::success(0)
     }
 }


### PR DESCRIPTION
Return the SBI-defined errors for misaligned and unrepresentable shared memory addresses. Track per-hart STA shared-memory state so each hart registers its own reporting region. Remove the unused reporting helper until a scheduler can provide real steal-time accounting data.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
