### PR TITLE
feat(prototyper): add K3 RPMI-backed SBI services

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,4 +8,4 @@ prototyper = "xtask prototyper"
 AX_CONFIG_PATH = { value = "arceboot/.axconfig.toml", relative = true }
 
 [target.riscv64gc-unknown-none-elf]
-rustflags = ["-Zcrate-attr=feature(core_io)", "-Aunused-features"]
+rustflags = ["-Zcrate-attr=feature(core_io)", "-Aunused-features", "-C", "target-feature=+zicbom"]

--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -17,6 +17,15 @@ All notable changes to this project will be documented in this file. See [conven
   unavailable until supervisor context switching is implemented.
 - Add AIA IMSIC IPI backend support for RustSBI Prototyper.
 - Add SpacemiT K1 SoC platform support for RustSBI Prototyper, including OrangePi RV2 board configuration.
+- Add SpacemiT K3 board configuration, warm entry, cache coherency,
+  power-domain control, and protected RCPU runtime regions.
+- Add K3 access-fault emulation, hart wake-up, system suspend, and IMSIC state
+  preservation hooks.
+- Add the shared-memory RPMI mailbox transport used by K3 platform services.
+- Provide RPMI-backed CPPC and MPXY services when the platform mailbox is
+  present. MPXY exposes only service groups without a dedicated SBI extension.
+- Support FWFT feature locking and the SBI v3.0 `menvcfg` field layout and
+  pointer-masking values.
 
 ### Modified
 - refactor(prototyper): unify build commands (#227)

--- a/firmware/prototyper/Cargo.toml
+++ b/firmware/prototyper/Cargo.toml
@@ -18,6 +18,7 @@ buddy_system_allocator = "0.11.0"
 rustsbi = { version = "0.4.1", features = [
     "machine",
 ], path = "../../library/rustsbi" }
+rpmi = { version = "0.0.0", path = "../../library/rpmi" }
 sbi-spec = { version = "0.0.10", features = [
     "legacy",
 ], path = "../../library/sbi-spec" }

--- a/firmware/prototyper/config/k3.toml
+++ b/firmware/prototyper/config/k3.toml
@@ -1,0 +1,16 @@
+﻿# SpacemiT K3 board configuration (K3 Pico-ITX, CoM260, CoM260 IFX,
+# DeepComputing FML13V05).
+# 16 GB LPDDR5 at 0x100000000; 8 x SpacemiT X100 cores.
+num_hart_max = 16
+stack_size_per_hart = 16384 # 16 * 1024
+heap_size = 0x100000 # 1024 * 1024
+page_size = 4096
+log_level = "INFO"
+link_start_address = 0x100000000 # Firmware load address at the DRAM base
+payload_address = 0x100200000 # RAM base + 2 MiB
+jump_address = 0x100200000 # Next stage, 2 MiB above the DRAM base
+tlb_flush_limit = 16384 # page_size * 4
+
+[[next_addr]]
+start = 0x100000000
+end = 0x500000000

--- a/firmware/prototyper/src/entry/start.S
+++ b/firmware/prototyper/src/entry/start.S
@@ -1,14 +1,19 @@
-// Machine-mode startup ceremony: from the architectural reset vector to
-// safe Rust policy. The `#[entry]` attribute macro wraps this file into the
-// `_start` entry point; steps are marked inline.
+// Machine-mode startup from the reset vector to the Rust entry point.
 //
 // The 6:/7: signal words are read before BSS is cleared, so they must live
 // in .text.entry (loaded content), not in BSS.
+//
+// The cold path must remain first because the FIT entry point is the image
+// base. K3 cluster RVBADDR registers target `_start_warm_k3` separately.
 
 .option arch, +a
 
 // 1. Mask all interrupts.
 csrw    mie, zero
+
+// Flush TLB and I-cache before a PMU-woken hart executes the warm path.
+        sfence.vma
+        fence.i
 
 // 2. Elect a single boot hart: the first hart to arrive wins the race
 // (amoadd returns the previous value; nonzero means another hart won).
@@ -52,3 +57,57 @@ csrw    mie, zero
   .word    0
 7: // bss ready signal word.
   .word    0
+
+// PMU-woken harts fetch this entry from their cluster RVBADDR. Data cache and
+// snoop must be enabled before AMOs or Rust code execute. BSS and boot-hart
+// election are already complete.
+    .balign  4
+    .globl _start_warm_k3
+_start_warm_k3:
+    // Mask all interrupts.
+    csrw    mie, zero
+
+    // Configure the audio window as cacheable.
+    li      t0, 0xff
+    slli    t0, t0, 48
+    csrc    0x7de, t0
+    li      t0, 0x20
+    slli    t0, t0, 48
+    csrs    0x7de, t0
+    sfence.vma
+
+    // Configure the XIP window as device memory.
+    lui     t0, 0xff0
+    csrc    0x7de, t0
+    lui     t0, 0x220
+    csrs    0x7de, t0
+    sfence.vma
+
+    // Enable core snoop for this hart.
+    csrw    0x7f0, zero
+    csrr    t0, mhartid
+    andi    t1, t0, 3
+    li      a5, 1
+    sllw    a5, a5, t1
+    csrs    0x7f0, a5
+
+    // Enable instruction and data caches before executing AMOs.
+    li      a5, 0x10073
+    csrs    0x7c0, a5
+    fence   iorw, iorw
+
+    // Only X100 harts implement the hypervisor extension.
+    csrr    t0, mhartid
+    li      t1, 8
+    bgeu    t0, t1, 20f
+    csrr    t2, misa
+    li      t3, 1
+    slli    t3, t3, 7      // 'H' - 'A'
+    or      t2, t2, t3
+    csrw    misa, t2
+20:
+    // PMU wakeup does not preserve the boot envelope; zero it before joining
+    // the common stack and Rust entry path.
+    li      a1, 0
+    li      a2, 0
+    j       5b

--- a/firmware/prototyper/src/firmware/domain.rs
+++ b/firmware/prototyper/src/firmware/domain.rs
@@ -1,0 +1,109 @@
+//! PMP regions used to isolate platform memory.
+
+use riscv::register::{Permission, Range, pmpcfg0, pmpcfg2};
+use riscv::register::{
+    pmpaddr0, pmpaddr1, pmpaddr2, pmpaddr3, pmpaddr4, pmpaddr5, pmpaddr6, pmpaddr7, pmpaddr8,
+    pmpaddr9, pmpaddr10, pmpaddr11, pmpaddr12, pmpaddr13, pmpaddr14, pmpaddr15,
+};
+
+/// Deny all R/W/X access in all modes and lock the PMP entry.
+pub const ENF_PERMISSIONS: u32 = 1 << 0;
+
+/// M-mode R/W/X, S/U denied; the PMP entry is not locked (M-mode access is
+/// what allows M-mode to emulate S-mode accesses, e.g. the K3
+/// REGISTER_PRESERVATION window).
+pub const M_RWX: u32 = 1 << 1;
+
+pub struct DomainRegion {
+    base: usize,
+    size: usize,
+    flags: u32,
+}
+
+impl DomainRegion {
+    pub const fn new(base: usize, size: usize, flags: u32) -> Self {
+        Self { base, size, flags }
+    }
+
+    fn end(&self) -> Option<usize> {
+        self.base.checked_add(self.size)
+    }
+}
+
+/// Programs a run of protected windows inside `[region_start, region_end)`
+/// into PMP TOR entries beginning at `first_slot`.
+///
+/// Windows must be nonempty, ordered, nonoverlapping, and contained in the
+/// supplied physical range.
+pub fn program_windows(
+    first_slot: usize,
+    region_start: usize,
+    region_end: usize,
+    windows: &[DomainRegion],
+) -> Option<usize> {
+    let entries = windows.len().checked_mul(2)?.checked_add(1)?;
+    if first_slot.checked_add(entries)? > 16 || region_start > region_end {
+        return None;
+    }
+    let mut cursor = region_start;
+    for window in windows {
+        let end = window.end()?;
+        if window.size == 0 || window.base < cursor || end > region_end {
+            return None;
+        }
+        cursor = end;
+    }
+
+    let mut slot = first_slot;
+    for w in windows {
+        write_entry(slot, Permission::RWX, false, w.base);
+        slot += 1;
+        let locked = w.flags & ENF_PERMISSIONS != 0;
+        write_entry(slot, Permission::NONE, locked, w.end()?);
+        slot += 1;
+    }
+    write_entry(slot, Permission::RWX, false, region_end);
+    Some(slot + 1)
+}
+
+/// Writes a single PMP TOR entry at `slot` (0..=15).
+///
+/// # Panics
+///
+/// Panics if `slot >= 16`.
+pub fn write_entry(slot: usize, perm: Permission, locked: bool, addr: usize) {
+    assert!(slot < 16, "PMP slot {slot} out of range");
+    let idx = slot & 7;
+    // SAFETY: PMP CSR accesses are volatile register writes; `slot` is
+    // bounds-checked above and the addresses are validated by callers.
+    unsafe {
+        match slot {
+            0..=7 => pmpcfg0::set_pmp(idx, Range::TOR, perm, locked),
+            8..=15 => pmpcfg2::set_pmp(idx, Range::TOR, perm, locked),
+            _ => unreachable!(),
+        }
+    }
+    let addr = addr >> 2;
+    // SAFETY: the slot is bounds-checked and the address is caller-validated.
+    unsafe {
+        match slot {
+            0 => pmpaddr0::write(addr),
+            1 => pmpaddr1::write(addr),
+            2 => pmpaddr2::write(addr),
+            3 => pmpaddr3::write(addr),
+            4 => pmpaddr4::write(addr),
+            5 => pmpaddr5::write(addr),
+            6 => pmpaddr6::write(addr),
+            7 => pmpaddr7::write(addr),
+            8 => pmpaddr8::write(addr),
+            9 => pmpaddr9::write(addr),
+            10 => pmpaddr10::write(addr),
+            11 => pmpaddr11::write(addr),
+            12 => pmpaddr12::write(addr),
+            13 => pmpaddr13::write(addr),
+            14 => pmpaddr14::write(addr),
+            15 => pmpaddr15::write(addr),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/firmware/prototyper/src/firmware/mod.rs
+++ b/firmware/prototyper/src/firmware/mod.rs
@@ -17,6 +17,8 @@ use riscv::register::{self, Permission};
 
 use crate::riscv::current_hartid;
 
+pub mod domain;
+
 /// Decides whether this hart leads the boot (designated in `DynamicInfo`,
 /// or raced when absent).
 fn is_work_hart(_dynamic_info_addr: usize) -> bool {
@@ -56,7 +58,7 @@ fn is_work_hart(_dynamic_info_addr: usize) -> bool {
     }
 }
 
-use alloc::{format, vec};
+use alloc::format;
 use core::arch::asm;
 use core::ops::Range;
 
@@ -221,19 +223,22 @@ pub fn patch_device_tree(device_tree_ptr: usize) -> usize {
 
     let patched_length = serde_device_tree::ser::probe_dtb_length(&tree, &list).unwrap();
 
-    // We need aligned address here, so we use create u64 vec.
-    let patched_dtb_buffer = vec![0u64; patched_length.div_ceil(8)];
-    // Intentionally leak the buffer so that the patched DTB remains valid for the lifetime of the firmware.
-    // This is required because the returned pointer is used elsewhere and must not be deallocated.
-    let patched_dtb_buffer = patched_dtb_buffer.leak();
-    let mut patched_dtb_buffer_u8: &'static mut [u8] = unsafe {
-        core::slice::from_raw_parts_mut(patched_dtb_buffer.as_ptr() as *mut u8, patched_length)
+    // We need aligned address here. Place the patched DTB in the writable
+    // memory right after the SBI image instead of in the heap: the heap
+    // lives inside the SBI image, which the PMP marks read-only for
+    // S-mode, and U-Boot writes/relocates the DTB during early boot
+    // (FDT fixup). On K3 the gap [sbi_end, RCPU0) is writable in the PMP
+    // layout, so keep the mutable copy there.
+    let dtb_buf_addr = (sbi_end + 0xfff) & !0xfff;
+    let patched_dtb_buffer: &'static mut [u64] = unsafe {
+        core::slice::from_raw_parts_mut(dtb_buf_addr as *mut u64, patched_length.div_ceil(8))
     };
+    let mut patched_dtb_buffer_u8: &'static mut [u8] =
+        unsafe { core::slice::from_raw_parts_mut(dtb_buf_addr as *mut u8, patched_length) };
     serde_device_tree::ser::to_dtb(&tree, &list, &mut patched_dtb_buffer_u8).unwrap();
 
-    // When AIA is active, NOP out M-level IMSIC and APLIC nodes in the
-    // DTB so Linux does not try to probe them. This matches OpenSBI's
-    // fdt_domain_based_fixup approach.
+    // Hide M-level IMSIC and APLIC nodes from supervisor software when AIA is
+    // active.
     if crate::platform::aia::is_aia_active() {
         let dtb_buf = unsafe {
             core::slice::from_raw_parts_mut(patched_dtb_buffer.as_ptr() as *mut u8, patched_length)
@@ -540,7 +545,32 @@ pub(crate) fn supervisor_writable(start: usize, len: usize) -> bool {
         return false;
     }
 
-    end <= sbi_start || start >= sbi_end
+    if start < sbi_end && end > sbi_start {
+        return false;
+    }
+
+    if crate::platform::IS_K3_PLATFORM.load(core::sync::atomic::Ordering::Acquire) {
+        use crate::riscv::spacemit_k3::{
+            RCPU_DTB_SPACE_BASE_ADDR, RCPU_DTB_SPACE_SIZE, RCPU0_RUNTIME_SPACE_BASE_ADDR,
+            RCPU0_RUNTIME_SPACE_SIZE, RCPU1_RUNTIME_SPACE_BASE_ADDR, RCPU1_RUNTIME_SPACE_SIZE,
+            REGISTER_PRESERVATION_BASE, REGISTER_PRESERVATION_SIZE,
+        };
+        for (protected_start, protected_size) in [
+            (RCPU0_RUNTIME_SPACE_BASE_ADDR, RCPU0_RUNTIME_SPACE_SIZE),
+            (RCPU1_RUNTIME_SPACE_BASE_ADDR, RCPU1_RUNTIME_SPACE_SIZE),
+            (RCPU_DTB_SPACE_BASE_ADDR, RCPU_DTB_SPACE_SIZE),
+            (REGISTER_PRESERVATION_BASE, REGISTER_PRESERVATION_SIZE),
+        ] {
+            let Some(protected_end) = protected_start.checked_add(protected_size) else {
+                return false;
+            };
+            if start < protected_end && end > protected_start {
+                return false;
+            }
+        }
+    }
+
+    true
 }
 
 pub fn set_pmp(memory_range: &Range<usize>) {
@@ -566,9 +596,106 @@ pub fn set_pmp(memory_range: &Range<usize>) {
         assert_eq!(RODATA_START_ADDRESS & 0x3, 0);
         assert_eq!(RODATA_END_ADDRESS & 0x3, 0);
 
+        // Deny S-mode access to the K3 RCPU runtime and DTB windows, and keep
+        // REGISTER_PRESERVATION M-mode-only for access-fault emulation. PMP
+        // entries match lowest index first, so protected windows must appear
+        // before a broader writable entry.
+        if crate::platform::IS_K3_PLATFORM.load(core::sync::atomic::Ordering::Acquire) {
+            use crate::riscv::spacemit_k3::{
+                RCPU_DTB_SPACE_BASE_ADDR, RCPU_DTB_SPACE_SIZE, RCPU0_RUNTIME_SPACE_BASE_ADDR,
+                RCPU0_RUNTIME_SPACE_SIZE, RCPU1_RUNTIME_SPACE_BASE_ADDR, RCPU1_RUNTIME_SPACE_SIZE,
+                REGISTER_PRESERVATION_SIZE,
+            };
+
+            let rcpu0_start = RCPU0_RUNTIME_SPACE_BASE_ADDR;
+            let rcpu0_end = RCPU0_RUNTIME_SPACE_BASE_ADDR + RCPU0_RUNTIME_SPACE_SIZE;
+            let rcpu1_start = RCPU1_RUNTIME_SPACE_BASE_ADDR;
+            let rcpu1_end = RCPU1_RUNTIME_SPACE_BASE_ADDR + RCPU1_RUNTIME_SPACE_SIZE;
+            let dtb_start = RCPU_DTB_SPACE_BASE_ADDR;
+            let dtb_end = RCPU_DTB_SPACE_BASE_ADDR + RCPU_DTB_SPACE_SIZE;
+            let reg_pres_start = crate::riscv::spacemit_k3::REGISTER_PRESERVATION_BASE;
+            let reg_pres_end =
+                reg_pres_start + crate::riscv::spacemit_k3::REGISTER_PRESERVATION_SIZE;
+
+            assert_eq!(rcpu0_start & 0x3, 0);
+            assert_eq!(rcpu0_end & 0x3, 0);
+            assert_eq!(rcpu1_start & 0x3, 0);
+            assert_eq!(rcpu1_end & 0x3, 0);
+            assert_eq!(dtb_start & 0x3, 0);
+            assert_eq!(dtb_end & 0x3, 0);
+            assert_eq!(reg_pres_start & 0x3, 0);
+            assert_eq!(reg_pres_end & 0x3, 0);
+
+            // pmpaddr0 = 0 (OFF entry)
+            pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
+            pmpaddr0::write(0);
+
+            // [0..REGISTER_PRESERVATION] RWX / [REGISTER_PRESERVATION] NONE
+            // (M_RWX: M-mode keeps access so it can emulate S-mode accesses) /
+            // [REGISTER_PRESERVATION..memory_range.start] RWX. Programmed via
+            // the memory-domain PMP region API.
+            let next = domain::program_windows(
+                1,
+                0,
+                memory_range.start,
+                &[domain::DomainRegion::new(
+                    reg_pres_start,
+                    REGISTER_PRESERVATION_SIZE,
+                    domain::M_RWX,
+                )],
+            )
+            .expect("K3 PMP table capacity");
+            assert_eq!(next, 4);
+
+            // [memory_range.start..sbi_start] RWX (K3 links at RAM base, so
+            // this window is typically empty; kept for symmetry)
+            pmpcfg0::set_pmp(4, Range::TOR, Permission::RWX, false);
+            pmpaddr4::write(SBI_START_ADDRESS >> 2);
+            // [sbi_start..sbi_rodata_start] R
+            pmpcfg0::set_pmp(5, Range::TOR, Permission::R, false);
+            pmpaddr5::write(RODATA_START_ADDRESS >> 2);
+            // [sbi_rodata_start..sbi_rodata_end] NONE
+            pmpcfg0::set_pmp(6, Range::TOR, Permission::NONE, false);
+            pmpaddr6::write(RODATA_END_ADDRESS >> 2);
+            // [sbi_rodata_end..sbi_end] R
+            pmpcfg0::set_pmp(7, Range::TOR, Permission::R, false);
+            pmpaddr7::write(SBI_END_ADDRESS >> 2);
+
+            // [sbi_end..RCPU0] RWX / RCPU0+RCPU1+DTB windows NONE-locked
+            // (ENF_PERMISSIONS: no R/W/X for M/S/U) / [DTB end..memory_end]
+            // RWX. Programmed via the memory-domain PMP region API.
+            let next = domain::program_windows(
+                8,
+                SBI_END_ADDRESS,
+                memory_range.end,
+                &[
+                    domain::DomainRegion::new(
+                        RCPU0_RUNTIME_SPACE_BASE_ADDR,
+                        RCPU0_RUNTIME_SPACE_SIZE,
+                        domain::ENF_PERMISSIONS,
+                    ),
+                    domain::DomainRegion::new(
+                        RCPU1_RUNTIME_SPACE_BASE_ADDR,
+                        RCPU1_RUNTIME_SPACE_SIZE,
+                        domain::ENF_PERMISSIONS,
+                    ),
+                    domain::DomainRegion::new(
+                        RCPU_DTB_SPACE_BASE_ADDR,
+                        RCPU_DTB_SPACE_SIZE,
+                        domain::ENF_PERMISSIONS,
+                    ),
+                ],
+            )
+            .expect("K3 PMP table capacity");
+            assert_eq!(next, 15);
+
+            // [memory_range.end..INF] RWX
+            domain::write_entry(15, Permission::RWX, false, usize::MAX);
+            return;
+        }
+
         // When AIA is active, block S-mode access to M-level interrupt
         // controller regions while keeping other low MMIO visible.
-        // This matches OpenSBI's domain isolation approach.
         if crate::platform::aia::is_aia_active()
             && crate::platform::board_info().is_qemu_virt()
             && let Some(aia_info) = crate::platform::board_info().aia.as_ref()

--- a/firmware/prototyper/src/main.rs
+++ b/firmware/prototyper/src/main.rs
@@ -13,6 +13,7 @@ mod fail;
 mod firmware;
 mod platform;
 mod riscv;
+mod rpmi;
 mod sbi;
 
 use crate::firmware::BootInfo;
@@ -24,11 +25,15 @@ use crate::sbi::heap;
 use crate::sbi::hsm::hart_hsm;
 use crate::sbi::ipi;
 use crate::sbi::trap_stack;
+use ::riscv::register::mstatus::MPP;
 use rustsbi_prototyper_macros::entry;
 
 #[entry]
 fn main(boot: BootInfo) {
-    if boot.is_boot_hart() {
+    // A K3 hart started through HSM has no dynamic boot envelope. Its pending
+    // HSM state determines that it must follow the secondary path.
+    let woken = crate::sbi::hsm::local_hsm().has_pending();
+    if boot.is_boot_hart() && !woken {
         boot_hart(&boot);
     } else {
         secondary_hart(&boot);
@@ -60,20 +65,44 @@ fn boot_hart(boot: &BootInfo) {
         hart_id, next.start_addr, next.next_mode
     );
     hart_hsm().start(next);
+    // Secondary harts are parked by SPL and never enter RustSBI to
+    // self-initialize; clear their HSM cells so HSM `hart_start` finds every
+    // hart in STOPPED and can wake it for smp bring-up.
+    crate::sbi::hsm::init_secondary_hsm_cells(hart_id);
 
     enable_supervisor_services();
 }
 
 fn secondary_hart(boot: &BootInfo) {
+    // Preserve START_PENDING across hart-local initialization.
+    let pending = crate::sbi::hsm::local_hsm().take_pending();
+    let woken = pending.is_some();
+
     detect_hart_features();
     trap_stack::prepare_for_trap();
 
+    if let Some(next) = pending {
+        crate::sbi::hsm::local_hsm().restore_pending(next);
+    }
+
+    // Enable this hart's core snoop BEFORE spinning on the boot-ready flag,
+    // so a cold-booted secondary observes the boot hart's writes (READY,
+    // delegate/trap setup) coherently.
+    platform::secondary_hart_init();
     platform::wait_until_ready();
     platform::secondary_hart_init();
     firmware::set_pmp(&platform::memory_range());
 
-    let next = boot.next_stage();
-    check_privilege(next.next_mode);
+    if woken {
+        // The HSM start payload, not DynamicInfo, defines the next stage.
+        check_privilege(MPP::Supervisor);
+    } else {
+        let next = boot.next_stage();
+        check_privilege(next.next_mode);
+    }
+
+    // Publish the privilege check before HSM validates future starts.
+    platform::refresh_cpu_features();
 
     enable_supervisor_services();
 }

--- a/firmware/prototyper/src/platform/boot.rs
+++ b/firmware/prototyper/src/platform/boot.rs
@@ -6,11 +6,13 @@ use core::ops::Range;
 use core::sync::atomic::Ordering;
 
 use super::{
-    BOARD_INFO, BoardInfo, IS_K1_PLATFORM, READY, board_info, print_board_info, publish_cpu_enabled,
+    BOARD_INFO, BoardInfo, IS_K1_PLATFORM, IS_K3_PLATFORM, READY, board_info, print_board_info,
+    publish_cpu_enabled,
 };
 use crate::devicetree::{Tree, parse_device_tree};
 use crate::fail;
 use crate::riscv::spacemit_k1;
+use crate::riscv::spacemit_k3;
 use crate::sbi;
 use crate::sbi::SbiDispatcher;
 use crate::sbi::cppc::SbiCppc;
@@ -37,66 +39,102 @@ pub fn init_board(fdt_address: usize) {
     // Get console device, init sbi console and logger.
     board.discover_console(&root);
     let console = sbi::console::init(&board);
-    let cppc = Some(SbiCppc::new());
-    let dbtr = Some(SbiDbtr);
-    let fwft = Some(SbiFwft);
     // Get other info that later platform initialization depends on.
     let cpu_list = board.discover_misc(&tree);
     publish_cpu_enabled(cpu_list);
     // Get clint and reset device, init sbi ipi, reset, hsm, rfence and susp extension.
     board.discover_devices(&root);
+    let mailbox = crate::rpmi::discover_mailbox(&root);
     let ipi = sbi::ipi::init(&board);
     let hsm = ipi.as_ref().map(|_| SbiHsm);
-    let reset = sbi::reset::init(&board);
     let rfence = ipi.as_ref().map(|_| SbiRFence);
     let susp = hsm.as_ref().map(|_| SbiSuspend);
     // Initialize pmu extension
     let pmu = sbi::pmu::init(&root);
-    let mpxy = Some(sbi::mpxy::SbiMpxy::new());
     let sta = Some(SbiSta);
     let nacl = Some(SbiNacl);
+
+    // Publish the board facts before platform initialization, so that
+    // harts observing `READY` (Acquire) also observe the published board.
+    BOARD_INFO.call_once(move || board);
+
+    // Record platform detection before releasing the ready flag, so
+    // that secondary harts observing `READY` also observe the flag.
+    // Match root `compatible` strings first, then fall back to the model.
+    let k3_platform = match root.get_prop("compatible") {
+        Some(prop) => {
+            let seq = prop.deserialize::<serde_device_tree::buildin::StrSeq>();
+            spacemit_k3::is_k3_platform(&board_info().model, seq.iter())
+        }
+        None => spacemit_k3::is_k3_platform(&board_info().model, core::iter::empty::<&str>()),
+    };
+    IS_K3_PLATFORM.store(k3_platform, Ordering::Release);
+    if !k3_platform {
+        let k1_platform = match root.get_prop("compatible") {
+            Some(prop) => {
+                let seq = prop.deserialize::<serde_device_tree::buildin::StrSeq>();
+                spacemit_k1::is_k1_platform(&board_info().model, seq.iter())
+            }
+            None => spacemit_k1::is_k1_platform(&board_info().model, core::iter::empty::<&str>()),
+        };
+        IS_K1_PLATFORM.store(k1_platform, Ordering::Release);
+    }
+
+    if IS_K3_PLATFORM.load(Ordering::Acquire) {
+        spacemit_k3::cold_boot_allowed(crate::riscv::current_hartid());
+        spacemit_k3::cold_boot_init();
+        spacemit_k3::init_maplic_delegation();
+        info!("SpacemiT K3: early init done (RVBADDR + CCI-550 + A100 park)");
+    } else if IS_K1_PLATFORM.load(Ordering::Acquire) {
+        spacemit_k1::cold_boot_init();
+        info!("SpacemiT K1: early init done (MSETUP + CCI-550)");
+    }
+
+    let cppc = mailbox.and_then(|mailbox| {
+        mailbox
+            .probe_service_group(crate::rpmi::servicegroup::CPPC)
+            .filter(|version| version >> 16 == 1)
+            .map(|_| {
+                let cppc = SbiCppc::new();
+                cppc.set_mailbox(mailbox);
+                cppc
+            })
+    });
+    let reset = sbi::reset::init(board_info(), mailbox);
+    let mpxy = mailbox.and_then(|mailbox| sbi::mpxy::SbiMpxy::from_fdt(&root, mailbox));
+    // DBTR remains unavailable until trigger installation, update, and
+    // lifecycle operations are implemented as a complete SBI v3.0 service.
+    let dbtr: Option<SbiDbtr> = None;
+    let fwft = Some(SbiFwft);
     // Keep SSE unavailable until supervisor handler context switching is implemented.
     let sse: Option<SbiSse> = None;
 
-    // Publish the SBI extension set before the K1 detect / READY release,
-    // so that harts observing `READY` also observe the published dispatcher.
     sbi::SBI_DISPATCHER.call_once(|| {
         SbiDispatcher::new(
             console, cppc, dbtr, fwft, ipi, hsm, reset, rfence, susp, pmu, sta, mpxy, nacl, sse,
         )
     });
 
-    // Publish the board facts before the K1 detect / READY release, so that
-    // harts observing `READY` (Acquire) also observe the published board.
-    BOARD_INFO.call_once(move || board);
-
-    // Record K1 platform detection *before* releasing the ready flag, so
-    // that secondary harts observing `READY` also observe the flag.
-    // Match the root node's `compatible` strings first (OpenSBI's
-    // spacemit_k1_match[] table), falling back to the model string.
-    let k1_platform = match root.get_prop("compatible") {
-        Some(prop) => {
-            let seq = prop.deserialize::<serde_device_tree::buildin::StrSeq>();
-            spacemit_k1::is_k1_platform(&board_info().model, seq.iter())
-        }
-        None => spacemit_k1::is_k1_platform(&board_info().model, core::iter::empty::<&str>()),
-    };
-    IS_K1_PLATFORM.store(k1_platform, Ordering::Release);
-
+    // Secondary harts may proceed only after SoC-wide initialization and all
+    // published dispatcher state are visible.
     READY.store(true, Ordering::Release);
 
     print_board_info();
-
-    if IS_K1_PLATFORM.load(Ordering::Acquire) {
-        spacemit_k1::cold_boot_init();
-        info!("SpacemiT K1: early init done (MSETUP + CCI-550)");
-    }
 }
 
 /// Runs the SoC-specific per-hart setup for secondary harts.
 pub fn secondary_hart_init() {
-    if IS_K1_PLATFORM.load(Ordering::Acquire) {
+    if IS_K3_PLATFORM.load(Ordering::Acquire) {
+        spacemit_k3::cold_boot_allowed(crate::riscv::current_hartid());
+    } else if IS_K1_PLATFORM.load(Ordering::Acquire) {
         spacemit_k1::cold_boot_allowed(crate::riscv::current_hartid());
+    }
+}
+
+/// Wakes a platform hart before HSM raises its software interrupt.
+pub fn wakeup_hart(hartid: usize) {
+    if IS_K3_PLATFORM.load(Ordering::Acquire) {
+        spacemit_k3::wakeup_core(hartid);
     }
 }
 

--- a/firmware/prototyper/src/platform/console.rs
+++ b/firmware/prototyper/src/platform/console.rs
@@ -17,9 +17,10 @@ pub(crate) const UARTAXILITE_COMPATIBLE: [&str; 1] = ["xlnx,xps-uartlite-1.00.a"
 pub(crate) const UARTBFLB_COMPATIBLE: [&str; 1] = ["bflb,bl808-uart"];
 pub(crate) const UARTSIFIVE_COMPATIBLE: [&str; 1] = ["sifive,uart0"];
 pub(crate) const UARTPL011_COMPATIBLE: [&str; 1] = ["pl011"];
-pub(crate) const UARTXSCALE_COMPATIBLE: [&str; 3] = [
+pub(crate) const UARTXSCALE_COMPATIBLE: [&str; 4] = [
     "intel,xscale-uart",
     "spacemit,k1-uart",
+    "spacemit,k3-uart",
     // Official OrangePi RV2 U-Boot (orangepi-xunlong/u-boot-orangepi,
     // v2022.10-ky) describes uart0 as plain "ns16550" with reg-io-width=4 and
     // drives it as the XScale variant (CONFIG_SYS_NS16550_IER=0x40 = UUE).

--- a/firmware/prototyper/src/platform/mod.rs
+++ b/firmware/prototyper/src/platform/mod.rs
@@ -13,6 +13,7 @@ use crate::platform::console::{
     UARTBFLB_COMPATIBLE, UARTPL011_COMPATIBLE, UARTSIFIVE_COMPATIBLE, UARTXSCALE_COMPATIBLE,
 };
 use crate::platform::reset::P1_PMIC_COMPATIBLE;
+use crate::platform::reset::RPMI_SYSRST_COMPATIBLE;
 use crate::platform::reset::SIFIVETEST_COMPATIBLE;
 use crate::sbi::features::extension_detection;
 use spin::{Once, RwLock};
@@ -23,7 +24,47 @@ pub(crate) mod clint;
 pub(crate) mod console;
 pub(crate) mod reset;
 
-pub use boot::{init_board, memory_range, secondary_hart_init, wait_until_ready};
+pub use boot::{init_board, memory_range, secondary_hart_init, wait_until_ready, wakeup_hart};
+
+/// Result of a platform access-fault emulation attempt.
+///
+/// Returned by [`emulate_access_fault`].
+pub enum AccessFaultResult {
+    /// The platform did not handle the access; re-inject the fault to S-mode.
+    NotHandled,
+    /// Emulated load: the value read from the emulated MMIO register.
+    EmulatedLoad(u64),
+    /// Emulated store succeeded.
+    EmulatedStore,
+}
+
+/// Platform-level load/store access-fault emulation hook.
+///
+/// Dispatches S-mode load/store access faults to the platform's MMIO
+/// emulation. On the SpacemiT K3 this is the REGISTER_PRESERVATION window
+/// emulation ([`crate::riscv::spacemit_k3::emulate_load`] and
+/// [`crate::riscv::spacemit_k3::emulate_store`]); other platforms return
+/// [`AccessFaultResult::NotHandled`].
+pub(crate) fn emulate_access_fault(
+    is_load: bool,
+    addr: usize,
+    len: usize,
+    value: u64,
+) -> AccessFaultResult {
+    if !IS_K3_PLATFORM.load(Ordering::Acquire) {
+        return AccessFaultResult::NotHandled;
+    }
+    if is_load {
+        match crate::riscv::spacemit_k3::emulate_load(addr, len) {
+            Some(v) => AccessFaultResult::EmulatedLoad(v),
+            None => AccessFaultResult::NotHandled,
+        }
+    } else if crate::riscv::spacemit_k3::emulate_store(addr, len, value) {
+        AccessFaultResult::EmulatedStore
+    } else {
+        AccessFaultResult::NotHandled
+    }
+}
 
 pub(crate) static CPU_PRIVILEGED_ENABLED: [AtomicBool; NUM_HART_MAX] =
     [const { AtomicBool::new(false) }; NUM_HART_MAX];
@@ -34,6 +75,11 @@ pub(crate) static CPU_PRIVILEGED_ENABLED: [AtomicBool; NUM_HART_MAX] =
 /// secondary hart observing `READY == true` is guaranteed to also observe
 /// this flag (main.rs secondary-hart path).
 pub(crate) static IS_K1_PLATFORM: AtomicBool = AtomicBool::new(false);
+pub(crate) static IS_K3_PLATFORM: AtomicBool = AtomicBool::new(false);
+/// Whether the running platform is a SpacemiT K3.
+pub(crate) fn is_k3() -> bool {
+    IS_K3_PLATFORM.load(Ordering::Acquire)
+}
 
 /// Boot synchronization flag: set by the boot hart once platform
 /// initialization is complete, spinning secondary harts observe it with
@@ -74,14 +120,17 @@ pub(crate) fn publish_cpu_enabled(cpu_list: Option<CpuEnableList>) {
 ///
 /// Runs post-`READY` on the boot hart while other harts may read the table;
 /// the write lock makes their copies atomic snapshots of the whole list.
+///
+/// A successful per-hart privilege check may enable a DTB-listed hart. Entries
+/// are never cleared before every secondary hart has completed that check.
 pub fn refresh_cpu_features() {
     let mut cpu_enabled = CPU_ENABLED.write();
     let Some(cpu_enabled) = cpu_enabled.as_mut() else {
         return;
     };
     for (hart_id, enabled) in cpu_enabled.iter_mut().enumerate() {
-        if *enabled {
-            *enabled = CPU_PRIVILEGED_ENABLED[hart_id].load(Ordering::Acquire);
+        if CPU_PRIVILEGED_ENABLED[hart_id].load(Ordering::Acquire) {
+            *enabled = true;
         }
     }
 }
@@ -138,7 +187,10 @@ fn node_phandle(node: &serde_device_tree::buildin::Node) -> Option<u32> {
         .map(|prop| prop.deserialize::<u32>())
 }
 
-fn prop_u32_cells(node: &serde_device_tree::buildin::Node, name: &str) -> Option<Vec<u32>> {
+pub(crate) fn prop_u32_cells(
+    node: &serde_device_tree::buildin::Node,
+    name: &str,
+) -> Option<Vec<u32>> {
     let prop = node.get_prop(name)?;
     let data = prop.deserialize::<&[u8]>();
     let mut cells = Vec::new();
@@ -190,6 +242,9 @@ pub struct BoardInfo {
     pub console: Option<(BaseAddress, MachineConsoleType)>,
     pub console_clock: Option<u32>,
     pub reset: Option<BaseAddress>,
+    /// True when the platform exposes system reset through the RPMI
+    /// System Reset service group (K3) rather than an MMIO test device.
+    pub rpmi_reset: bool,
     pub ipi: Option<(BaseAddress, MachineClintType)>,
     pub aia: Option<aia::AiaInfo>,
     pub cpu_num: Option<usize>,
@@ -205,6 +260,7 @@ impl BoardInfo {
             console: None,
             console_clock: None,
             reset: None,
+            rpmi_reset: false,
             ipi: None,
             aia: None,
             cpu_num: None,
@@ -315,6 +371,16 @@ impl BoardInfo {
         let mut find_device =
             |node: &serde_device_tree::buildin::Node,
              parent: Option<&serde_device_tree::buildin::Node>| {
+                // RPMI system reset may be described by a node without a
+                // `reg` property (K3: rpmi-mpxy-sysreset@0 has only
+                // compatible/mboxes/status), so discover it before the
+                // reg-requiring path below returns early.
+                if let Some(compatible) = node.get_prop("compatible") {
+                    let seq = compatible.deserialize::<serde_device_tree::buildin::StrSeq>();
+                    for device_id in seq.iter() {
+                        self.discover_rpmi_reset(device_id);
+                    }
+                }
                 let Some((compatible, regs)) = get_compatible_and_ranges(node) else {
                     return;
                 };
@@ -356,6 +422,18 @@ impl BoardInfo {
         // Initialize reset device.
         if SIFIVETEST_COMPATIBLE.contains(&device_id) {
             self.reset = Some(base_address);
+        }
+    }
+
+    /// Discovers the K3 RPMI system reset device from a `compatible` match.
+    ///
+    /// The K3 exposes system reset through the RPMI System Reset service
+    /// group (delivered over the shared-memory mailbox), not through a
+    /// sifive,test0-style MMIO device. We record the node so the reset
+    /// extension can be backed by the injected mailbox.
+    fn discover_rpmi_reset(&mut self, device_id: &str) {
+        if RPMI_SYSRST_COMPATIBLE.contains(&device_id) {
+            self.rpmi_reset = true;
         }
     }
 
@@ -677,6 +755,11 @@ fn print_reset_info() {
         info!(
             "{:<30}: Available (P1 PMIC @ 0x{:02x}, I2C Base: 0x{:x})",
             "Platform Reset Extension", pmic_addr, i2c_base
+        );
+    } else if board_info().rpmi_reset && crate::sbi::reset().is_some() {
+        info!(
+            "{:<30}: Available (RPMI System Reset service group)",
+            "Platform Reset Extension"
         );
     } else {
         warn!("{:<30}: Not Available", "Platform Reset Device");

--- a/firmware/prototyper/src/platform/reset.rs
+++ b/firmware/prototyper/src/platform/reset.rs
@@ -3,6 +3,10 @@ use sifive_test_device::SifiveTestDevice;
 
 use crate::sbi::reset::ResetDevice;
 pub(crate) const SIFIVETEST_COMPATIBLE: [&str; 1] = ["sifive,test0"];
+/// K3 reset is exposed as an RPMI System Reset service group via the
+/// `riscv,rpmi-shmem-mbox` node; the DTB marks it with
+/// `riscv,rpmi-system-reset`.
+pub(crate) const RPMI_SYSRST_COMPATIBLE: [&str; 1] = ["riscv,rpmi-system-reset"];
 pub(crate) const P1_PMIC_COMPATIBLE: [&str; 2] = [
     "spacemit,p1",
     // Official OrangePi RV2 U-Boot (orangepi-xunlong/u-boot-orangepi,
@@ -48,7 +52,7 @@ impl ResetDevice for SifiveTestDeviceWrap {
     }
 
     #[inline]
-    fn reset(&self) -> ! {
+    fn reset(&self, _warm: bool) -> ! {
         self.write(0x7777)
     }
 }
@@ -56,12 +60,12 @@ impl ResetDevice for SifiveTestDeviceWrap {
 /// SpacemiT P1 PMIC reset device.
 ///
 /// The P1 PMIC is an I2C-controlled power management IC used with the
-/// SpacemiT K1 SoC. Reset is triggered by writing to the PMIC's
+/// SpacemiT K1 and K3 SoCs. Reset is triggered by writing to the PMIC's
 /// Power Control Register 2 (0x7e):
 /// - Bit 1: Reset request
 /// - Bit 2: Shutdown request
 ///
-/// This driver directly accesses the K1's I2C controller registers via
+/// This driver directly accesses the SoC's I2C controller registers via
 /// MMIO to avoid needing a full I2C framework.
 pub struct P1PmicResetWrap {
     /// I2C controller MMIO registers.
@@ -74,8 +78,9 @@ impl P1PmicResetWrap {
     /// Create a new P1 PMIC reset device.
     ///
     /// `i2c_base` is the MMIO base address of the I2C controller.
-    /// `pmic_addr` is the 7-bit I2C address of the P1 PMIC (0x41 on the
-    /// OrangePi RV2, per its device tree `pmic@41` node).
+    /// `pmic_addr` is the 7-bit I2C address of the P1 PMIC (0x41 on
+    /// SpacemiT K1/K3 boards, as described by their `pmic@41` device-tree
+    /// nodes).
     pub const fn new(i2c_base: usize, pmic_addr: u8) -> Self {
         Self {
             i2c: i2c_base as *const I2cK1Registers,
@@ -88,7 +93,7 @@ unsafe impl Send for P1PmicResetWrap {}
 unsafe impl Sync for P1PmicResetWrap {}
 
 // SpacemiT I2C controller registers (K1).
-// Layout per Linux `drivers/i2c/busses/i2c-k1.c` — the K1 I2C controller is
+// Layout per Linux `drivers/i2c/busses/i2c-k1.c`; the K1 I2C controller is
 // SpacemiT-proprietary (ICR/ISR/IDBR/IRCR/IBMR), NOT DesignWare I2C.
 /// SpacemiT K1 I2C controller MMIO registers.
 #[repr(C)]
@@ -294,7 +299,7 @@ impl ResetDevice for P1PmicResetWrap {
     }
 
     #[inline]
-    fn reset(&self) -> ! {
+    fn reset(&self, _warm: bool) -> ! {
         // P1 PMIC: set reset bit in PWR_CTRL2
         unsafe {
             i2c_write_reg(

--- a/firmware/prototyper/src/riscv/csr.rs
+++ b/firmware/prototyper/src/riscv/csr.rs
@@ -20,6 +20,10 @@ pub const CSR_MSTATEEN1: u16 = 0x30d;
 pub const CSR_MSTATEEN2: u16 = 0x30e;
 pub const CSR_MSTATEEN3: u16 = 0x30f;
 
+// Hypervisor State-Enable 0 (H extension; absent on K3 despite the DTB
+// declaring 'h' and smstateen).
+pub const CSR_HSTATEEN0: u16 = 0x60c;
+
 // Machine Counter Setup (Inhibit, Privilege Filtering and Event Selection)
 pub const CSR_MCOUNTINHIBIT: u16 = 0x320;
 pub const CSR_MCYCLECFG: u16 = 0x321;
@@ -117,8 +121,9 @@ pub mod menvcfg {
     pub const FIOM: usize = 0x1 << 0;
     /// Cache block invalidate - flush.
     pub const CBIE_FLUSH: usize = 0x01 << 4;
-    /// Cache block invalidate - invalidate.
-    pub const CBIE_INVALIDATE: usize = 0x11 << 4;
+    /// Cache block invalidate - invalidate one block plus fence.i.
+    /// Encoding required for `cbo.flush` and `cbo.inval` on the K3.
+    pub const CBIE_INVALIDATE: usize = 0x3 << 4;
     /// Cache block clean for enclave.
     pub const CBCFE: usize = 0x1 << 6;
     /// Cache block zero for enclave.
@@ -174,6 +179,21 @@ pub mod mstateen {
     #[inline(always)]
     pub fn enable_smode_aia() {
         let stateen0 = STATEN | CONTEXT | IMSIC | AIA | SVSLCT | HSENVCFG | CTR;
+        unsafe {
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN0, value = in(reg) stateen0, options(nomem));
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN1, value = in(reg) STATEN, options(nomem));
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN2, value = in(reg) STATEN, options(nomem));
+            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN3, value = in(reg) STATEN, options(nomem));
+        }
+    }
+
+    /// Writes the full `mstateen0` value (S/HS-mode access control for
+    /// state-enable CSRs). `mstateen1-3` get `STATEN` so the corresponding
+    /// state-enable CSR groups stay accessible. Used instead of
+    /// [`enable_smode_aia`] when the caller wants to grant only the base bits
+    /// (`STATEN|CONTEXT|HSENVCFG`) plus optional AIA bits.
+    #[inline(always)]
+    pub fn set_stateen0(stateen0: usize) {
         unsafe {
             asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN0, value = in(reg) stateen0, options(nomem));
             asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN1, value = in(reg) STATEN, options(nomem));
@@ -400,6 +420,17 @@ pub fn configure_delegation() {
         medeleg::clear_load_misaligned();
         medeleg::clear_store_misaligned();
         medeleg::clear_illegal_instruction();
+    }
+}
+
+/// Keeps load and store access faults in M-mode for platform emulation.
+pub fn keep_access_faults_in_mmode() {
+    use riscv::register::medeleg;
+
+    // SAFETY: this updates only the current hart's delegation policy.
+    unsafe {
+        medeleg::clear_load_fault();
+        medeleg::clear_store_fault();
     }
 }
 

--- a/firmware/prototyper/src/riscv/mod.rs
+++ b/firmware/prototyper/src/riscv/mod.rs
@@ -1,5 +1,6 @@
 pub mod csr;
 pub mod spacemit_k1;
+pub mod spacemit_k3;
 
 /// Returns the current hart (hardware thread) ID.
 #[inline]

--- a/firmware/prototyper/src/riscv/spacemit_k3.rs
+++ b/firmware/prototyper/src/riscv/spacemit_k3.rs
@@ -1,0 +1,1216 @@
+//! SpacemiT K3 platform support.
+
+use core::{arch::asm, cell::UnsafeCell};
+
+const CSR_ML2SETUP: u16 = 0x7f0;
+const CSR_ML2HINT: u16 = 0x7f7;
+const CSR_PERF_CTRL: u16 = 0x7d0;
+const CSR_PREFETCH_CTRL: u16 = 0x7d1;
+
+// ML2SETUP bit fields (in addition to the per-hart L2 cache mask)
+const ML2SETUP_IPRF: usize = 1 << 16; // Instruction prefetch enable
+const ML2SETUP_TPRF: usize = 1 << 18; // TLB prefetch enable
+
+// ML2HINT bit fields.
+const ML2HINT_CIU_CHR2_MER_DIS: usize = 1 << 2; // Disable read/prefetch transaction merge
+const ML2HINT_CIU_CHR2_DEPD_DIS: usize = 1 << 3; // Disable full address dependency check
+const ML2HINT_TRACE_TOP_ICGEN: usize = 1 << 26; // RV-Trace top clock enable
+
+// PERF_CTRL bit fields.
+const PERF_CTRL_VEC_L1BYPASS: usize = 1 << 32; // Vector loads bypass L1, cached in L2 only
+
+// PREFETCH_CTRL bit fields.
+const PREFETCH_CTRL_L2_PERF_DIST: usize = 3 << 10; // L2 prefetch distance: 56 entries
+
+#[repr(transparent)]
+struct MmioReg(UnsafeCell<u32>);
+
+// SAFETY: access is volatile and synchronization is defined by each device's
+// register protocol rather than Rust memory accesses.
+unsafe impl Sync for MmioReg {}
+
+impl MmioReg {
+    #[inline]
+    fn read(&self) -> u32 {
+        // SAFETY: `self` points at MMIO registers; reads are volatile so the
+        // compiler cannot cache or reorder them.
+        unsafe { self.0.get().read_volatile() }
+    }
+
+    #[inline]
+    fn write(&self, val: u32) {
+        // SAFETY: `self` points at MMIO registers; writes are volatile so
+        // the compiler cannot elide or reorder them.
+        unsafe { self.0.get().write_volatile(val) }
+    }
+}
+
+#[inline]
+fn mmio_reg(address: *const MmioReg) -> &'static MmioReg {
+    // SAFETY: callers use fixed K3 register addresses after platform detection.
+    unsafe { &*address }
+}
+
+#[inline]
+fn warmboot_reg(address: *const WarmbootAddr) -> &'static WarmbootAddr {
+    // SAFETY: callers use fixed K3 cluster RVBADDR addresses after detection.
+    unsafe { &*address }
+}
+
+/// A pair of adjacent LO/HI warmboot address registers (8 bytes).
+#[repr(C)]
+struct WarmbootAddr {
+    lo: MmioReg,
+    hi: MmioReg,
+}
+
+impl WarmbootAddr {
+    #[inline]
+    fn set(&self, addr: u64) {
+        self.lo.write(addr as u32);
+        self.hi.write((addr >> 32) as u32);
+    }
+}
+
+const C0_RVBADDR: *const WarmbootAddr = 0xd4282db0usize as *const WarmbootAddr;
+const C1_RVBADDR: *const WarmbootAddr = (0xd4282c00usize + 0x2b0) as *const WarmbootAddr;
+const C2_RVBADDR: *const WarmbootAddr = (0xd4282c00usize + 0x3e8) as *const WarmbootAddr;
+const C3_RVBADDR: *const WarmbootAddr = (0xd4282c00usize + 0x260) as *const WarmbootAddr;
+
+const PMU_CAP_BASE: usize = 0xd4282800;
+
+const PMU_CAP_CORE_WAKEUP: [*const MmioReg; 16] = [
+    (PMU_CAP_BASE + 0x12c) as *const MmioReg, // CORE0
+    (PMU_CAP_BASE + 0x130) as *const MmioReg, // CORE1
+    (PMU_CAP_BASE + 0x134) as *const MmioReg, // CORE2
+    (PMU_CAP_BASE + 0x138) as *const MmioReg, // CORE3
+    (PMU_CAP_BASE + 0x324) as *const MmioReg, // CORE4
+    (PMU_CAP_BASE + 0x328) as *const MmioReg, // CORE5
+    (PMU_CAP_BASE + 0x32c) as *const MmioReg, // CORE6
+    (PMU_CAP_BASE + 0x330) as *const MmioReg, // CORE7
+    (PMU_CAP_BASE + 0x360) as *const MmioReg, // CORE8
+    (PMU_CAP_BASE + 0x364) as *const MmioReg, // CORE9
+    (PMU_CAP_BASE + 0x368) as *const MmioReg, // CORE10
+    (PMU_CAP_BASE + 0x36c) as *const MmioReg, // CORE11
+    (PMU_CAP_BASE + 0x22c) as *const MmioReg, // CORE12
+    (PMU_CAP_BASE + 0x230) as *const MmioReg, // CORE13
+    (PMU_CAP_BASE + 0x234) as *const MmioReg, // CORE14
+    (PMU_CAP_BASE + 0x238) as *const MmioReg, // CORE15
+];
+
+const PMU_CAP_CORE_IDLE_CFG: [*const MmioReg; 16] = [
+    (PMU_CAP_BASE + 0x124) as *const MmioReg, // CORE0
+    (PMU_CAP_BASE + 0x128) as *const MmioReg, // CORE1
+    (PMU_CAP_BASE + 0x160) as *const MmioReg, // CORE2
+    (PMU_CAP_BASE + 0x164) as *const MmioReg, // CORE3
+    (PMU_CAP_BASE + 0x304) as *const MmioReg, // CORE4
+    (PMU_CAP_BASE + 0x308) as *const MmioReg, // CORE5
+    (PMU_CAP_BASE + 0x30c) as *const MmioReg, // CORE6
+    (PMU_CAP_BASE + 0x310) as *const MmioReg, // CORE7
+    (PMU_CAP_BASE + 0x340) as *const MmioReg, // CORE8
+    (PMU_CAP_BASE + 0x344) as *const MmioReg, // CORE9
+    (PMU_CAP_BASE + 0x348) as *const MmioReg, // CORE10
+    (PMU_CAP_BASE + 0x34c) as *const MmioReg, // CORE11
+    (PMU_CAP_BASE + 0x20c) as *const MmioReg, // CORE12
+    (PMU_CAP_BASE + 0x210) as *const MmioReg, // CORE13
+    (PMU_CAP_BASE + 0x214) as *const MmioReg, // CORE14
+    (PMU_CAP_BASE + 0x218) as *const MmioReg, // CORE15
+];
+
+const PMU_CX_CAPMP_IDLE_CFG: [*const MmioReg; 16] = [
+    (PMU_CAP_BASE + 0x120) as *const MmioReg, // CFG0  (cluster 0, hart 0)
+    (PMU_CAP_BASE + 0xe4) as *const MmioReg,  // CFG1  (cluster 0, hart 1)
+    (PMU_CAP_BASE + 0x150) as *const MmioReg, // CFG2  (cluster 0, hart 2)
+    (PMU_CAP_BASE + 0x154) as *const MmioReg, // CFG3  (cluster 0, hart 3)
+    (PMU_CAP_BASE + 0x314) as *const MmioReg, // CFG4  (cluster 1, hart 4)
+    (PMU_CAP_BASE + 0x318) as *const MmioReg, // CFG5  (cluster 1, hart 5)
+    (PMU_CAP_BASE + 0x31c) as *const MmioReg, // CFG6  (cluster 1, hart 6)
+    (PMU_CAP_BASE + 0x320) as *const MmioReg, // CFG7  (cluster 1, hart 7)
+    (PMU_CAP_BASE + 0x350) as *const MmioReg, // CFG8  (cluster 2, hart 8)
+    (PMU_CAP_BASE + 0x354) as *const MmioReg, // CFG9  (cluster 2, hart 9)
+    (PMU_CAP_BASE + 0x358) as *const MmioReg, // CFG10 (cluster 2, hart 10)
+    (PMU_CAP_BASE + 0x35c) as *const MmioReg, // CFG11 (cluster 2, hart 11)
+    (PMU_CAP_BASE + 0x21c) as *const MmioReg, // CFG12 (cluster 3, hart 12)
+    (PMU_CAP_BASE + 0x220) as *const MmioReg, // CFG13 (cluster 3, hart 13)
+    (PMU_CAP_BASE + 0x224) as *const MmioReg, // CFG14 (cluster 3, hart 14)
+    (PMU_CAP_BASE + 0x228) as *const MmioReg, // CFG15 (cluster 3, hart 15)
+];
+
+const CPU_MASK_FI_INTTERUPT: u32 = (1 << 3) | (1 << 4);
+const CPU_PWR_DOWN_VALUE: u32 = 0x1f;
+const CLUSTER_PWR_DOWN_VALUE: u32 = 0x8f;
+
+const APCR_CORE_VETE_REG: [*const MmioReg; 16] = [
+    (0xd4050000usize + 0x10c0) as *const MmioReg, // CORE0
+    (0xd4050000usize + 0x10c4) as *const MmioReg, // CORE1
+    (0xd4050000usize + 0x10c8) as *const MmioReg, // CORE2
+    (0xd4050000usize + 0x10cc) as *const MmioReg, // CORE3
+    (0xd4050000usize + 0x10d0) as *const MmioReg, // CORE4
+    (0xd4050000usize + 0x10d4) as *const MmioReg, // CORE5
+    (0xd4050000usize + 0x10d8) as *const MmioReg, // CORE6
+    (0xd4050000usize + 0x10dc) as *const MmioReg, // CORE7
+    (0xd4050000usize + 0x10e0) as *const MmioReg, // CORE8
+    (0xd4050000usize + 0x10e4) as *const MmioReg, // CORE9
+    (0xd4050000usize + 0x10e8) as *const MmioReg, // CORE10
+    (0xd4050000usize + 0x10ec) as *const MmioReg, // CORE11
+    (0xd4050000usize + 0x10f0) as *const MmioReg, // CORE12
+    (0xd4050000usize + 0x10f4) as *const MmioReg, // CORE13
+    (0xd4050000usize + 0x10f8) as *const MmioReg, // CORE14
+    (0xd4050000usize + 0x10fc) as *const MmioReg, // CORE15
+];
+
+const APCR_COREX_DEFAULT_VATE_VALUE: u32 = (1 << 3)
+    | (1 << 13)
+    | (1 << 14)
+    | (1 << 19)
+    | (1 << 25)
+    | (1 << 26)
+    | (1 << 27)
+    | (1 << 29)
+    | (1 << 31);
+
+const PMU_L2_FLUSH_BASE: usize = 0xd8440000;
+const PMU_C0_L2_FLUSH_CTRL: *const MmioReg = (PMU_L2_FLUSH_BASE + 0x1b0) as *const MmioReg;
+const PMU_C1_L2_FLUSH_CTRL: *const MmioReg = (PMU_L2_FLUSH_BASE + 0x1b4) as *const MmioReg;
+const PMU_C2_L2_FLUSH_CTRL: *const MmioReg = (PMU_L2_FLUSH_BASE + 0x1c4) as *const MmioReg;
+const PMU_C3_L2_FLUSH_CTRL: *const MmioReg = (PMU_L2_FLUSH_BASE + 0x1ec) as *const MmioReg;
+const PMU_L2_FLUSH_HW_TYPE: u32 = 1 << 0; // Hardware flush type
+const PMU_L2_FLUSH_HW_EN: u32 = 1 << 2; // Hardware flush enable
+
+const DMASYS_RESET: *const MmioReg = (PMU_L2_FLUSH_BASE + 0x22c) as *const MmioReg;
+const DMASYS_CLK_EN: *const MmioReg = (PMU_L2_FLUSH_BASE + 0x234) as *const MmioReg;
+
+// CCI-550 cache coherent interconnect
+
+/// CCI-550 control and status registers.
+#[repr(C)]
+struct Cci550Registers {
+    _ctrl_override: MmioReg, // 0x0000
+    _reserved0: MmioReg,     // 0x0004
+    _reserved1: MmioReg,     // 0x0008
+    status: MmioReg,         // 0x000c
+}
+
+impl Cci550Registers {
+    #[inline]
+    fn change_pending(&self) -> bool {
+        self.status.read() & CCI_550_STATUS_CHANGE_PENDING != 0
+    }
+
+    /// Registers of the slave interface at `idx`.
+    ///
+    /// # Safety
+    ///
+    /// `idx` must be a valid CCI-550 slave interface index (0..7).
+    #[inline]
+    unsafe fn slave_iface(&self, idx: usize) -> &CciSlaveIfaceRegisters {
+        // SAFETY: `self` is a valid CCI-550 base address and `idx` is a valid
+        // slave interface index, so the computed address aliases its MMIO.
+        unsafe {
+            &*((self as *const Self as usize + cci_slave_iface_offset(idx))
+                as *const CciSlaveIfaceRegisters)
+        }
+    }
+}
+
+#[repr(C)]
+struct CciSlaveIfaceRegisters {
+    snoop_ctrl: MmioReg, // 0x0000
+}
+
+const CCI_550_BASE: *const Cci550Registers = 0xd8500000usize as *const Cci550Registers;
+const CCI_550_STATUS_CHANGE_PENDING: u32 = 1 << 0;
+
+const CCI_550_SLAVE_IFACE0_OFFSET: usize = 0x1000;
+const fn cci_slave_iface_offset(idx: usize) -> usize {
+    CCI_550_SLAVE_IFACE0_OFFSET + 0x1000 * idx
+}
+const CCI_550_SNOOP_CTRL_ENABLE_SNOOPS: u32 = 1 << 0;
+const CCI_550_SNOOP_CTRL_ENABLE_DVMS: u32 = 1 << 1;
+
+const PLATFORM_MAX_CPUS: usize = 8;
+const PLATFORM_MAX_CPUS_PER_CLUSTER: usize = 4;
+const fn cpu_to_cluster(cpu: usize) -> usize {
+    cpu / PLATFORM_MAX_CPUS_PER_CLUSTER
+}
+
+#[inline]
+unsafe fn csr_read<const CSR: u16>() -> usize {
+    let r: usize;
+    unsafe {
+        asm!("csrr {r}, {csr}", r = out(reg) r, csr = const CSR, options(nomem));
+    }
+    r
+}
+
+#[inline]
+unsafe fn csr_write<const CSR: u16>(val: usize) {
+    unsafe {
+        asm!("csrw {csr}, {val}", csr = const CSR, val = in(reg) val, options(nomem));
+    }
+}
+
+#[inline]
+unsafe fn csr_set<const CSR: u16>(bits: usize) {
+    let old = unsafe { csr_read::<CSR>() };
+    unsafe { csr_write::<CSR>(old | bits) };
+}
+
+#[inline]
+unsafe fn csr_clear<const CSR: u16>(bits: usize) {
+    let old = unsafe { csr_read::<CSR>() };
+    unsafe { csr_write::<CSR>(old & !bits) };
+}
+
+fn vote_powrdown_core(hartid: usize) {
+    let reg = mmio_reg(PMU_CAP_CORE_IDLE_CFG[hartid]);
+    let value = reg.read() | CPU_PWR_DOWN_VALUE;
+    reg.write(value);
+}
+
+fn vote_powrdown_cluster(hartid: usize) {
+    let core_reg = mmio_reg(PMU_CAP_CORE_IDLE_CFG[hartid]);
+    core_reg.write(core_reg.read() | CPU_PWR_DOWN_VALUE);
+    let cluster_reg = mmio_reg(PMU_CX_CAPMP_IDLE_CFG[hartid]);
+    cluster_reg.write(cluster_reg.read() | CLUSTER_PWR_DOWN_VALUE);
+}
+
+fn devote_pwrdown_cluster(hartid: usize) {
+    let core_reg = mmio_reg(PMU_CAP_CORE_IDLE_CFG[hartid]);
+    let value = core_reg.read() & !(CPU_PWR_DOWN_VALUE | CPU_MASK_FI_INTTERUPT);
+    core_reg.write(value);
+    let cluster_reg = mmio_reg(PMU_CX_CAPMP_IDLE_CFG[hartid]);
+    cluster_reg.write(cluster_reg.read() & !CLUSTER_PWR_DOWN_VALUE);
+}
+
+fn vote_core_apcr(hartid: usize) {
+    let reg = mmio_reg(APCR_CORE_VETE_REG[hartid]);
+    reg.write(APCR_COREX_DEFAULT_VATE_VALUE);
+}
+
+fn devote_core_apcr(hartid: usize) {
+    let reg = mmio_reg(APCR_CORE_VETE_REG[hartid]);
+    reg.write(0);
+}
+
+/// Wakes a core from a PMU low-power state.
+pub(crate) fn wakeup_core(hartid: usize) {
+    let reg = mmio_reg(PMU_CAP_CORE_WAKEUP[hartid]);
+    reg.write(1 << hartid);
+}
+
+/// Parks the first A100 core after preparing cluster 2 for warm boot.
+fn boot_entry_dummy() -> ! {
+    let hartid = crate::riscv::current_hartid();
+
+    // SAFETY: this K3 A100 parking entry runs in M-mode on a hart with these
+    // custom CSRs and fixed PMU register mappings.
+    unsafe {
+        csr_set::<CSR_PERF_CTRL>(PERF_CTRL_VEC_L1BYPASS);
+        csr_set::<CSR_PREFETCH_CTRL>(PREFETCH_CTRL_L2_PERF_DIST);
+        csr_clear::<CSR_ML2HINT>(ML2HINT_CIU_CHR2_DEPD_DIS);
+        csr_set::<CSR_ML2HINT>(ML2HINT_CIU_CHR2_MER_DIS);
+
+        // Keep the cluster powered until the parking state is prepared.
+        devote_pwrdown_cluster(hartid);
+        devote_core_apcr(hartid);
+
+        // Future cluster 2 wakeups must use the normal HSM warm entry.
+        warmboot_reg(C2_RVBADDR).set(warm_entry());
+
+        vote_powrdown_core(8);
+
+        csr_write::<0x14d>(usize::MAX); // CSR_STIMECMP
+
+        const MIP_ALL: usize = (1 << 1) | (1 << 3) | (1 << 5) | (1 << 7) | (1 << 9) | (1 << 11);
+        csr_clear::<0x304>(MIP_ALL); // CSR_MIE
+
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+
+        csr_clear::<CSR_ML2SETUP>(1 << (hartid % PLATFORM_MAX_CPUS_PER_CLUSTER));
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+    }
+
+    loop {
+        // SAFETY: WFI runs after interrupts and power votes are configured.
+        unsafe { asm!("wfi", options(nomem, nostack)) };
+    }
+}
+
+/// Enables CCI-550 snoop and DVM messages on a slave interface.
+///
+/// # Safety
+///
+/// Must only be called once per interface during cold boot. `slave_if_id`
+/// must be a valid CCI-550 slave interface index (0..6).
+unsafe fn cci_enable_snoop_dvm_reqs(slave_if_id: usize) {
+    // SAFETY: the function contract limits access to the K3 CCI-550 and a
+    // valid slave interface.
+    let cci = unsafe { &*CCI_550_BASE };
+    let iface = unsafe { cci.slave_iface(slave_if_id) };
+
+    iface
+        .snoop_ctrl
+        .write(CCI_550_SNOOP_CTRL_ENABLE_SNOOPS | CCI_550_SNOOP_CTRL_ENABLE_DVMS);
+
+    core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+
+    while cci.change_pending() {}
+}
+
+/// # Safety
+///
+/// Must only be called once during cold boot on the boot hart.
+unsafe fn k3_pre_init(warmboot_addr: u64) {
+    // RVBADDR must be visible before a cluster can be woken.
+    for cluster in 0..4 {
+        let (rvbaddr, l2_flush_ctrl) = match cluster {
+            0 => (C0_RVBADDR, PMU_C0_L2_FLUSH_CTRL),
+            1 => (C1_RVBADDR, PMU_C1_L2_FLUSH_CTRL),
+            2 => (C2_RVBADDR, PMU_C2_L2_FLUSH_CTRL),
+            3 => (C3_RVBADDR, PMU_C3_L2_FLUSH_CTRL),
+            _ => unreachable!(),
+        };
+        warmboot_reg(rvbaddr).set(warmboot_addr);
+        mmio_reg(l2_flush_ctrl).write(PMU_L2_FLUSH_HW_EN | PMU_L2_FLUSH_HW_TYPE);
+    }
+
+    for slave_if_id in 0..=6 {
+        unsafe { cci_enable_snoop_dvm_reqs(slave_if_id) };
+    }
+
+    // Keep managed clusters powered, then use core 8 to install cluster 2's
+    // normal warm entry before it parks.
+    for hartid in 0..PLATFORM_MAX_CPUS {
+        devote_pwrdown_cluster(hartid);
+    }
+    warmboot_reg(C2_RVBADDR).set(boot_entry_dummy as *const () as usize as u64);
+    wakeup_core(8);
+
+    // DMASYS must be clocked and out of reset before CPUs access the full TCM.
+    mmio_reg(DMASYS_RESET).write(1);
+    mmio_reg(DMASYS_CLK_EN).write(1);
+}
+
+/// # Safety
+///
+/// Cold initialization must run once in M-mode on the K3 boot hart.
+pub unsafe fn early_init(cold_boot: bool, warmboot_addr: u64) {
+    if cold_boot {
+        unsafe { k3_pre_init(warmboot_addr) };
+    }
+}
+
+pub fn cold_boot_init() {
+    // SAFETY: platform detection selects this path once on the boot hart.
+    unsafe { early_init(true, warm_entry()) }
+}
+
+/// Performs per-hart K3 setup and permits cold boot only on hart 0.
+pub fn cold_boot_allowed(hart_id: usize) -> bool {
+    let cluster_bit = 1 << (hart_id % PLATFORM_MAX_CPUS_PER_CLUSTER);
+    // SAFETY: platform detection guarantees these K3 CSRs are present.
+    unsafe {
+        csr_set::<CSR_ML2SETUP>(cluster_bit | ML2SETUP_IPRF | ML2SETUP_TPRF);
+
+        if hart_id >= 8 {
+            csr_set::<CSR_PERF_CTRL>(PERF_CTRL_VEC_L1BYPASS);
+            csr_set::<CSR_PREFETCH_CTRL>(PREFETCH_CTRL_L2_PERF_DIST);
+            csr_clear::<CSR_ML2HINT>(ML2HINT_CIU_CHR2_DEPD_DIS);
+            csr_set::<CSR_ML2HINT>(ML2HINT_CIU_CHR2_MER_DIS);
+        }
+
+        csr_set::<CSR_ML2HINT>(ML2HINT_TRACE_TOP_ICGEN);
+
+        devote_pwrdown_cluster(hart_id);
+        devote_core_apcr(hart_id);
+    }
+    hart_id == 0
+}
+
+unsafe extern "C" {
+    #[link_name = "_start_warm_k3"]
+    static START_WARM_K3: u8;
+}
+
+pub fn warm_entry() -> u64 {
+    core::ptr::addr_of!(START_WARM_K3) as u64
+}
+#[inline]
+pub const fn max_cpus() -> usize {
+    PLATFORM_MAX_CPUS
+}
+
+#[inline]
+pub const fn cpus_per_cluster() -> usize {
+    PLATFORM_MAX_CPUS_PER_CLUSTER
+}
+
+#[inline]
+pub fn is_k3_compatible(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    lower.contains("k3")
+        || lower.contains("pico-itx")
+        || lower.contains("pico_itx")
+        || lower.contains("com260")
+        || lower.contains("fml13v05")
+}
+
+#[inline]
+pub fn is_k3_platform<'a>(model: &str, compatibles: impl IntoIterator<Item = &'a str>) -> bool {
+    let by_compatible = compatibles
+        .into_iter()
+        .any(|c| c.to_ascii_lowercase().starts_with("spacemit,k3"));
+    by_compatible || is_k3_compatible(model)
+}
+
+pub const RCPU0_RUNTIME_SPACE_BASE_ADDR: usize = 0x100200000;
+pub const RCPU0_RUNTIME_SPACE_SIZE: usize = 0x400000;
+pub const RCPU1_RUNTIME_SPACE_BASE_ADDR: usize = 0x100800000;
+pub const RCPU1_RUNTIME_SPACE_SIZE: usize = 0x400000;
+pub const RCPU_DTB_SPACE_BASE_ADDR: usize = 0x100d00000;
+pub const RCPU_DTB_SPACE_SIZE: usize = 0x100000;
+
+/// K3 register window emulated by M-mode for S-mode accesses.
+pub const REGISTER_PRESERVATION_BASE: usize = 0xd4282000;
+pub const REGISTER_PRESERVATION_SIZE: usize = 0x1000;
+
+const SATP64_MODE_SHIFT: usize = 60;
+const SV39_VPN_BITS: usize = 9;
+const SV39_VPN_MASK: usize = (1 << SV39_VPN_BITS) - 1;
+const SV39_VPN2_SHIFT: usize = 30;
+const SV39_VPN1_SHIFT: usize = 21;
+const SV39_VPN0_SHIFT: usize = 12; // PAGE_SHIFT
+const PTE_V: usize = 1 << 0; // valid
+const PTE_PPN_SHIFT: usize = 10;
+
+/// Translates an S-mode Sv39 virtual address for register emulation.
+pub fn s_addr_to_pa(addr: usize) -> Option<usize> {
+    // SAFETY: reading `satp` only observes the current hart's translation state.
+    unsafe {
+        let satp: usize;
+        core::arch::asm!("csrr {}, satp", out(reg) satp, options(nomem));
+        let mode = (satp >> SATP64_MODE_SHIFT) & 0xf;
+
+        if mode == 0 {
+            return Some(addr);
+        }
+        if mode != 8 {
+            return None;
+        }
+        let upper = addr >> 39;
+        let expected_upper = if addr & (1 << 38) == 0 {
+            0
+        } else {
+            (1 << 25) - 1
+        };
+        if upper != expected_upper {
+            return None;
+        }
+
+        let mut ppn = satp & ((1 << 44) - 1); // SATP64_PPN (44 bits)
+        let vpn = [
+            (addr >> SV39_VPN2_SHIFT) & SV39_VPN_MASK,
+            (addr >> SV39_VPN1_SHIFT) & SV39_VPN_MASK,
+            (addr >> SV39_VPN0_SHIFT) & SV39_VPN_MASK,
+        ];
+
+        for (i, &vpn_i) in vpn.iter().enumerate() {
+            let ptep = (ppn << 12) + vpn_i * core::mem::size_of::<usize>();
+            if !crate::firmware::supervisor_writable(ptep, core::mem::size_of::<usize>()) {
+                return None;
+            }
+            // SAFETY: `supervisor_writable` bounds the aligned PTE address to
+            // supervisor RAM outside firmware and K3 protected windows.
+            let pte = (ptep as *const usize).read_volatile();
+
+            let readable = pte & (1 << 1) != 0;
+            let writable = pte & (1 << 2) != 0;
+            let executable = pte & (1 << 3) != 0;
+            if pte & PTE_V == 0 || (!readable && writable) {
+                return None;
+            }
+
+            ppn = (pte >> PTE_PPN_SHIFT) & ((1 << 44) - 1);
+
+            if readable || executable {
+                let pg_off_bits = 12 + SV39_VPN_BITS * (2 - i);
+                let offset_mask = (1usize << pg_off_bits) - 1;
+                let page_base = ppn << 12;
+                if page_base & offset_mask != 0 {
+                    return None;
+                }
+                return Some(page_base | (addr & offset_mask));
+            }
+        }
+        None
+    }
+}
+
+/// M-mode-only subranges of the emulated K3 register window.
+struct AddrRange {
+    base: usize,
+    size: usize,
+}
+
+const fn addr_range(base: usize, size: usize) -> AddrRange {
+    AddrRange { base, size }
+}
+
+const M_ONLY_RANGES: [AddrRange; 11] = [
+    addr_range(0xd4282db0, 2 * 4),          // C0_RVBADDR LO/HI
+    addr_range(0xd4282c00 + 0x2b0, 2 * 4),  // C1_RVBADDR LO/HI
+    addr_range(0xd4282c00 + 0x3e8, 2 * 4),  // C2_RVBADDR LO/HI
+    addr_range(0xd4282c00 + 0x260, 2 * 4),  // C3_RVBADDR LO/HI
+    addr_range(0xd4282800 + 0xe4, 4),       // PMU_CX_CAPMP_IDLE_CFG1
+    addr_range(0xd4282800 + 0x120, 7 * 4),  // CFG0, IDLE_CFG0/1, WAKEUP0-3
+    addr_range(0xd4282800 + 0x150, 2 * 4),  // CFG2/3
+    addr_range(0xd4282800 + 0x160, 2 * 4),  // IDLE_CFG2/3
+    addr_range(0xd4282800 + 0x20c, 12 * 4), // IDLE_CFG12-15, CX_CFG12-15, WAKEUP12-15
+    addr_range(0xd4282800 + 0x304, 12 * 4), // IDLE_CFG4-7, CX_CFG4-7, WAKEUP4-7
+    addr_range(0xd4282800 + 0x340, 12 * 4), // IDLE_CFG8-11, CX_CFG8-11, WAKEUP8-11
+];
+
+fn pa_is_m_only(pa: usize, len: usize) -> bool {
+    let Some(end) = pa.checked_add(len) else {
+        return false;
+    };
+    M_ONLY_RANGES.iter().any(|range| {
+        range
+            .base
+            .checked_add(range.size)
+            .is_some_and(|range_end| pa >= range.base && end <= range_end)
+    })
+}
+
+/// Emulates a permitted S-mode load from the K3 register window.
+pub fn emulate_load(addr: usize, len: usize) -> Option<u64> {
+    let pa = s_addr_to_pa(addr)?;
+    let end = pa.checked_add(len)?;
+    let region_end = REGISTER_PRESERVATION_BASE.checked_add(REGISTER_PRESERVATION_SIZE)?;
+
+    if !matches!(len, 1 | 2 | 4 | 8)
+        || !pa.is_multiple_of(len)
+        || pa < REGISTER_PRESERVATION_BASE
+        || end > region_end
+    {
+        return None;
+    }
+
+    if pa_is_m_only(pa, len) {
+        return None;
+    }
+
+    // SAFETY: `pa` is within the verified REGISTER_PRESERVATION window.
+    Some(match len {
+        1 => unsafe { (pa as *const u8).read_volatile() as u64 },
+        2 => unsafe { (pa as *const u16).read_volatile() as u64 },
+        4 => unsafe { (pa as *const u32).read_volatile() as u64 },
+        8 => unsafe { (pa as *const u64).read_volatile() },
+        _ => return None,
+    })
+}
+
+/// Emulates a permitted S-mode store to the K3 register window.
+pub fn emulate_store(addr: usize, len: usize, val: u64) -> bool {
+    let pa = match s_addr_to_pa(addr) {
+        Some(pa) => pa,
+        None => return false,
+    };
+
+    let Some(end) = pa.checked_add(len) else {
+        return false;
+    };
+    let Some(region_end) = REGISTER_PRESERVATION_BASE.checked_add(REGISTER_PRESERVATION_SIZE)
+    else {
+        return false;
+    };
+    if !matches!(len, 1 | 2 | 4 | 8)
+        || !pa.is_multiple_of(len)
+        || pa < REGISTER_PRESERVATION_BASE
+        || end > region_end
+    {
+        return false;
+    }
+
+    if pa_is_m_only(pa, len) {
+        return false;
+    }
+
+    // SAFETY: `pa` is within the verified REGISTER_PRESERVATION window.
+    match len {
+        1 => unsafe { (pa as *mut u8).write_volatile(val as u8) },
+        2 => unsafe { (pa as *mut u16).write_volatile(val as u16) },
+        4 => unsafe { (pa as *mut u32).write_volatile(val as u32) },
+        8 => unsafe { (pa as *mut u64).write_volatile(val) },
+        _ => return false,
+    }
+    true
+}
+
+const IMSIC_EIDELIVERY: usize = 0x70;
+const IMSIC_EITHRESHOLD: usize = 0x72;
+const IMSIC_FIRST_EIE_REG: usize = 0xc0;
+const MAX_IMSIC_EIE_REGISTERS: usize = 64;
+const IMSIC_MAX_VGEN: usize = 0x8;
+
+const TOPEI_ID_SHIFT: usize = 16;
+
+const CSR_MISELECT: usize = 0x350;
+const CSR_MIREG: usize = 0x351;
+const CSR_SISELECT: usize = 0x150;
+const CSR_SIREG: usize = 0x151;
+const CSR_VSISELECT: usize = 0x250;
+const CSR_VSIREG: usize = 0x251;
+
+const MIP_ALL: usize = (1 << 1) | (1 << 3) | (1 << 5) | (1 << 7) | (1 << 9) | (1 << 11);
+
+/// IMSIC interrupt state saved across suspend. M- and S-mode state exists on
+/// every managed hart; H/VS state exists only on X100 harts (`hartid < 8`).
+#[derive(Clone, Copy, Default)]
+pub struct ImsicConfig {
+    pub meidelivery: usize,
+    pub meithreshold: usize,
+    pub meie: [usize; MAX_IMSIC_EIE_REGISTERS / 2],
+    pub seidelivery: usize,
+    pub seithreshold: usize,
+    pub seie: [usize; MAX_IMSIC_EIE_REGISTERS / 2],
+    pub hstatus: usize,
+    pub hedeleg: usize,
+    pub hideleg: usize,
+    pub hie: usize,
+    pub hcounteren: usize,
+    pub hgeie: usize,
+    pub henvcfg: usize,
+    pub htval: usize,
+    pub hgatp: usize,
+    pub htimedelta: usize,
+    pub hc: [HimsicConfig; IMSIC_MAX_VGEN],
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct HimsicConfig {
+    pub heidelivery: usize,
+    pub heithreshold: usize,
+    pub heie: [usize; MAX_IMSIC_EIE_REGISTERS / 2],
+}
+
+/// Reads an indirect AIA CSR and restores the previous selector.
+///
+/// # Safety
+///
+/// The current hart must implement Smaia and be permitted to access the
+/// corresponding privilege-level CSRs.
+#[inline]
+unsafe fn indirect_read<const SELECT: u16, const REG: u16>(reg_id: usize) -> usize {
+    unsafe {
+        let prev: usize;
+        core::arch::asm!(
+            "csrrw {prev}, {sel}, {id}",
+            prev = out(reg) prev,
+            sel = const SELECT,
+            id = in(reg) reg_id,
+            options(nomem),
+        );
+        let value: usize;
+        core::arch::asm!(
+            "csrr {val}, {reg}",
+            val = out(reg) value,
+            reg = const REG,
+            options(nomem),
+        );
+        core::arch::asm!(
+            "csrw {sel}, {prev}",
+            sel = const SELECT,
+            prev = in(reg) prev,
+            options(nomem),
+        );
+        value
+    }
+}
+
+/// Writes an indirect AIA CSR and restores the previous selector.
+///
+/// # Safety
+///
+/// The current hart must implement Smaia and be permitted to access the
+/// corresponding privilege-level CSRs.
+#[inline]
+unsafe fn indirect_write<const SELECT: u16, const REG: u16>(reg_id: usize, value: usize) {
+    unsafe {
+        let prev: usize;
+        core::arch::asm!(
+            "csrrw {prev}, {sel}, {id}",
+            prev = out(reg) prev,
+            sel = const SELECT,
+            id = in(reg) reg_id,
+            options(nomem),
+        );
+        core::arch::asm!(
+            "csrw {reg}, {val}",
+            reg = const REG,
+            val = in(reg) value,
+            options(nomem),
+        );
+        core::arch::asm!(
+            "csrw {sel}, {prev}",
+            sel = const SELECT,
+            prev = in(reg) prev,
+            options(nomem),
+        );
+    }
+}
+
+/// Saves the M-/S-mode IMSIC interrupt-file state of the current hart.
+///
+/// # Safety
+///
+/// The current hart must implement Smaia.
+pub unsafe fn imsic_save_machine_supervisor(state: &mut ImsicConfig) {
+    unsafe {
+        state.meithreshold =
+            indirect_read::<{ CSR_MISELECT as u16 }, { CSR_MIREG as u16 }>(IMSIC_EITHRESHOLD);
+        state.meidelivery =
+            indirect_read::<{ CSR_MISELECT as u16 }, { CSR_MIREG as u16 }>(IMSIC_EIDELIVERY);
+        for (i, sel) in (0..MAX_IMSIC_EIE_REGISTERS).step_by(2).enumerate() {
+            state.meie[i] = indirect_read::<{ CSR_MISELECT as u16 }, { CSR_MIREG as u16 }>(
+                IMSIC_FIRST_EIE_REG + sel,
+            );
+        }
+
+        state.seithreshold =
+            indirect_read::<{ CSR_SISELECT as u16 }, { CSR_SIREG as u16 }>(IMSIC_EITHRESHOLD);
+        state.seidelivery =
+            indirect_read::<{ CSR_SISELECT as u16 }, { CSR_SIREG as u16 }>(IMSIC_EIDELIVERY);
+        for (i, sel) in (0..MAX_IMSIC_EIE_REGISTERS).step_by(2).enumerate() {
+            state.seie[i] = indirect_read::<{ CSR_SISELECT as u16 }, { CSR_SIREG as u16 }>(
+                IMSIC_FIRST_EIE_REG + sel,
+            );
+        }
+    }
+}
+
+/// Restores the M-/S-mode IMSIC interrupt-file state of the current hart.
+///
+/// # Safety
+///
+/// The current hart must implement Smaia.
+pub unsafe fn imsic_restore_machine_supervisor(state: &ImsicConfig) {
+    unsafe {
+        indirect_write::<{ CSR_MISELECT as u16 }, { CSR_MIREG as u16 }>(
+            IMSIC_EITHRESHOLD,
+            state.meithreshold,
+        );
+        indirect_write::<{ CSR_MISELECT as u16 }, { CSR_MIREG as u16 }>(
+            IMSIC_EIDELIVERY,
+            state.meidelivery,
+        );
+        for (i, sel) in (0..MAX_IMSIC_EIE_REGISTERS).step_by(2).enumerate() {
+            indirect_write::<{ CSR_MISELECT as u16 }, { CSR_MIREG as u16 }>(
+                IMSIC_FIRST_EIE_REG + sel,
+                state.meie[i],
+            );
+        }
+
+        indirect_write::<{ CSR_SISELECT as u16 }, { CSR_SIREG as u16 }>(
+            IMSIC_EITHRESHOLD,
+            state.seithreshold,
+        );
+        indirect_write::<{ CSR_SISELECT as u16 }, { CSR_SIREG as u16 }>(
+            IMSIC_EIDELIVERY,
+            state.seidelivery,
+        );
+        for (i, sel) in (0..MAX_IMSIC_EIE_REGISTERS).step_by(2).enumerate() {
+            indirect_write::<{ CSR_SISELECT as u16 }, { CSR_SIREG as u16 }>(
+                IMSIC_FIRST_EIE_REG + sel,
+                state.seie[i],
+            );
+        }
+    }
+}
+
+/// Saves the H/VS-mode IMSIC state of an X100 hart (`hartid < 8`).
+///
+/// # Safety
+///
+/// The current hart must implement Smaia and the hypervisor extension.
+pub unsafe fn imsic_save_hypervisor(state: &mut ImsicConfig) {
+    unsafe {
+        state.hstatus = csr_read_raw::<0x600>(); // CSR_HSTATUS
+        state.hedeleg = csr_read_raw::<0x602>(); // CSR_HEDELEG
+        state.hideleg = csr_read_raw::<0x603>(); // CSR_HIDELEG
+        state.hie = csr_read_raw::<0x604>(); // CSR_HIE
+        state.hcounteren = csr_read_raw::<0x606>(); // CSR_HCOUNTEREN
+        state.hgeie = csr_read_raw::<0x607>(); // CSR_HGEIE
+        state.henvcfg = csr_read_raw::<0x60a>(); // CSR_HENVCFG
+        state.htval = csr_read_raw::<0x643>(); // CSR_HTVAL
+        state.hgatp = csr_read_raw::<0x680>(); // CSR_HGATP
+        state.htimedelta = csr_read_raw::<0x605>(); // CSR_HTIMEDELTA
+
+        for k in 1..IMSIC_MAX_VGEN {
+            let s = (state.hstatus & !(0x3f << 12)) | (k << 12);
+            csr_write_raw::<0x600>(s); // set HSTATUS.VGEIN = k
+
+            state.hc[k].heithreshold =
+                indirect_read::<{ CSR_VSISELECT as u16 }, { CSR_VSIREG as u16 }>(IMSIC_EITHRESHOLD);
+            state.hc[k].heidelivery =
+                indirect_read::<{ CSR_VSISELECT as u16 }, { CSR_VSIREG as u16 }>(IMSIC_EIDELIVERY);
+            for (i, sel) in (0..MAX_IMSIC_EIE_REGISTERS).step_by(2).enumerate() {
+                state.hc[k].heie[i] = indirect_read::<
+                    { CSR_VSISELECT as u16 },
+                    { CSR_VSIREG as u16 },
+                >(IMSIC_FIRST_EIE_REG + sel);
+            }
+        }
+    }
+}
+
+/// Restores the H/VS-mode IMSIC state of an X100 hart (`hartid < 8`).
+///
+/// # Safety
+///
+/// The current hart must implement Smaia and the hypervisor extension.
+pub unsafe fn imsic_restore_hypervisor(state: &ImsicConfig) {
+    unsafe {
+        for k in 1..IMSIC_MAX_VGEN {
+            let s = (state.hstatus & !(0x3f << 12)) | (k << 12);
+            csr_write_raw::<0x600>(s);
+
+            indirect_write::<{ CSR_VSISELECT as u16 }, { CSR_VSIREG as u16 }>(
+                IMSIC_EITHRESHOLD,
+                state.hc[k].heithreshold,
+            );
+            indirect_write::<{ CSR_VSISELECT as u16 }, { CSR_VSIREG as u16 }>(
+                IMSIC_EIDELIVERY,
+                state.hc[k].heidelivery,
+            );
+            for (i, sel) in (0..MAX_IMSIC_EIE_REGISTERS).step_by(2).enumerate() {
+                indirect_write::<{ CSR_VSISELECT as u16 }, { CSR_VSIREG as u16 }>(
+                    IMSIC_FIRST_EIE_REG + sel,
+                    state.hc[k].heie[i],
+                );
+            }
+        }
+
+        csr_write_raw::<0x602>(state.hedeleg);
+        csr_write_raw::<0x603>(state.hideleg);
+        csr_write_raw::<0x604>(state.hie);
+        csr_write_raw::<0x606>(state.hcounteren);
+        csr_write_raw::<0x607>(state.hgeie);
+        csr_write_raw::<0x60a>(state.henvcfg);
+        csr_write_raw::<0x643>(state.htval);
+        csr_write_raw::<0x680>(state.hgatp);
+        csr_write_raw::<0x605>(state.htimedelta);
+        csr_write_raw::<0x600>(state.hstatus);
+    }
+}
+
+/// # Safety
+///
+/// The CSR must be implemented on the current hart.
+#[inline]
+unsafe fn csr_read_raw<const CSR: u16>() -> usize {
+    let value: usize;
+    unsafe {
+        core::arch::asm!("csrr {val}, {csr}", val = out(reg) value, csr = const CSR, options(nomem));
+    }
+    value
+}
+
+/// # Safety
+///
+/// The CSR must be implemented on the current hart.
+#[inline]
+unsafe fn csr_write_raw<const CSR: u16>(value: usize) {
+    unsafe {
+        core::arch::asm!("csrw {csr}, {val}", csr = const CSR, val = in(reg) value, options(nomem));
+    }
+}
+
+fn mask_irq(hartid: usize) {
+    let reg = mmio_reg(PMU_CAP_CORE_IDLE_CFG[hartid]);
+    reg.write(reg.read() | CPU_MASK_FI_INTTERUPT);
+}
+
+fn unmask_irq(hartid: usize) {
+    let reg = mmio_reg(PMU_CAP_CORE_IDLE_CFG[hartid]);
+    reg.write(reg.read() & !CPU_MASK_FI_INTTERUPT);
+}
+
+/// Prepares the current hart for suspend. Five consecutive IMSIC checks must
+/// observe no M/S/VS interrupt before power votes are applied.
+///
+/// Returns `true` if the hart may proceed with suspend.
+pub fn suspend_pre(hartid: usize) -> bool {
+    mask_irq(hartid);
+
+    let mut retry_count = 5usize;
+
+    while retry_count != 0 {
+        retry_count -= 1;
+
+        // SAFETY: K3 harts implement the Smaia top-interrupt CSRs; X100 harts
+        // also implement HGEIP.
+        if unsafe { csr_read_raw::<0x15c>() } >> TOPEI_ID_SHIFT != 0 {
+            unmask_irq(hartid);
+            return false;
+        }
+        if unsafe { csr_read_raw::<0x35c>() } >> TOPEI_ID_SHIFT != 0 {
+            unmask_irq(hartid);
+            return false;
+        }
+        if hartid < 8 && unsafe { csr_read_raw::<0xe12>() } != 0 {
+            unmask_irq(hartid);
+            return false;
+        }
+    }
+
+    vote_core_apcr(hartid);
+    vote_powrdown_cluster(12);
+    true
+}
+
+/// Performs the K3 non-retentive suspend sequence.
+pub fn suspend(hartid: usize, sleep_type: u32, state: &mut ImsicConfig) {
+    const SBI_HSM_SUSP_NON_RET_BIT: u32 = 1 << 0;
+    const SBI_HSM_SUSP_PLAT_BASE: u32 = 0x10000000;
+
+    mask_irq(hartid);
+
+    // SAFETY: K3 harts implement Smaia, and X100 harts implement H-mode.
+    unsafe {
+        imsic_save_machine_supervisor(state);
+        if hartid < 8 {
+            imsic_save_hypervisor(state);
+        }
+    }
+
+    // Harts 8 and 12 vote only their own core. Platform suspend also uses a
+    // core vote; regular suspend votes the whole cluster.
+    if hartid == 8 || hartid == 12 {
+        vote_powrdown_core(hartid);
+    } else if sleep_type == (SBI_HSM_SUSP_NON_RET_BIT | SBI_HSM_SUSP_PLAT_BASE) {
+        vote_powrdown_core(hartid);
+    } else {
+        vote_powrdown_cluster(hartid);
+    }
+
+    // SAFETY: platform detection guarantees the K3 cache-control CSR.
+    unsafe {
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+
+        csr_clear::<CSR_ML2SETUP>(1 << (hartid % PLATFORM_MAX_CPUS_PER_CLUSTER));
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+
+        core::arch::asm!("wfi", options(nomem, nostack));
+
+        csr_set::<CSR_ML2SETUP>(1 << (hartid % PLATFORM_MAX_CPUS_PER_CLUSTER));
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+    }
+
+    // SAFETY: the same hardware prerequisites apply to restoration.
+    unsafe {
+        imsic_restore_machine_supervisor(state);
+        if hartid < 8 {
+            imsic_restore_hypervisor(state);
+        }
+    }
+
+    unmask_irq(hartid);
+}
+
+/// Powers down the current hart and waits indefinitely in `wfi`.
+pub fn shutdown_process(hartid: usize) -> ! {
+    mask_irq(hartid);
+
+    if hartid == 8 || hartid == 12 {
+        vote_powrdown_core(hartid);
+    } else {
+        vote_powrdown_cluster(hartid);
+    }
+    vote_core_apcr(hartid);
+
+    // SAFETY: platform detection guarantees these K3 machine CSRs.
+    unsafe {
+        csr_write::<0x14d>(usize::MAX); // CSR_STIMECMP
+
+        csr_clear::<0x304>(MIP_ALL); // CSR_MIE
+
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+        csr_clear::<CSR_ML2SETUP>(1 << (hartid % PLATFORM_MAX_CPUS_PER_CLUSTER));
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+    }
+
+    loop {
+        // SAFETY: the hart has completed the K3 shutdown sequence.
+        unsafe { asm!("wfi", options(nomem, nostack)) };
+    }
+}
+
+/// Delegates the K3 wired interrupt range from the M-level to S-level APLIC.
+pub fn init_maplic_delegation() {
+    if !crate::platform::IS_K3_PLATFORM.load(core::sync::atomic::Ordering::Acquire) {
+        return;
+    }
+    const MAPLIC_BASE: usize = 0xf180_0000;
+    const APLIC_DOMAINCFG: usize = 0x0000;
+    const APLIC_SOURCECFG_BASE: usize = 0x0004;
+    const APLIC_SOURCECFG_D: u32 = 1 << 10;
+    const CHILD_INDEX_SAPLIC: u32 = 0;
+    const FIRST_DELEG_IRQ: u32 = 1;
+    const LAST_DELEG_IRQ: u32 = 0x200;
+
+    #[inline]
+    fn wr(base: usize, off: usize, val: u32) {
+        // SAFETY: callers pass aligned offsets in the detected K3 APLIC.
+        unsafe { core::ptr::write_volatile((base + off) as *mut u32, val) }
+    }
+
+    const APLIC_CLRIE_BASE: usize = 0x1f00;
+    const APLIC_TARGET_BASE: usize = 0x3004;
+    const APLIC_MMSICFGADDR: usize = 0x1bc0;
+    const APLIC_MMSICFGADDRH: usize = 0x1bc4;
+    const APLIC_SMSICFGADDR: usize = 0x1bc8;
+    const APLIC_SMSICFGADDRH: usize = 0x1bcc;
+
+    #[inline]
+    fn rd(base: usize, off: usize) -> u32 {
+        // SAFETY: callers pass aligned offsets in the detected K3 APLIC.
+        unsafe { core::ptr::read_volatile((base + off) as *const u32) }
+    }
+
+    wr(MAPLIC_BASE, APLIC_DOMAINCFG, 0);
+    for i in (0..=LAST_DELEG_IRQ).step_by(32) {
+        wr(
+            MAPLIC_BASE,
+            APLIC_CLRIE_BASE + (i as usize / 32) * 4,
+            u32::MAX,
+        );
+    }
+    for i in FIRST_DELEG_IRQ..=LAST_DELEG_IRQ {
+        let src_off = APLIC_SOURCECFG_BASE + (i - 1) as usize * 4;
+        wr(MAPLIC_BASE, src_off, 0);
+        wr(MAPLIC_BASE, APLIC_TARGET_BASE + (i - 1) as usize * 4, 1);
+        wr(MAPLIC_BASE, src_off, APLIC_SOURCECFG_D | CHILD_INDEX_SAPLIC);
+    }
+    // The AIA root APLIC owns both IMSIC address configurations. Preserve a
+    // firmware-locked configuration and otherwise use the K3 DT encodings.
+    let m_h = rd(MAPLIC_BASE, APLIC_MMSICFGADDRH);
+    if m_h & (1 << 31) == 0 {
+        wr(MAPLIC_BASE, APLIC_MMSICFGADDR, 0x000f_1000);
+        wr(MAPLIC_BASE, APLIC_MMSICFGADDRH, 0x0000_4000);
+    }
+    let s_h = rd(MAPLIC_BASE, APLIC_SMSICFGADDRH);
+    if s_h & (1 << 31) == 0 {
+        wr(MAPLIC_BASE, APLIC_SMSICFGADDR, 0x000e_0400);
+        wr(MAPLIC_BASE, APLIC_SMSICFGADDRH, 0x0060_4000);
+    }
+    info!(
+        "[MAplic] delegated IRQ 1..=0x200 to saplic; msicfg m=0x{:x}/0x{:x} s=0x{:x}/0x{:x}",
+        rd(MAPLIC_BASE, APLIC_MMSICFGADDR),
+        rd(MAPLIC_BASE, APLIC_MMSICFGADDRH),
+        rd(MAPLIC_BASE, APLIC_SMSICFGADDR),
+        rd(MAPLIC_BASE, APLIC_SMSICFGADDRH)
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::offset_of;
+
+    #[test]
+    fn test_topology() {
+        assert_eq!(max_cpus(), 8);
+        assert_eq!(cpus_per_cluster(), 4);
+        assert_eq!(cpu_to_cluster(0), 0);
+        assert_eq!(cpu_to_cluster(3), 0);
+        assert_eq!(cpu_to_cluster(4), 1);
+        assert_eq!(cpu_to_cluster(7), 1);
+    }
+
+    #[test]
+    fn test_compatible() {
+        assert!(is_k3_compatible("SpacemiT K3 Pico-ITX"));
+        assert!(is_k3_compatible("SpacemiT K3 CoM260 Module"));
+        assert!(is_k3_compatible("SpacemiT K3 CoM260 IFX"));
+        assert!(is_k3_compatible("DeepComputing FML13V05"));
+        assert!(!is_k3_compatible("OrangePi RV2"));
+        assert!(!is_k3_compatible("sifive,fu740"));
+    }
+
+    #[test]
+    fn test_platform_detection() {
+        assert!(is_k3_platform("", ["spacemit,k3"]));
+        assert!(is_k3_platform("SpacemiT K3", ["riscv-spacemit"]));
+        assert!(!is_k3_platform("", ["riscv-spacemit"]));
+        assert!(is_k3_platform("", ["spacemit,k3-pico-itx", "spacemit,k3"]));
+        assert!(is_k3_platform("", ["spacemit,k3-com260", "spacemit,k3"]));
+        assert!(is_k3_platform(
+            "",
+            ["spacemit,k3-com260-ifx", "spacemit,k3"]
+        ));
+        assert!(is_k3_platform(
+            "",
+            ["deepcomputing,fml13v05", "spacemit,k3"]
+        ));
+        assert!(is_k3_platform("SpacemiT K3 Pico-ITX", ["sifive,fu740"]));
+        assert!(!is_k3_platform("OrangePi RV2", ["spacemit,k1"]));
+        assert!(!is_k3_platform("Sifive FU740", ["sifive,fu740"]));
+    }
+
+    #[test]
+    fn test_register_layout() {
+        assert_eq!(core::mem::size_of::<MmioReg>(), 4);
+        assert_eq!(offset_of!(WarmbootAddr, lo), 0x0);
+        assert_eq!(offset_of!(WarmbootAddr, hi), 0x4);
+        assert_eq!(core::mem::size_of::<WarmbootAddr>(), 8);
+        assert_eq!(offset_of!(Cci550Registers, status), 0x000c);
+        assert_eq!(offset_of!(CciSlaveIfaceRegisters, snoop_ctrl), 0x0);
+        assert_eq!(cci_slave_iface_offset(0), 0x1000);
+        assert_eq!(cci_slave_iface_offset(3), 0x4000);
+    }
+
+    #[test]
+    fn test_register_addresses() {
+        assert_eq!(C0_RVBADDR as usize, 0xd4282db0);
+        assert_eq!(C1_RVBADDR as usize, 0xd4282eb0);
+        assert_eq!(C2_RVBADDR as usize, 0xd4282fe8);
+        assert_eq!(C3_RVBADDR as usize, 0xd4282e60);
+        assert_eq!(PMU_CAP_CORE_WAKEUP[0] as usize, 0xd428292c);
+        assert_eq!(PMU_CAP_CORE_WAKEUP[8] as usize, 0xd4282b60);
+        assert_eq!(PMU_CAP_CORE_IDLE_CFG[8] as usize, 0xd4282b40);
+        assert_eq!(PMU_CAP_CORE_IDLE_CFG[0] as usize, 0xd4282924);
+        assert_eq!(APCR_CORE_VETE_REG[0] as usize, 0xd40510c0);
+        assert_eq!(APCR_CORE_VETE_REG[15] as usize, 0xd40510fc);
+        assert_eq!(PMU_C0_L2_FLUSH_CTRL as usize, 0xd84401b0);
+        assert_eq!(PMU_C3_L2_FLUSH_CTRL as usize, 0xd84401ec);
+        assert_eq!(DMASYS_RESET as usize, 0xd844022c);
+        assert_eq!(DMASYS_CLK_EN as usize, 0xd8440234);
+    }
+
+    #[test]
+    fn test_m_only_ranges() {
+        assert!(pa_is_m_only(0xd4282db0, 4));
+        assert!(pa_is_m_only(0xd4282db4, 4));
+        assert!(pa_is_m_only(0xd4282fe8, 8));
+        assert!(pa_is_m_only(0xd4282b40, 4));
+        assert!(!pa_is_m_only(0xd4283000, 4)); // outside M-only ranges
+    }
+
+    #[test]
+    fn test_imsic_config_layout() {
+        assert_eq!(core::mem::size_of::<u64>(), 8);
+        let cfg = ImsicConfig::default();
+        assert_eq!(cfg.meie.len(), 32);
+        assert_eq!(cfg.seie.len(), 32);
+        assert_eq!(cfg.hc.len(), 8);
+        let himsic = HimsicConfig::default();
+        assert_eq!(himsic.heie.len(), 32);
+        assert_eq!(IMSIC_EIDELIVERY, 0x70);
+        assert_eq!(IMSIC_EITHRESHOLD, 0x72);
+        assert_eq!(IMSIC_FIRST_EIE_REG, 0xc0);
+        assert_eq!(MAX_IMSIC_EIE_REGISTERS, 64);
+        assert_eq!(IMSIC_MAX_VGEN, 8);
+    }
+}

--- a/firmware/prototyper/src/rpmi.rs
+++ b/firmware/prototyper/src/rpmi.rs
@@ -1,0 +1,749 @@
+//! RPMI shared-memory mailbox transport.
+//!
+use alloc::{boxed::Box, vec, vec::Vec};
+use core::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicU16, Ordering},
+};
+
+use log::warn;
+use rpmi::message::{MessageHeader, MessageType, Status};
+use spin::Mutex;
+
+/// Size of an RPMI message header.
+pub const RPMI_MSG_HDR_SIZE: usize = 8;
+/// Default transfer timeouts in milliseconds.
+pub const RPMI_DEF_TX_TIMEOUT: u32 = 500;
+pub const RPMI_DEF_RX_TIMEOUT: u32 = 500;
+
+const QUEUE_HEADER_SLOTS: usize = 2;
+const MAILBOX_DOORBELL_TRIGGER_OFFSET: usize = 0x40;
+const MAILBOX_INT_EN_REG_OFFSET: usize = 0x118;
+
+/// Discovers and constructs the platform RPMI shared-memory mailbox.
+pub fn discover_mailbox(root: &serde_device_tree::buildin::Node) -> Option<&'static RpmiMailbox> {
+    let timebase_frequency = root
+        .find("/cpus")?
+        .get_prop("timebase-frequency")?
+        .deserialize::<u32>();
+    if timebase_frequency == 0 {
+        warn!("rpmi-shmem-mbox: invalid timebase frequency");
+        return None;
+    }
+    let mut mailbox = None;
+    crate::devicetree::search_with_parent(root, &mut |node, _| {
+        if mailbox.is_some() {
+            return;
+        }
+        let Some(compatible) = node.get_prop("compatible") else {
+            return;
+        };
+        let compatible = compatible.deserialize::<serde_device_tree::buildin::StrSeq>();
+        if !compatible
+            .iter()
+            .any(|value| value == "riscv,rpmi-shmem-mbox")
+        {
+            return;
+        }
+        let Some(slot_size) = crate::platform::prop_u32_cells(node, "riscv,slot-size")
+            .and_then(|cells| cells.first().copied())
+            .map(|value| value as usize)
+        else {
+            warn!("rpmi-shmem-mbox: missing slot size");
+            return;
+        };
+        let Some(reg) = node.get_prop("reg") else {
+            warn!("rpmi-shmem-mbox: missing register regions");
+            return;
+        };
+        let reg = reg.deserialize::<serde_device_tree::buildin::Reg>();
+        let ranges: Vec<_> = reg.iter().map(|entry| entry.0).collect();
+        if slot_size < 64
+            || !slot_size.is_power_of_two()
+            || slot_size - RPMI_MSG_HDR_SIZE > u16::MAX as usize
+            || ranges.len() < 5
+        {
+            warn!("rpmi-shmem-mbox: invalid queue layout");
+            return;
+        }
+        let Some(headers_size) = QUEUE_HEADER_SLOTS.checked_mul(slot_size) else {
+            warn!("rpmi-shmem-mbox: invalid slot size");
+            return;
+        };
+        let Some(queue_min_size) = slot_size
+            .checked_mul(2)
+            .and_then(|slots_size| headers_size.checked_add(slots_size))
+        else {
+            warn!("rpmi-shmem-mbox: invalid slot size");
+            return;
+        };
+        if ranges[..4].iter().any(|range| {
+            range.start % slot_size != 0
+                || range.len() < queue_min_size
+                || (range.len() - headers_size) % slot_size != 0
+        }) || ranges[0].len() != ranges[1].len()
+            || ranges[2].len() != ranges[3].len()
+        {
+            warn!("rpmi-shmem-mbox: invalid queue region size");
+            return;
+        }
+
+        let queues = core::array::from_fn(|index| {
+            let range = &ranges[index];
+            let base = range.start as *mut u8;
+            let num_slots = range.len().saturating_sub(headers_size) / slot_size;
+            // SAFETY: the compatible node supplies shared queue memory, and
+            // the size and alignment checks above cover every queue slot.
+            unsafe {
+                SmqQueue::new(
+                    base.cast(),
+                    base.add(slot_size).cast(),
+                    base.add(headers_size),
+                    slot_size,
+                    num_slots,
+                )
+            }
+        });
+        let doorbell_base = ranges[4].start;
+        if doorbell_base % core::mem::align_of::<Le32>() != 0
+            || ranges[4].len() < MAILBOX_INT_EN_REG_OFFSET + core::mem::size_of::<Le32>()
+        {
+            warn!("rpmi-shmem-mbox: invalid doorbell region");
+            return;
+        }
+        let Some(interrupt_enable) = doorbell_base
+            .checked_add(MAILBOX_INT_EN_REG_OFFSET)
+            .map(|address| address as *const Le32)
+        else {
+            warn!("rpmi-shmem-mbox: invalid doorbell address");
+            return;
+        };
+        // SAFETY: the doorbell region bounds and alignment were validated.
+        unsafe { (*interrupt_enable).write(1) };
+        let Some(doorbell) = doorbell_base
+            .checked_add(MAILBOX_DOORBELL_TRIGGER_OFFSET)
+            .map(|address| address as *const Le32)
+        else {
+            warn!("rpmi-shmem-mbox: invalid doorbell address");
+            return;
+        };
+        // SAFETY: every queue has aligned headers and at least two complete
+        // slots, and the doorbell lies inside its FDT register region.
+        let transport = unsafe {
+            RpmiMailbox::new(
+                slot_size,
+                timebase_frequency as u64,
+                queues,
+                Some(&*doorbell),
+            )
+        };
+        mailbox = Some(Box::leak(Box::new(transport)) as &'static RpmiMailbox);
+    });
+    mailbox
+}
+
+/// Read the hart's mtime tick count via the TIME CSR.
+///
+/// The TIME CSR is readable in M-mode (the SBI ecall path) and, unlike
+/// `mcycle` (`mcountinhibit.CY`), cannot be inhibited.
+#[inline]
+fn mtime_ticks() -> u64 {
+    riscv::register::time::read64()
+}
+
+/// RPMI service-group identifiers used by Prototyper services.
+pub mod servicegroup {
+    /// Base service group.
+    pub const BASE: u16 = ::rpmi::base::SERVICE_GROUP_ID;
+    /// System reset service group.
+    pub const SYSTEM_RESET: u16 = ::rpmi::system_reset::SERVICE_GROUP_ID;
+    /// CPPC service group.
+    pub const CPPC: u16 = ::rpmi::cppc::SERVICE_GROUP_ID;
+    /// Voltage service group.
+    pub const VOLTAGE: u16 = ::rpmi::voltage::SERVICE_GROUP_ID;
+    /// Clock service group.
+    pub const CLOCK: u16 = ::rpmi::clock::SERVICE_GROUP_ID;
+    /// Device power domain service group.
+    pub const DOMAIN: u16 = ::rpmi::device_power::SERVICE_GROUP_ID;
+}
+
+/// CPPC register-probe request for the K3 management firmware.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CppcProbeReq {
+    /// Hart identifier.
+    pub hart_id: u32,
+    /// CPPC register identifier.
+    pub reg_id: u32,
+}
+
+/// CPPC register-read request for the K3 management firmware.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CppcReadReq {
+    /// Hart identifier.
+    pub hart_id: u32,
+    /// CPPC register identifier.
+    pub reg_id: u32,
+}
+
+/// CPPC register-write request for the K3 management firmware.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CppcWriteReq {
+    /// Hart identifier.
+    pub hart_id: u32,
+    /// CPPC register identifier.
+    pub reg_id: u32,
+    /// Lower 32 bits of the register value.
+    pub data_lo: u32,
+    /// Upper 32 bits of the register value.
+    pub data_hi: u32,
+}
+
+impl CppcProbeReq {
+    pub fn to_bytes(self) -> [u8; 8] {
+        let mut bytes = [0; 8];
+        bytes[..4].copy_from_slice(&self.hart_id.to_le_bytes());
+        bytes[4..].copy_from_slice(&self.reg_id.to_le_bytes());
+        bytes
+    }
+}
+
+impl CppcReadReq {
+    pub fn to_bytes(self) -> [u8; 8] {
+        let mut bytes = [0; 8];
+        bytes[..4].copy_from_slice(&self.hart_id.to_le_bytes());
+        bytes[4..].copy_from_slice(&self.reg_id.to_le_bytes());
+        bytes
+    }
+}
+
+impl CppcWriteReq {
+    pub fn to_bytes(self) -> [u8; 16] {
+        let mut bytes = [0; 16];
+        bytes[..4].copy_from_slice(&self.hart_id.to_le_bytes());
+        bytes[4..8].copy_from_slice(&self.reg_id.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.data_lo.to_le_bytes());
+        bytes[12..].copy_from_slice(&self.data_hi.to_le_bytes());
+        bytes
+    }
+}
+
+#[repr(transparent)]
+struct Le32(UnsafeCell<u32>);
+
+// SAFETY: accesses are volatile and ordered by the shared-memory queue
+// protocol; remote writes are expected while shared references exist.
+unsafe impl Send for Le32 {}
+// SAFETY: see the `Send` implementation above.
+unsafe impl Sync for Le32 {}
+
+impl Le32 {
+    #[inline]
+    fn read(&self) -> u32 {
+        // SAFETY: `self` aliases a shared-memory word; the volatile read
+        // cannot be cached or reordered by the compiler.
+        unsafe { u32::from_le(self.0.get().read_volatile()) }
+    }
+
+    #[inline]
+    fn write(&self, value: u32) {
+        // SAFETY: `self` aliases a shared-memory word; the volatile write
+        // cannot be elided or reordered by the compiler.
+        unsafe { self.0.get().write_volatile(value.to_le()) }
+    }
+}
+
+struct SmqQueue {
+    head: *const Le32,
+    tail: *const Le32,
+    buffer: *mut u8,
+    slot_size: usize,
+    num_slots: usize,
+}
+
+// SAFETY: the queue aliases shared memory accessed by both the AP and the
+// PuC; all accesses are volatile and guarded by the queue indices published
+// with release/acquire fences, so sharing the queue between harts (and the
+// dispatcher static) is sound.
+unsafe impl Send for SmqQueue {}
+unsafe impl Sync for SmqQueue {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QueueError {
+    Full,
+    Invalid,
+}
+
+impl SmqQueue {
+    /// Creates a queue view.
+    ///
+    /// # Safety
+    ///
+    /// `head`, `tail` and `buffer` must point into shared memory that is
+    /// accessible to both the AP and the PuC, and `slot_size * num_slots`
+    /// bytes must be readable/writable at `buffer`. `slot_size` must hold an
+    /// RPMI header and `num_slots` must be at least two.
+    const unsafe fn new(
+        head: *const Le32,
+        tail: *const Le32,
+        buffer: *mut u8,
+        slot_size: usize,
+        num_slots: usize,
+    ) -> Self {
+        Self {
+            head,
+            tail,
+            buffer,
+            slot_size,
+            num_slots,
+        }
+    }
+
+    fn indices(&self) -> Option<(usize, usize)> {
+        // SAFETY: `new` requires both indices to remain valid for this queue.
+        let head = unsafe { &*self.head }.read() as usize;
+        let tail = unsafe { &*self.tail }.read() as usize;
+        (head < self.num_slots && tail < self.num_slots).then_some((head, tail))
+    }
+
+    /// SpacemiT K3 L1 data-cache line size.
+    const CACHE_LINE_SIZE: usize = 64;
+
+    /// Clean and invalidate a data-cache range so writes become visible to
+    /// the remote management processor.
+    ///
+    /// # Safety
+    ///
+    /// The range must identify shared memory accessible to the current hart.
+    unsafe fn dcache_clean_invalid_range(addr: usize, size: usize) {
+        // SAFETY: the caller guarantees the cache-block range is accessible.
+        unsafe {
+            core::arch::asm!("fence rw, rw");
+            let start = addr & !(Self::CACHE_LINE_SIZE - 1);
+            let end = addr + size;
+            let mut op = start;
+            while op < end {
+                core::arch::asm!("cbo.flush 0({})", in(reg) op);
+                op += Self::CACHE_LINE_SIZE;
+            }
+            core::arch::asm!("fence rw, rw");
+        }
+    }
+
+    /// Invalidate a data-cache range so the local hart reads data written by
+    /// the remote management processor.
+    ///
+    /// # Safety
+    ///
+    /// The range must identify shared memory accessible to the current hart.
+    unsafe fn dcache_invalid_range(addr: usize, size: usize) {
+        // SAFETY: the caller guarantees the cache-block range is accessible.
+        unsafe {
+            core::arch::asm!("fence rw, rw");
+            let start = addr & !(Self::CACHE_LINE_SIZE - 1);
+            let end = addr + size;
+            let mut op = start;
+            while op < end {
+                core::arch::asm!("cbo.inval 0({})", in(reg) op);
+                op += Self::CACHE_LINE_SIZE;
+            }
+            core::arch::asm!("fence rw, rw");
+        }
+    }
+
+    /// # Safety
+    ///
+    /// `data.len()` must not exceed `slot_size - 8`.
+    unsafe fn send(
+        &self,
+        header: &MessageHeader,
+        data: &[u8],
+        doorbell: Option<&Le32>,
+    ) -> Result<(), QueueError> {
+        // SAFETY: `new` requires the queue indices to remain in shared memory.
+        unsafe {
+            Self::dcache_invalid_range(self.head as usize, core::mem::size_of::<Le32>());
+            Self::dcache_invalid_range(self.tail as usize, core::mem::size_of::<Le32>());
+        }
+        let Some((head, tail)) = self.indices() else {
+            return Err(QueueError::Invalid);
+        };
+        if (tail + 1) % self.num_slots == head {
+            return Err(QueueError::Full);
+        }
+        if data.len() > self.slot_size - RPMI_MSG_HDR_SIZE
+            || header.data_len() as usize != data.len()
+        {
+            return Err(QueueError::Invalid);
+        }
+
+        // SAFETY: the validated tail index selects a complete queue slot.
+        let slot = unsafe { self.buffer.add(tail * self.slot_size) };
+
+        // Write the header little-endian. The RPMI logical words pack into
+        // the same byte layout the shared-memory transport specifies.
+        let words = header.words();
+        // SAFETY: RPMI slots are aligned to `slot_size`, which is at least 64.
+        unsafe {
+            (slot as *mut u32).write_volatile(words[0].to_le());
+            (slot.add(4) as *mut u32).write_volatile(words[1].to_le());
+        }
+        if !data.is_empty() {
+            // SAFETY: the length check keeps the copy inside this slot.
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    data.as_ptr(),
+                    slot.add(RPMI_MSG_HDR_SIZE),
+                    data.len(),
+                );
+            }
+        }
+
+        // SAFETY: `slot` lies in the shared buffer required by `new`.
+        unsafe { Self::dcache_clean_invalid_range(slot as usize, self.slot_size) };
+
+        // SAFETY: `new` requires the tail index to remain valid.
+        unsafe { &*self.tail }.write(((tail + 1) % self.num_slots) as u32);
+        // SAFETY: `new` requires the tail index to remain in shared memory.
+        unsafe {
+            Self::dcache_clean_invalid_range(self.tail as usize, core::mem::size_of::<Le32>())
+        };
+
+        if let Some(db) = doorbell {
+            db.write(1);
+        }
+        Ok(())
+    }
+
+    /// # Safety
+    ///
+    /// The shared-memory regions passed to `new` must remain valid.
+    unsafe fn receive(
+        &self,
+        service_group_id: u16,
+        service_id: u8,
+        token: u16,
+        out: &mut [u8],
+    ) -> Result<Option<usize>, QueueError> {
+        // SAFETY: `new` requires the queue indices to remain in shared memory.
+        unsafe {
+            Self::dcache_invalid_range(self.head as usize, core::mem::size_of::<Le32>());
+            Self::dcache_invalid_range(self.tail as usize, core::mem::size_of::<Le32>());
+        }
+        let Some((head, tail)) = self.indices() else {
+            return Err(QueueError::Invalid);
+        };
+        if head == tail {
+            return Ok(None);
+        }
+
+        let mut pos = head;
+        loop {
+            // SAFETY: `pos` is reduced modulo the validated slot count.
+            let slot = unsafe { self.buffer.add(pos * self.slot_size) };
+            // SAFETY: `slot` lies in the shared buffer required by `new`.
+            unsafe { Self::dcache_invalid_range(slot as usize, self.slot_size) };
+            // SAFETY: RPMI slots are aligned and contain an eight-byte header.
+            let slot_token = unsafe { (slot.add(6) as *const u16).read_volatile() };
+            if u16::from_le(slot_token) == token {
+                break;
+            }
+            pos = (pos + 1) % self.num_slots;
+            if pos == tail {
+                return Ok(None);
+            }
+        }
+
+        if pos != head {
+            // SAFETY: both indices were validated against the slot count.
+            let head_slot = unsafe { self.buffer.add(head * self.slot_size) };
+            let pos_slot = unsafe { self.buffer.add(pos * self.slot_size) };
+            // SAFETY: both slots lie in the shared buffer required by `new`.
+            unsafe {
+                for i in 0..self.slot_size {
+                    let a = head_slot.add(i).read_volatile();
+                    let b = pos_slot.add(i).read_volatile();
+                    head_slot.add(i).write_volatile(b);
+                    pos_slot.add(i).write_volatile(a);
+                }
+                Self::dcache_clean_invalid_range(head_slot as usize, self.slot_size);
+                Self::dcache_clean_invalid_range(pos_slot as usize, self.slot_size);
+            }
+        }
+
+        // SAFETY: the validated head index selects a complete queue slot.
+        let slot = unsafe { self.buffer.add(head * self.slot_size) };
+        // SAFETY: RPMI slots are aligned and contain an eight-byte header.
+        let header = MessageHeader::from_words(unsafe {
+            [
+                u32::from_le((slot as *const u32).read_volatile()),
+                u32::from_le((slot.add(4) as *const u32).read_volatile()),
+            ]
+        });
+        let datalen = header.data_len() as usize;
+        let valid = MessageHeader::new(
+            header.service_group_id(),
+            header.service_id(),
+            header.flags(),
+            header.data_len(),
+            header.token(),
+        ) == Some(header)
+            && header.service_group_id() == service_group_id
+            && header.service_id() == service_id
+            && header.message_type() == Ok(MessageType::Acknowledgement)
+            && datalen <= self.slot_size - RPMI_MSG_HDR_SIZE
+            && datalen <= out.len();
+        if valid && datalen > 0 {
+            // SAFETY: header validation bounds the copy by the slot and output.
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    slot.add(RPMI_MSG_HDR_SIZE),
+                    out.as_mut_ptr(),
+                    datalen,
+                );
+            }
+        }
+
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+        // SAFETY: `new` requires the head index to remain valid.
+        unsafe { &*self.head }.write(((head + 1) % self.num_slots) as u32);
+        // SAFETY: `new` requires the head index to remain in shared memory.
+        unsafe {
+            Self::dcache_clean_invalid_range(self.head as usize, core::mem::size_of::<Le32>())
+        };
+        if valid {
+            Ok(Some(datalen))
+        } else {
+            Err(QueueError::Invalid)
+        }
+    }
+}
+
+/// RPMI shared-memory queue indices.
+pub mod queue_idx {
+    /// AP to PuC request.
+    pub const A2P_REQ: usize = 0;
+    /// PuC to AP acknowledgement.
+    pub const P2A_ACK: usize = 1;
+    /// Number of queues.
+    pub const MAX_COUNT: usize = 4;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MailboxError {
+    /// The request or response could not be transferred correctly.
+    Io,
+    /// The response did not arrive before the transport deadline.
+    Timeout,
+}
+
+/// RPMI protocol attributes reported by the Base service group.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RpmiProtocolInfo {
+    /// Implemented RPMI specification version.
+    pub spec_version: u32,
+    /// RPMI implementation identifier.
+    pub implementation_id: u32,
+    /// RPMI implementation version.
+    pub implementation_version: u32,
+}
+
+/// RPMI shared-memory mailbox controller.
+pub struct RpmiMailbox {
+    queues: [SmqQueue; queue_idx::MAX_COUNT],
+    doorbell: Option<&'static Le32>,
+    timebase_frequency: u64,
+    next_token: AtomicU16,
+    operation: Mutex<()>,
+}
+
+impl RpmiMailbox {
+    /// Creates a mailbox controller.
+    ///
+    /// # Safety
+    ///
+    /// Every queue must alias shared memory accessible to both the AP and
+    /// the PuC (see [`SmqQueue::new`]), use `slot_size`, and contain at least
+    /// two slots. `timebase_frequency` must be nonzero.
+    unsafe fn new(
+        slot_size: usize,
+        timebase_frequency: u64,
+        queues: [SmqQueue; queue_idx::MAX_COUNT],
+        doorbell: Option<&'static Le32>,
+    ) -> Self {
+        debug_assert!(
+            queues
+                .iter()
+                .all(|queue| queue.slot_size == slot_size && queue.num_slots >= 2)
+        );
+        Self {
+            queues,
+            doorbell,
+            timebase_frequency,
+            next_token: AtomicU16::new(1),
+            operation: Mutex::new(()),
+        }
+    }
+
+    fn alloc_token(&self) -> u16 {
+        let mut token = self.next_token.load(Ordering::Relaxed);
+        loop {
+            let next = token.wrapping_add(1).max(1);
+            match self.next_token.compare_exchange_weak(
+                token,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return next,
+                Err(current) => token = current,
+            }
+        }
+    }
+
+    /// Maximum RPMI message-data length supported by the shared-memory slots.
+    pub fn message_data_max_len(&self) -> usize {
+        self.queues[queue_idx::A2P_REQ].slot_size - RPMI_MSG_HDR_SIZE
+    }
+
+    fn base_word(&self, service_id: u8, request: &[u8]) -> Option<u32> {
+        let mut response = [0u8; 8];
+        match self.normal_request_with_status(
+            servicegroup::BASE,
+            service_id,
+            request,
+            &mut response,
+        ) {
+            Ok((Status::Success, 8)) => Some(u32::from_le_bytes([
+                response[4],
+                response[5],
+                response[6],
+                response[7],
+            ])),
+            _ => None,
+        }
+    }
+
+    /// Read the RPMI specification and implementation attributes.
+    pub fn protocol_info(&self) -> Option<RpmiProtocolInfo> {
+        Some(RpmiProtocolInfo {
+            spec_version: self.base_word(::rpmi::base::GET_SPEC_VERSION, &[])?,
+            implementation_id: self.base_word(::rpmi::base::GET_IMPLEMENTATION_ID, &[])?,
+            implementation_version: self
+                .base_word(::rpmi::base::GET_IMPLEMENTATION_VERSION, &[])?,
+        })
+    }
+
+    /// Probe an RPMI service group and return its nonzero version.
+    pub fn probe_service_group(&self, service_group_id: u16) -> Option<u32> {
+        let request = (service_group_id as u32).to_le_bytes();
+        self.base_word(::rpmi::base::PROBE_SERVICE_GROUP, &request)
+            .filter(|version| *version != 0)
+    }
+
+    fn send_request(&self, header: &MessageHeader, request: &[u8]) -> Result<(), MailboxError> {
+        let deadline = mtime_ticks()
+            .saturating_add(RPMI_DEF_TX_TIMEOUT as u64 * self.timebase_frequency / 1_000);
+        loop {
+            // SAFETY: the queue aliases the shared memory established by `new`.
+            match unsafe { self.queues[queue_idx::A2P_REQ].send(header, request, self.doorbell) } {
+                Ok(()) => return Ok(()),
+                Err(QueueError::Invalid) => return Err(MailboxError::Io),
+                Err(QueueError::Full) if mtime_ticks() >= deadline => {
+                    return Err(MailboxError::Timeout);
+                }
+                Err(QueueError::Full) => core::hint::spin_loop(),
+            }
+        }
+    }
+
+    /// Perform a normal RPMI request expecting a response.
+    ///
+    /// Sends a `NormalRequest` message on the A2P_REQ queue and waits for
+    /// the matching acknowledgement on the P2A_ACK queue. The response
+    /// payload is copied into `resp` and the first word (the status code)
+    /// is returned as a [`Status`].
+    ///
+    /// Returns an error when the request cannot be sent or the response does
+    /// not arrive before the transport deadline.
+    pub fn normal_request_with_status(
+        &self,
+        servicegroup_id: u16,
+        service_id: u8,
+        req: &[u8],
+        resp: &mut [u8],
+    ) -> Result<(Status, usize), MailboxError> {
+        let _operation = self.operation.lock();
+        if resp.len() < 4 {
+            return Err(MailboxError::Io);
+        }
+        let token = self.alloc_token();
+        let data_len = u16::try_from(req.len()).map_err(|_| MailboxError::Io)?;
+        let header = MessageHeader::new(
+            servicegroup_id,
+            service_id,
+            MessageType::NormalRequest.bits(),
+            data_len,
+            token,
+        )
+        .ok_or(MailboxError::Io)?;
+        self.send_request(&header, req)?;
+        let deadline = mtime_ticks()
+            .saturating_add(RPMI_DEF_RX_TIMEOUT as u64 * self.timebase_frequency / 1_000);
+        let mut rx = vec![0u8; self.message_data_max_len()];
+        loop {
+            // SAFETY: the queue aliases the shared memory established by `new`.
+            let received = unsafe {
+                self.queues[queue_idx::P2A_ACK].receive(servicegroup_id, service_id, token, &mut rx)
+            };
+            if let Some(n) = received.map_err(|_| MailboxError::Io)? {
+                if n < 4 {
+                    return Err(MailboxError::Io);
+                }
+                if n > resp.len() {
+                    return Err(MailboxError::Io);
+                }
+                let status = Status::try_from(u32::from_le_bytes([rx[0], rx[1], rx[2], rx[3]]))
+                    .unwrap_or(Status::Failed);
+                resp[..n].copy_from_slice(&rx[..n]);
+                return Ok((status, n));
+            }
+            if mtime_ticks() >= deadline {
+                break;
+            }
+            // No message yet: yield and retry.
+            core::hint::spin_loop();
+        }
+        warn!(
+            "RPMI send TIMEOUT: sg={} svc={} token={} (no ack in {} ms)",
+            servicegroup_id, service_id, token, RPMI_DEF_RX_TIMEOUT
+        );
+        Err(MailboxError::Timeout)
+    }
+
+    /// Perform a posted RPMI request without a response.
+    ///
+    /// Sends a `PostedRequest` message on the A2P_REQ queue and returns
+    /// immediately.
+    pub fn posted_request(
+        &self,
+        servicegroup_id: u16,
+        service_id: u8,
+        req: &[u8],
+    ) -> Result<(), MailboxError> {
+        let _operation = self.operation.lock();
+        let token = self.alloc_token();
+        let data_len = u16::try_from(req.len()).map_err(|_| MailboxError::Io)?;
+        let header = MessageHeader::new(
+            servicegroup_id,
+            service_id,
+            MessageType::PostedRequest.bits(),
+            data_len,
+            token,
+        )
+        .ok_or(MailboxError::Io)?;
+        self.send_request(&header, req)
+    }
+}

--- a/firmware/prototyper/src/sbi/cppc.rs
+++ b/firmware/prototyper/src/sbi/cppc.rs
@@ -1,28 +1,150 @@
 use rustsbi::SbiRet;
+use spin::Mutex;
 
-/// CPPC extension for platforms without a register backend.
-pub(crate) struct SbiCppc;
+use crate::rpmi::servicegroup;
+use crate::rpmi::{CppcProbeReq, CppcReadReq, CppcWriteReq, RpmiMailbox};
+use ::rpmi::cppc;
+use ::rpmi::message::Status as RpmiError;
+
+use crate::riscv::current_hartid;
+
+const LAST_ACPI_REG_ID: u32 = 0x14;
+const TRANSITION_LATENCY_REG_ID: u32 = 0x8000_0000;
+
+fn valid_reg_id(reg_id: u32) -> bool {
+    reg_id <= LAST_ACPI_REG_ID || reg_id == TRANSITION_LATENCY_REG_ID
+}
+
+fn rpmi_access_error_to_sbi(err: RpmiError) -> SbiRet {
+    match err {
+        RpmiError::NotSupported => SbiRet::not_supported(),
+        RpmiError::Denied => SbiRet::denied(),
+        _ => SbiRet::failed(),
+    }
+}
+
+/// CPPC extension backed by the RPMI CPPC service group.
+///
+/// Without a mailbox backend, probes report zero-width registers and accesses
+/// are not supported.
+pub(crate) struct SbiCppc {
+    mailbox: Mutex<Option<&'static RpmiMailbox>>,
+}
 
 impl SbiCppc {
+    /// Create a new CPPC extension without a mailbox backend.
     pub(crate) const fn new() -> Self {
-        Self
+        Self {
+            mailbox: Mutex::new(None),
+        }
+    }
+
+    /// Inject the platform mailbox backend.
+    pub(crate) fn set_mailbox(&self, mailbox: &'static RpmiMailbox) {
+        *self.mailbox.lock() = Some(mailbox);
     }
 }
 
 impl rustsbi::Cppc for SbiCppc {
-    fn probe(&self, _reg_id: u32) -> SbiRet {
-        SbiRet::success(0)
+    fn probe(&self, reg_id: u32) -> SbiRet {
+        if !valid_reg_id(reg_id) {
+            return SbiRet::invalid_param();
+        }
+        let mailbox = self.mailbox.lock();
+        let Some(mbox) = mailbox.as_ref().copied() else {
+            // No backend: register not implemented (width 0).
+            return SbiRet::success(0);
+        };
+        let req = CppcProbeReq {
+            hart_id: current_hartid() as u32,
+            reg_id,
+        }
+        .to_bytes();
+        let mut resp = [0u8; 8];
+        match mbox.normal_request_with_status(servicegroup::CPPC, cppc::PROBE_REG, &req, &mut resp)
+        {
+            Ok((RpmiError::Success, len)) if len >= resp.len() => {
+                let reg_len = u32::from_le_bytes([resp[4], resp[5], resp[6], resp[7]]);
+                SbiRet::success(reg_len as usize)
+            }
+            Ok((RpmiError::NotSupported, _)) => SbiRet::success(0),
+            Ok(_) => SbiRet::failed(),
+            Err(_) => SbiRet::failed(),
+        }
     }
 
-    fn read(&self, _reg_id: u32) -> SbiRet {
-        SbiRet::not_supported()
+    fn read(&self, reg_id: u32) -> SbiRet {
+        if !valid_reg_id(reg_id) {
+            return SbiRet::invalid_param();
+        }
+        let mailbox = self.mailbox.lock();
+        let Some(mbox) = mailbox.as_ref().copied() else {
+            return SbiRet::not_supported();
+        };
+        let req = CppcReadReq {
+            hart_id: current_hartid() as u32,
+            reg_id,
+        }
+        .to_bytes();
+        let mut resp = [0u8; 12];
+        match mbox.normal_request_with_status(servicegroup::CPPC, cppc::READ_REG, &req, &mut resp) {
+            Ok((RpmiError::Success, len)) if len >= resp.len() => {
+                let lo = u32::from_le_bytes([resp[4], resp[5], resp[6], resp[7]]);
+                SbiRet::success(lo as usize)
+            }
+            Ok((err, _)) => rpmi_access_error_to_sbi(err),
+            Err(_) => SbiRet::failed(),
+        }
     }
 
-    fn read_hi(&self, _reg_id: u32) -> SbiRet {
-        SbiRet::not_supported()
+    fn read_hi(&self, reg_id: u32) -> SbiRet {
+        if !valid_reg_id(reg_id) {
+            return SbiRet::invalid_param();
+        }
+        if cfg!(target_pointer_width = "64") {
+            return SbiRet::success(0);
+        }
+        let mailbox = self.mailbox.lock();
+        let Some(mbox) = mailbox.as_ref().copied() else {
+            return SbiRet::not_supported();
+        };
+        let req = CppcReadReq {
+            hart_id: current_hartid() as u32,
+            reg_id,
+        }
+        .to_bytes();
+        let mut resp = [0u8; 12];
+        match mbox.normal_request_with_status(servicegroup::CPPC, cppc::READ_REG, &req, &mut resp) {
+            Ok((RpmiError::Success, len)) if len >= resp.len() => {
+                let hi = u32::from_le_bytes([resp[8], resp[9], resp[10], resp[11]]);
+                SbiRet::success(hi as usize)
+            }
+            Ok((err, _)) => rpmi_access_error_to_sbi(err),
+            Err(_) => SbiRet::failed(),
+        }
     }
 
-    fn write(&self, _reg_id: u32, _val: u64) -> SbiRet {
-        SbiRet::not_supported()
+    fn write(&self, reg_id: u32, val: u64) -> SbiRet {
+        if !valid_reg_id(reg_id) {
+            return SbiRet::invalid_param();
+        }
+        let mailbox = self.mailbox.lock();
+        let Some(mbox) = mailbox.as_ref().copied() else {
+            return SbiRet::not_supported();
+        };
+        let req = CppcWriteReq {
+            hart_id: current_hartid() as u32,
+            reg_id,
+            data_lo: val as u32,
+            data_hi: (val >> 32) as u32,
+        }
+        .to_bytes();
+        let mut resp = [0u8; 4];
+        match mbox.normal_request_with_status(servicegroup::CPPC, cppc::WRITE_REG, &req, &mut resp)
+        {
+            Ok((RpmiError::Success, len)) if len >= resp.len() => SbiRet::success(0),
+            Ok((err, _)) => rpmi_access_error_to_sbi(err),
+            Err(_) => SbiRet::failed(),
+        }
     }
 }

--- a/firmware/prototyper/src/sbi/features.rs
+++ b/firmware/prototyper/src/sbi/features.rs
@@ -102,6 +102,9 @@ pub fn extension_detection(cpus: &NodeSeq) {
                 Extension::Hypervisor if hart_id == current_hartid() => {
                     misa::read().has_extension('H')
                 }
+                Extension::Smaia if hart_id == current_hartid() => {
+                    dt_supported || has_csr::<0x350>()
+                }
                 _ => dt_supported,
             };
         }
@@ -220,6 +223,9 @@ fn has_mstateen0() -> bool {
 pub fn configure_delegation_and_trap() {
     // Delegate all interrupts and exceptions to supervisor mode.
     configure_delegation();
+    if crate::platform::IS_K3_PLATFORM.load(Ordering::Acquire) {
+        keep_access_faults_in_mmode();
+    }
 
     let hart_priv_version = hart_privileged_version(current_hartid());
     if hart_priv_version >= PrivilegedVersion::Version1_11 {
@@ -229,16 +235,23 @@ pub fn configure_delegation_and_trap() {
         // Configure environment features based on available extensions.
         if hart_extension_probe(current_hartid(), Extension::Sstc) {
             menvcfg::set_bits(
-                menvcfg::STCE | menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE,
+                menvcfg::STCE
+                    | menvcfg::PBMTE
+                    | menvcfg::CBIE_INVALIDATE
+                    | menvcfg::CBCFE
+                    | menvcfg::CBZE,
             );
         } else {
-            menvcfg::set_bits(menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE);
+            menvcfg::set_bits(
+                menvcfg::PBMTE | menvcfg::CBIE_INVALIDATE | menvcfg::CBCFE | menvcfg::CBZE,
+            );
         }
-        if is_aia_active()
-            && hart_extension_probe(current_hartid(), Extension::Smaia)
-            && has_mstateen0()
-        {
-            mstateen::enable_smode_aia();
+        if has_mstateen0() {
+            let mut stateen0 = mstateen::STATEN | mstateen::CONTEXT | mstateen::HSENVCFG;
+            if is_aia_active() && hart_extension_probe(current_hartid(), Extension::Smaia) {
+                stateen0 |= mstateen::AIA | mstateen::IMSIC | mstateen::SVSLCT;
+            }
+            mstateen::set_stateen0(stateen0);
         }
     }
     install_trap_vector();

--- a/firmware/prototyper/src/sbi/hsm.rs
+++ b/firmware/prototyper/src/sbi/hsm.rs
@@ -10,7 +10,7 @@ use crate::riscv::current_hartid;
 use crate::sbi::hart_context::NextStage;
 
 use super::trap::boot::boot;
-use super::trap_stack::{RemoteHsmCell, hart_local, reset_hart};
+use super::trap_stack::{HsmCell, RemoteHsmCell, hart_local, reset_hart, with_hart};
 
 /// Gets the local HSM cell for the current hart.
 pub(crate) use super::trap_stack::local_hsm;
@@ -21,6 +21,15 @@ pub(crate) use super::trap_stack::remote_hsm;
 /// Returns a remote-capable view of the current hart's HSM cell.
 pub(crate) fn hart_hsm() -> RemoteHsmCell<'static, NextStage> {
     hart_local(current_hartid()).hsm.remote()
+}
+
+/// Initializes non-boot hart HSM cells for later supervisor starts.
+pub(crate) fn init_secondary_hsm_cells(boot_hart: usize) {
+    for hart_id in 0..crate::cfg::NUM_HART_MAX {
+        if hart_id != boot_hart {
+            with_hart(hart_id, |local| local.hsm = HsmCell::new());
+        }
+    }
 }
 
 /// Implementation of SBI HSM (Hart State Management) extension.
@@ -42,7 +51,10 @@ impl rustsbi::Hsm for SbiHsm {
                     opaque,
                     next_mode: MPP::Supervisor,
                 }) {
-                    crate::sbi::ipi().unwrap().set_msip(hartid);
+                    crate::platform::wakeup_hart(hartid);
+                    if !crate::platform::is_k3() {
+                        crate::sbi::ipi().unwrap().set_msip(hartid);
+                    }
                     SbiRet::success(0)
                 } else {
                     SbiRet::already_available()
@@ -56,6 +68,9 @@ impl rustsbi::Hsm for SbiHsm {
     #[inline]
     fn hart_stop(&self) -> SbiRet {
         local_hsm().stop();
+        if crate::platform::is_k3() {
+            crate::riscv::spacemit_k3::shutdown_process(current_hartid());
+        }
         mie::disable_msoft();
         riscv::asm::wfi();
         SbiRet::success(0)

--- a/firmware/prototyper/src/sbi/mod.rs
+++ b/firmware/prototyper/src/sbi/mod.rs
@@ -151,6 +151,11 @@ pub(crate) fn fwft() -> Option<&'static SbiFwft> {
     SBI_DISPATCHER.get().and_then(|sbi| sbi.fwft.as_ref())
 }
 
+/// Returns the mpxy extension, if present.
+pub(crate) fn mpxy() -> Option<&'static SbiMpxy> {
+    SBI_DISPATCHER.get().and_then(|sbi| sbi.mpxy.as_ref())
+}
+
 /// Returns the hsm extension, if present.
 pub(crate) fn hsm() -> Option<&'static SbiHsm> {
     SBI_DISPATCHER.get().and_then(|sbi| sbi.hsm.as_ref())

--- a/firmware/prototyper/src/sbi/mpxy.rs
+++ b/firmware/prototyper/src/sbi/mpxy.rs
@@ -1,90 +1,395 @@
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use rustsbi::SbiRet;
 use sbi_spec::binary::SharedPtr;
 
-const SHMEM_SIZE: usize = 4096;
+use crate::rpmi::servicegroup;
+use crate::rpmi::{MailboxError, RpmiMailbox};
 
-/// Message Proxy extension with per-hart shared memory but no message channels.
+// Standard MPXY channel attribute identifiers from the SBI specification.
+mod channel_attr {
+    pub const MSG_PROT_ID: u32 = 0;
+    pub const MSG_PROT_VERSION: u32 = 1;
+    pub const MSG_MAX_LEN: u32 = 2;
+    pub const MSG_SEND_TIMEOUT: u32 = 3;
+    pub const MSG_COMPLETION_TIMEOUT: u32 = 4;
+    pub const CAPABILITY: u32 = 5;
+    pub const SSE_EVENT_ID: u32 = 6;
+    pub const MSI_CONTROL: u32 = 7;
+    pub const MSI_ADDR_LO: u32 = 8;
+    pub const MSI_ADDR_HI: u32 = 9;
+    pub const MSI_DATA: u32 = 10;
+    pub const EVENTS_STATE_CONTROL: u32 = 11;
+    // RPMI message-protocol attributes start at `0x8000_0000`.
+    pub const RPMI_SERVICEGROUP_ID: u32 = 0x8000_0000;
+    pub const RPMI_SERVICEGROUP_VERSION: u32 = 0x8000_0001;
+    pub const RPMI_IMPL_ID: u32 = 0x8000_0002;
+    pub const RPMI_IMPL_VERSION: u32 = 0x8000_0003;
+}
+
+// MPXY assigns protocol ID zero to RPMI.
+const RPMI_MSGPROTO_ID: u32 = 0x0;
+const CHANNEL_CAPABILITY: u32 = 1 << 3;
+
+// SBI v3.0 excludes RPMI groups already exposed through a dedicated SBI
+// extension.
+const CHANNEL_COMPATIBLES: &[(&str, u16)] = &[
+    ("riscv,rpmi-mpxy-voltage", servicegroup::VOLTAGE),
+    ("riscv,rpmi-mpxy-clock", servicegroup::CLOCK),
+    ("riscv,rpmi-mpxy-domain", servicegroup::DOMAIN),
+];
+
+#[derive(Clone, Copy)]
+struct Channel {
+    channel_id: u32,
+    service_group_id: u16,
+    version: u32,
+}
+
+/// Message Proxy extension backed by the RPMI mailbox.
+///
+/// Each channel is bound to one RPMI service group, and message IDs map to
+/// service IDs within that group. Operations require a platform-provided
+/// mailbox backend.
 pub(crate) struct SbiMpxy {
+    mailbox: &'static RpmiMailbox,
+    protocol_info: crate::rpmi::RpmiProtocolInfo,
+    channels: Vec<Channel>,
+    // MPXY shared memory is configured independently for each hart.
     shmem: [AtomicUsize; crate::cfg::NUM_HART_MAX],
 }
 
 impl SbiMpxy {
-    pub(crate) const fn new() -> Self {
-        Self {
-            shmem: [const { AtomicUsize::new(0) }; crate::cfg::NUM_HART_MAX],
+    /// Create an MPXY extension for RPMI channels described by the device
+    /// tree.
+    pub(crate) fn from_fdt(
+        root: &serde_device_tree::buildin::Node,
+        mailbox: &'static RpmiMailbox,
+    ) -> Option<Self> {
+        let protocol_info = mailbox.protocol_info()?;
+        if protocol_info.spec_version >> 16 != 1 {
+            return None;
         }
+        let mut channel_descriptions = Vec::new();
+        crate::devicetree::search_with_parent(root, &mut |node, _| {
+            let Some(compatible) = node.get_prop("compatible") else {
+                return;
+            };
+            let compatible = compatible.deserialize::<serde_device_tree::buildin::StrSeq>();
+            let Some(service_group_id) = compatible.iter().find_map(|value| {
+                CHANNEL_COMPATIBLES
+                    .iter()
+                    .find(|(name, _)| *name == value)
+                    .map(|(_, id)| *id)
+            }) else {
+                return;
+            };
+            let Some(channel_id) = node
+                .get_prop("riscv,sbi-mpxy-channel-id")
+                .map(|value| value.deserialize::<u32>())
+            else {
+                return;
+            };
+            if !channel_descriptions
+                .iter()
+                .any(|(existing_id, _)| *existing_id == channel_id)
+            {
+                channel_descriptions.push((channel_id, service_group_id));
+            }
+        });
+        let channels = channel_descriptions
+            .into_iter()
+            .filter_map(|(channel_id, service_group_id)| {
+                mailbox
+                    .probe_service_group(service_group_id)
+                    .filter(|version| version >> 16 == 1)
+                    .map(|version| Channel {
+                        channel_id,
+                        service_group_id,
+                        version,
+                    })
+            })
+            .collect::<Vec<_>>();
+        if channels.is_empty() {
+            return None;
+        }
+        Some(Self {
+            mailbox,
+            protocol_info,
+            channels,
+            shmem: [const { AtomicUsize::new(0) }; crate::cfg::NUM_HART_MAX],
+        })
     }
 
+    // Return the current hart's shared-memory slot.
     #[inline]
     fn shmem_hart(&self) -> &AtomicUsize {
         &self.shmem[crate::riscv::current_hartid()]
+    }
+
+    fn channel(&self, channel_id: u32) -> Option<&Channel> {
+        self.channels
+            .iter()
+            .find(|channel| channel.channel_id == channel_id)
+    }
+
+    fn is_message(service_group_id: u16, message_id: u32) -> bool {
+        match service_group_id {
+            servicegroup::VOLTAGE | servicegroup::CLOCK => matches!(message_id, 1..=8),
+            servicegroup::DOMAIN => matches!(message_id, 1..=5),
+            _ => false,
+        }
+    }
+
+    fn read_channel_attrs(&self, channel_id: u32, base: u32, count: u32, out: &mut [u8]) -> bool {
+        let Some(channel) = self
+            .channels
+            .iter()
+            .find(|channel| channel.channel_id == channel_id)
+        else {
+            return false;
+        };
+        for i in 0..count {
+            let Some(attr) = base.checked_add(i) else {
+                return false;
+            };
+            let value = match attr {
+                // Standard SBI MPXY channel attributes
+                channel_attr::MSG_PROT_ID => RPMI_MSGPROTO_ID,
+                channel_attr::MSG_PROT_VERSION => self.protocol_info.spec_version,
+                channel_attr::MSG_MAX_LEN => self.mailbox.message_data_max_len() as u32,
+                channel_attr::MSG_SEND_TIMEOUT => crate::rpmi::RPMI_DEF_TX_TIMEOUT * 1_000,
+                channel_attr::MSG_COMPLETION_TIMEOUT => {
+                    (crate::rpmi::RPMI_DEF_TX_TIMEOUT + crate::rpmi::RPMI_DEF_RX_TIMEOUT) * 1_000
+                }
+                channel_attr::CAPABILITY => CHANNEL_CAPABILITY,
+                channel_attr::SSE_EVENT_ID => 0,
+                channel_attr::MSI_CONTROL => 0,
+                channel_attr::MSI_ADDR_LO => 0,
+                channel_attr::MSI_ADDR_HI => 0,
+                channel_attr::MSI_DATA => 0,
+                channel_attr::EVENTS_STATE_CONTROL => 0,
+                // RPMI message-protocol attributes
+                channel_attr::RPMI_SERVICEGROUP_ID => channel.service_group_id as u32,
+                channel_attr::RPMI_SERVICEGROUP_VERSION => channel.version,
+                channel_attr::RPMI_IMPL_ID => self.protocol_info.implementation_id,
+                channel_attr::RPMI_IMPL_VERSION => self.protocol_info.implementation_version,
+                _ => return false,
+            };
+            let off = (i * 4) as usize;
+            if off + 4 > out.len() {
+                return false;
+            }
+            out[off..off + 4].copy_from_slice(&value.to_le_bytes());
+        }
+        true
     }
 }
 
 impl rustsbi::Mpxy for SbiMpxy {
     fn get_shmem_size(&self) -> usize {
-        SHMEM_SIZE
+        // Shared memory for request/response data plus the channel-ID
+        // array header; 4 KiB aligned.
+        4096
     }
 
     fn set_shmem(&self, shmem: SharedPtr<u8>, flags: usize) -> SbiRet {
-        if flags != 0 {
+        if flags > 1 {
             return SbiRet::invalid_param();
         }
-
         let lo = shmem.phys_addr_lo();
         let hi = shmem.phys_addr_hi();
-        if lo == usize::MAX && hi == usize::MAX {
+        let all_ones = lo == usize::MAX && hi == usize::MAX;
+        if all_ones {
             self.shmem_hart().store(0, Ordering::Release);
             return SbiRet::success(0);
         }
-
-        if lo & (SHMEM_SIZE - 1) != 0 || hi != 0 {
+        if lo & 0xfff != 0 {
             return SbiRet::invalid_param();
         }
-        if !crate::firmware::supervisor_writable(lo, SHMEM_SIZE) {
+        if hi != 0 {
             return SbiRet::invalid_address();
         }
-
-        self.shmem_hart().store(lo, Ordering::Release);
+        if !crate::firmware::supervisor_writable(lo, self.get_shmem_size()) {
+            return SbiRet::invalid_address();
+        }
+        let previous = self.shmem_hart().swap(lo, Ordering::AcqRel);
+        if flags == 1 {
+            let (previous_lo, previous_hi) = if previous == 0 {
+                (usize::MAX, usize::MAX)
+            } else {
+                (previous, 0)
+            };
+            // SAFETY: `lo` identifies the writable 4 KiB region validated
+            // above, which is large enough for both XLEN-bit address words.
+            unsafe {
+                (lo as *mut usize).write_volatile(previous_lo.to_le());
+                (lo as *mut usize)
+                    .add(1)
+                    .write_volatile(previous_hi.to_le());
+            }
+        }
         SbiRet::success(0)
     }
 
-    fn get_channel_ids(&self, _start_index: u32) -> SbiRet {
-        if self.shmem_hart().load(Ordering::Acquire) == 0 {
+    fn get_channel_ids(&self, start_index: u32) -> SbiRet {
+        let shmem = self.shmem_hart().load(Ordering::Acquire);
+        if shmem == 0 {
             return SbiRet::no_shmem();
         }
-        SbiRet::failed()
+        // `start_index == count` is valid and returns an empty page. The first
+        // two words contain the remaining and returned channel counts.
+        let count = self.channels.len() as u32;
+        if start_index > count {
+            return SbiRet::invalid_param();
+        }
+        // Number of channel IDs that fit after the remaining/returned fields.
+        let max_channelids = (self.get_shmem_size() / 4) - 2;
+        let remaining_before = count - start_index;
+        let returned = remaining_before.min(max_channelids as u32);
+        let remaining_after = count - (start_index + returned);
+        // SAFETY: `set_shmem` validated the writable 4 KiB region, and the
+        // channel IDs fit within that region.
+        let base = shmem as *mut u8;
+        unsafe {
+            base.add(0).cast::<u32>().write_volatile(remaining_after);
+            base.add(4).cast::<u32>().write_volatile(returned);
+            for i in 0..returned {
+                base.add(8 + i as usize * 4)
+                    .cast::<u32>()
+                    .write_volatile(self.channels[(start_index + i) as usize].channel_id);
+            }
+        }
+        SbiRet::success(0)
     }
 
     fn read_attributes(
         &self,
-        _channel_id: u32,
-        _base_attribute_id: u32,
-        _attribute_count: u32,
+        channel_id: u32,
+        base_attribute_id: u32,
+        attribute_count: u32,
         _output: SharedPtr<u8>,
     ) -> SbiRet {
-        SbiRet::failed()
+        if self.channel(channel_id).is_none() {
+            return SbiRet::not_supported();
+        }
+        if attribute_count == 0 {
+            return SbiRet::invalid_param();
+        }
+        if attribute_count as usize > self.get_shmem_size() / 4 {
+            return SbiRet::invalid_param();
+        }
+        if !matches!(base_attribute_id, 0..=11 | 0x8000_0000..=0x8000_0003) {
+            return SbiRet::invalid_param();
+        }
+        // READ_ATTRIBUTES returns values through the buffer established by
+        // SET_SHMEM; the output register argument is not used by the ABI.
+        let shmem = self.shmem_hart().load(Ordering::Acquire);
+        if shmem == 0 {
+            return SbiRet::no_shmem();
+        }
+        // SAFETY: `set_shmem` validated the writable 4 KiB region, and the
+        // attribute count limits this slice to that region.
+        let out = unsafe {
+            core::slice::from_raw_parts_mut(shmem as *mut u8, (attribute_count as usize) * 4)
+        };
+        if !self.read_channel_attrs(channel_id, base_attribute_id, attribute_count, out) {
+            return SbiRet::bad_range();
+        }
+        SbiRet::success(0)
     }
 
     fn write_attributes(
         &self,
-        _channel_id: u32,
-        _base_attribute_id: u32,
-        _attribute_count: u32,
+        channel_id: u32,
+        base_attribute_id: u32,
+        attribute_count: u32,
         _input: SharedPtr<u8>,
     ) -> SbiRet {
-        SbiRet::failed()
+        if self.channel(channel_id).is_none() {
+            return SbiRet::not_supported();
+        }
+        if attribute_count == 0 {
+            return SbiRet::invalid_param();
+        }
+        if attribute_count as usize > self.get_shmem_size() / 4 {
+            return SbiRet::invalid_param();
+        }
+        if !matches!(base_attribute_id, 0..=11 | 0x8000_0000..=0x8000_0003) {
+            return SbiRet::invalid_param();
+        }
+        let Some(last_attribute_id) = base_attribute_id.checked_add(attribute_count - 1) else {
+            return SbiRet::bad_range();
+        };
+        if base_attribute_id < channel_attr::MSI_CONTROL
+            || last_attribute_id > channel_attr::EVENTS_STATE_CONTROL
+        {
+            return SbiRet::bad_range();
+        }
+        if self.shmem_hart().load(Ordering::Acquire) == 0 {
+            return SbiRet::no_shmem();
+        }
+        // MSI and event-state reporting are not advertised, so writes to
+        // their standard control attributes are ignored.
+        SbiRet::success(0)
     }
 
     fn send_message_with_response(
         &self,
-        _channel_id: u32,
-        _message_id: u32,
-        _message_data_len: usize,
+        channel_id: u32,
+        message_id: u32,
+        message_data_len: usize,
     ) -> SbiRet {
-        SbiRet::failed()
+        let Some(channel) = self.channel(channel_id) else {
+            return SbiRet::not_supported();
+        };
+        if !Self::is_message(channel.service_group_id, message_id) {
+            return SbiRet::not_supported();
+        }
+        if message_data_len > self.mailbox.message_data_max_len() {
+            return SbiRet::invalid_param();
+        }
+        if message_data_len % 4 != 0 {
+            return SbiRet::invalid_param();
+        }
+        let shmem = self.shmem_hart().load(Ordering::Acquire);
+        if shmem == 0 {
+            return SbiRet::no_shmem();
+        }
+        // MPXY message_id == RPMI service_id.
+        let service_id = message_id as u8;
+        // SAFETY: `set_shmem` validated the 4 KiB region, and
+        // `message_data_len` is bounded by the mailbox slot size.
+        let req = unsafe { core::slice::from_raw_parts(shmem as *const u8, message_data_len) };
+        let mut resp = alloc::vec![0u8; self.mailbox.message_data_max_len()];
+        match self.mailbox.normal_request_with_status(
+            channel.service_group_id,
+            service_id,
+            req,
+            &mut resp,
+        ) {
+            // The S-mode client interprets the RPMI status in the response;
+            // translating it into an SBI error would turn a protocol status
+            // such as RPMI_ERR_ALREADY into a transport failure.
+            Ok((_, len)) => {
+                // SAFETY: `resp` contains `len` initialized bytes, and the
+                // validated 4 KiB shared buffer is large enough for the reply.
+                unsafe {
+                    core::ptr::copy_nonoverlapping(resp.as_ptr(), shmem as *mut u8, len);
+                }
+                SbiRet::success(len)
+            }
+            // No acknowledgement received: the transfer itself failed.
+            Err(MailboxError::Timeout) => {
+                warn!(
+                    "MPXY send: channel {} service {} timed out (no ack)",
+                    channel_id, service_id
+                );
+                SbiRet::timeout()
+            }
+            Err(MailboxError::Io) => SbiRet::io(),
+        }
     }
 
     fn send_message_without_response(
@@ -93,10 +398,10 @@ impl rustsbi::Mpxy for SbiMpxy {
         _message_id: u32,
         _message_data_len: usize,
     ) -> SbiRet {
-        SbiRet::failed()
+        SbiRet::not_supported()
     }
 
     fn get_notification_events(&self, _channel_id: u32) -> SbiRet {
-        SbiRet::failed()
+        SbiRet::not_supported()
     }
 }

--- a/firmware/prototyper/src/sbi/reset.rs
+++ b/firmware/prototyper/src/sbi/reset.rs
@@ -7,10 +7,87 @@ use spin::Mutex;
 use crate::platform::BoardInfo;
 use crate::platform::reset::{P1PmicResetWrap, SifiveTestDeviceWrap};
 
+/// RPMI System Reset service and reset-type identifiers.
+mod rpmi_sysrst {
+    pub const SERVICE_GET_ATTRIBUTES: u8 = 0x02;
+    pub const SERVICE_SYSTEM_RESET: u8 = 0x03;
+    // K3 management firmware reports reset-type support in bit 1.
+    pub const ATTRIBUTE_SUPPORTED: u32 = 1 << 1;
+    pub const TYPE_SHUTDOWN: u8 = 0x0;
+    pub const TYPE_COLD_REBOOT: u8 = 0x1;
+    pub const TYPE_WARM_REBOOT: u8 = 0x2;
+}
+
+/// K3 system reset device backed by the RPMI System Reset service group.
+pub(crate) struct RpmiResetWrap {
+    mailbox: &'static crate::rpmi::RpmiMailbox,
+    warm_reset: bool,
+}
+
+impl RpmiResetWrap {
+    fn new(mailbox: &'static crate::rpmi::RpmiMailbox) -> Self {
+        let request = (rpmi_sysrst::TYPE_WARM_REBOOT as u32).to_le_bytes();
+        let mut response = [0u8; 8];
+        let warm_reset = matches!(
+            mailbox.normal_request_with_status(
+                crate::rpmi::servicegroup::SYSTEM_RESET,
+                rpmi_sysrst::SERVICE_GET_ATTRIBUTES,
+                &request,
+                &mut response,
+            ),
+            Ok((::rpmi::message::Status::Success, len))
+                if len >= response.len()
+                    && u32::from_le_bytes([response[4], response[5], response[6], response[7]])
+                        & rpmi_sysrst::ATTRIBUTE_SUPPORTED
+                        != 0
+        );
+        Self {
+            mailbox,
+            warm_reset,
+        }
+    }
+
+    fn do_reset(&self, reset_type: u8) -> ! {
+        let req = (reset_type as u32).to_le_bytes();
+        let _ = self.mailbox.posted_request(
+            crate::rpmi::servicegroup::SYSTEM_RESET,
+            rpmi_sysrst::SERVICE_SYSTEM_RESET,
+            &req,
+        );
+        // Reset requests do not return; wait if the transport fails.
+        loop {
+            core::hint::spin_loop()
+        }
+    }
+}
+
+impl ResetDevice for RpmiResetWrap {
+    fn fail(&self, _code: u16) -> ! {
+        self.do_reset(rpmi_sysrst::TYPE_SHUTDOWN)
+    }
+    fn pass(&self) -> ! {
+        self.do_reset(rpmi_sysrst::TYPE_SHUTDOWN)
+    }
+    fn supports_warm_reset(&self) -> bool {
+        self.warm_reset
+    }
+    fn reset(&self, warm: bool) -> ! {
+        let reset_type = if warm {
+            rpmi_sysrst::TYPE_WARM_REBOOT
+        } else {
+            rpmi_sysrst::TYPE_COLD_REBOOT
+        };
+        self.do_reset(reset_type)
+    }
+}
+
 pub trait ResetDevice: Send {
     fn fail(&self, code: u16) -> !;
     fn pass(&self) -> !;
-    fn reset(&self) -> !;
+    fn supports_warm_reset(&self) -> bool {
+        false
+    }
+    fn reset(&self, warm: bool) -> !;
 }
 
 pub struct SbiReset {
@@ -36,13 +113,26 @@ impl rustsbi::Reset for SbiReset {
             RESET_REASON_NO_REASON, RESET_REASON_SYSTEM_FAILURE, RESET_TYPE_COLD_REBOOT,
             RESET_TYPE_SHUTDOWN, RESET_TYPE_WARM_REBOOT,
         };
+        if !matches!(
+            reset_reason,
+            RESET_REASON_NO_REASON | RESET_REASON_SYSTEM_FAILURE
+        ) {
+            return SbiRet::invalid_param();
+        }
         match reset_type {
             RESET_TYPE_SHUTDOWN => match reset_reason {
                 RESET_REASON_NO_REASON => self.reset_dev.lock().pass(),
                 RESET_REASON_SYSTEM_FAILURE => self.reset_dev.lock().fail(u16::MAX),
                 value => self.reset_dev.lock().fail(value as _),
             },
-            RESET_TYPE_COLD_REBOOT | RESET_TYPE_WARM_REBOOT => self.reset_dev.lock().reset(),
+            RESET_TYPE_COLD_REBOOT => self.reset_dev.lock().reset(false),
+            RESET_TYPE_WARM_REBOOT => {
+                let reset_dev = self.reset_dev.lock();
+                if !reset_dev.supports_warm_reset() {
+                    return SbiRet::not_supported();
+                }
+                reset_dev.reset(true)
+            }
 
             _ => SbiRet::invalid_param(),
         }
@@ -63,7 +153,10 @@ pub fn fail() -> ! {
 }
 
 /// Initializes the SBI reset extension from the discovered board info.
-pub(crate) fn init(board: &BoardInfo) -> Option<SbiReset> {
+pub(crate) fn init(
+    board: &BoardInfo,
+    mailbox: Option<&'static crate::rpmi::RpmiMailbox>,
+) -> Option<SbiReset> {
     if let Some(base) = board.reset {
         Some(SbiReset::new(Mutex::new(Box::new(
             SifiveTestDeviceWrap::new(base),
@@ -72,6 +165,13 @@ pub(crate) fn init(board: &BoardInfo) -> Option<SbiReset> {
         Some(SbiReset::new(Mutex::new(Box::new(P1PmicResetWrap::new(
             i2c_base, pmic_addr,
         )))))
+    } else if board.rpmi_reset {
+        mailbox.and_then(|mailbox| {
+            mailbox
+                .probe_service_group(crate::rpmi::servicegroup::SYSTEM_RESET)
+                .filter(|version| version >> 16 == 1)
+                .map(|_| SbiReset::new(Mutex::new(Box::new(RpmiResetWrap::new(mailbox)))))
+        })
     } else {
         None
     }

--- a/firmware/prototyper/src/sbi/suspend.rs
+++ b/firmware/prototyper/src/sbi/suspend.rs
@@ -1,10 +1,12 @@
 #![forbid(unsafe_code)]
 
+use core::sync::atomic::Ordering;
 use riscv::register::mstatus;
 use rustsbi::{Hsm, SbiRet};
 use sbi_spec::hsm::{hart_state::STOPPED, suspend_type::NON_RETENTIVE};
 
 use crate::riscv::current_hartid;
+use crate::riscv::spacemit_k3;
 
 use super::hsm::remote_hsm;
 
@@ -45,6 +47,16 @@ impl rustsbi::Susp for SbiSuspend {
 
         // TODO: The validity of `resume_addr` should be checked.
         // If it is invalid, `SBI_ERR_INVALID_ADDRESS` should be returned.
+
+        if crate::platform::IS_K3_PLATFORM.load(Ordering::Acquire) {
+            let hartid = current_hartid();
+            if !spacemit_k3::suspend_pre(hartid) {
+                return SbiRet::failed();
+            }
+            let mut state = spacemit_k3::ImsicConfig::default();
+            spacemit_k3::suspend(hartid, sleep_type, &mut state);
+            return SbiRet::success(0);
+        }
 
         match crate::sbi::hsm() {
             Some(hsm) => hsm.hart_suspend(NON_RETENTIVE, resume_addr, opaque),

--- a/firmware/prototyper/src/sbi/trap/boot.rs
+++ b/firmware/prototyper/src/sbi/trap/boot.rs
@@ -10,7 +10,7 @@ use riscv::register::{mie, mstatus, satp, sstatus};
 ///
 /// Safe wrapper over the naked [`boot_entry`]: the entry diverges (its final
 /// `mret` drops to the staged next-mode PC instead of returning), and the
-/// staged start address / mode validity is the HSM cell's contract — the
+/// staged start address / mode validity is the HSM cell's contract; the
 /// HSM cell accepted them before this call.
 pub fn boot() -> ! {
     // SAFETY: divergent entry; target validity is the HSM cell's contract.
@@ -34,6 +34,11 @@ unsafe extern "C" fn boot_entry() -> ! {
         "call   {boot_handler}",
         // Restore mepc
         "ld     t0, 0*8(sp)
+        li      t1, 1
+        csrw    0x5db, t1
+        csrr    t1, 0x7c1
+        ori     t1, t1, 1
+        csrw    0x7c1, t1
         csrw    mepc, t0",
         // Restore registers
         "ld      a0, 1*8(sp)",
@@ -74,9 +79,13 @@ pub extern "C" fn boot_handler(ctx: &mut BootContext) {
         Ok(next_stage) => {
             ipi::claim_ipi();
             unsafe {
-                mstatus::set_mpie();
+                // MPIE must be clear so `mret` leaves M-mode interrupts disabled.
+                core::arch::asm!(
+                    "csrc mstatus, {}",
+                    in(reg) 1usize << 7,
+                    options(nomem, preserves_flags),
+                );
                 mstatus::set_mpp(next_stage.next_mode);
-                mie::set_msoft();
                 if !hart_extension_probe(current_hartid(), Extension::Sstc) {
                     mie::set_mtimer();
                 }

--- a/firmware/prototyper/src/sbi/trap/handler.rs
+++ b/firmware/prototyper/src/sbi/trap/handler.rs
@@ -3,7 +3,7 @@ use riscv::register::{mepc, mie, mstatus, mtval, satp, sstatus};
 use riscv_decode::{Instruction, decode};
 use sbi_spec::pmu::firmware_event;
 
-use crate::riscv::csr::{CSR_TIME, CSR_TIMEH};
+use crate::riscv::csr::{CSR_HSTATEEN0, CSR_TIME, CSR_TIMEH};
 use crate::riscv::current_hartid;
 use crate::sbi::console;
 use crate::sbi::features::{Extension, hart_extension_probe};
@@ -42,6 +42,13 @@ pub fn switch(mut ctx: FastContext, start_addr: usize, opaque: usize) -> FastRes
     ctx.regs().a[0] = current_hartid();
     ctx.regs().a[1] = opaque;
     ctx.regs().pc = start_addr;
+    // K3 requires TCMCFG and MHCR bit 0 before entering the next stage.
+    unsafe {
+        core::arch::asm!("csrw 0x5db, {}", in(reg) 1usize);
+        let mhcr: usize;
+        core::arch::asm!("csrr {}, 0x7c1", out(reg) mhcr);
+        core::arch::asm!("csrw 0x7c1, {}", in(reg) mhcr | 1);
+    }
     ctx.call(2)
 }
 
@@ -248,6 +255,17 @@ pub extern "C" fn illegal_instruction_handler(raw_ctx: EntireContext) -> EntireR
                     crate::sbi::ipi().unwrap().get_timeh(),
                 );
             }
+            CSR_HSTATEEN0 => {
+                // K3 implements neither hstateen0 (0x60c) nor the H
+                // extension state-enable CSRs, although the DTB declares
+                // 'h' + smstateen. Linux 6.18 sdtrig probes hstateen0 from
+                // S-mode without exception-table protection; an illegal
+                // instruction there panics the kernel. Emulate the CSR as
+                // read-only-zero so the probe reads back 0, making Linux
+                // fall through to its `sdtrig_csrs_disable_all` graceful
+                // degradation path instead of panicking.
+                save_reg_x(&mut ctx, csr.rd() as usize, 0);
+            }
             _ => {
                 delegate(&mut ctx);
                 return ctx.restore();
@@ -378,6 +396,144 @@ pub extern "C" fn store_misaligned_handler(ctx: EntireContext) -> EntireResult {
     );
     for i in 0..read_data.len() {
         save_byte(current_addr + i, read_data[i] as usize);
+    }
+
+    unsafe {
+        mepc::write(current_pc + inst_len);
+    }
+    ctx.restore()
+}
+
+/// SpacemiT K3 REGISTER_PRESERVATION access-fault emulation.
+///
+/// S-mode loads/stores to the REGISTER_PRESERVATION window are PMP-denied
+/// and raise Load/Store access faults; M-mode decodes the faulting
+/// instruction and emulates the access through the platform
+/// `emulate_load`/`emulate_store` hook
+/// ([`crate::platform::emulate_access_fault`], which dispatches to
+/// `spacemit_k3::emulate_load` or `emulate_store`). Unsupported
+/// instructions and M-mode-only registers are re-injected into S-mode via
+/// [`delegate`].
+#[inline]
+pub extern "C" fn access_fault_handler(raw_ctx: EntireContext) -> EntireResult {
+    let mut ctx = raw_ctx.split().0;
+    let current_pc = mepc::read();
+    let current_addr = mtval::read();
+
+    let (current_inst, inst_len) = get_inst(current_pc);
+    debug!(
+        "REGISTER_PRESERVATION access fault: inst/{:x?}, addr {:x?} in {:x?}",
+        current_inst, current_addr, current_pc
+    );
+    let decode_result = decode(current_inst as u32);
+
+    use riscv::interrupt::machine::Exception;
+    use riscv::register::mcause::Trap;
+
+    let is_load = match riscv::register::mcause::read().cause() {
+        Trap::Exception(n) if n == Exception::LoadFault as usize => true,
+        Trap::Exception(n) if n == Exception::StoreFault as usize => false,
+        _ => {
+            delegate(&mut ctx);
+            return ctx.restore();
+        }
+    };
+
+    if is_load {
+        let inst_type = match decode_result {
+            Ok(Instruction::Lb(data)) => (data.rd(), VarType::Signed, 1),
+            Ok(Instruction::Lbu(data)) => (data.rd(), VarType::UnSigned, 1),
+            Ok(Instruction::Lh(data)) => (data.rd(), VarType::Signed, 2),
+            Ok(Instruction::Lhu(data)) => (data.rd(), VarType::UnSigned, 2),
+            Ok(Instruction::Lw(data)) => (data.rd(), VarType::Signed, 4),
+            Ok(Instruction::Lwu(data)) => (data.rd(), VarType::UnSigned, 4),
+            Ok(Instruction::Ld(data)) => (data.rd(), VarType::Signed, 8),
+            Ok(Instruction::Flw(data)) => (data.rd(), VarType::Float, 4),
+            _ => {
+                delegate(&mut ctx);
+                return ctx.restore();
+            }
+        };
+        let (target_reg, var_type, len) = inst_type;
+
+        let raw_data = match crate::platform::emulate_access_fault(true, current_addr, len, 0) {
+            crate::platform::AccessFaultResult::EmulatedLoad(v) => v,
+            _ => {
+                delegate(&mut ctx);
+                return ctx.restore();
+            }
+        };
+        let read_data = match var_type {
+            VarType::Signed => match len {
+                1 => raw_data as i8 as usize,
+                2 => raw_data as i16 as usize,
+                4 => raw_data as i32 as usize,
+                8 => raw_data as i64 as usize,
+                _ => {
+                    delegate(&mut ctx);
+                    return ctx.restore();
+                }
+            },
+            VarType::UnSigned => match len {
+                1 => raw_data as u8 as usize,
+                2 => raw_data as u16 as usize,
+                4 => raw_data as u32 as usize,
+                8 => raw_data as u64 as usize,
+                _ => {
+                    delegate(&mut ctx);
+                    return ctx.restore();
+                }
+            },
+            VarType::Float => match len {
+                4 => raw_data as u32 as usize,
+                8 => raw_data as u64 as usize,
+                _ => {
+                    delegate(&mut ctx);
+                    return ctx.restore();
+                }
+            },
+        };
+        match var_type {
+            VarType::Signed | VarType::UnSigned => {
+                save_reg_x(&mut ctx, target_reg as usize, read_data)
+            }
+            VarType::Float => set_reg_f(target_reg as usize, len, read_data),
+        };
+    } else {
+        let inst_type = match decode_result {
+            Ok(Instruction::Sb(data)) => (data.rs2(), VarType::UnSigned, 1),
+            Ok(Instruction::Sh(data)) => (data.rs2(), VarType::UnSigned, 2),
+            Ok(Instruction::Sw(data)) => (data.rs2(), VarType::UnSigned, 4),
+            Ok(Instruction::Sd(data)) => (data.rs2(), VarType::UnSigned, 8),
+            Ok(Instruction::Fsw(data)) => (data.rs2(), VarType::Float, 4),
+            _ => {
+                delegate(&mut ctx);
+                return ctx.restore();
+            }
+        };
+        let (target_reg, var_type, len) = inst_type;
+        let raw_data = match var_type {
+            VarType::Signed | VarType::UnSigned => get_reg_x(&mut ctx, target_reg as usize),
+            VarType::Float => get_reg_f(target_reg as usize, len),
+        };
+        let value = match var_type {
+            VarType::Signed | VarType::UnSigned => raw_data as u64,
+            VarType::Float => match len {
+                4 => raw_data as u32 as u64,
+                8 => raw_data as u64,
+                _ => {
+                    delegate(&mut ctx);
+                    return ctx.restore();
+                }
+            },
+        };
+        match crate::platform::emulate_access_fault(false, current_addr, len, value) {
+            crate::platform::AccessFaultResult::EmulatedStore => {}
+            _ => {
+                delegate(&mut ctx);
+                return ctx.restore();
+            }
+        }
     }
 
     unsafe {

--- a/firmware/prototyper/src/sbi/trap/mod.rs
+++ b/firmware/prototyper/src/sbi/trap/mod.rs
@@ -3,6 +3,8 @@ pub mod handler;
 
 mod helper;
 
+use core::sync::atomic::Ordering;
+
 use super::pmu::pmu_firmware_counter_increment;
 use crate::fail::unsupported_trap;
 
@@ -123,6 +125,14 @@ fn handle_exception(
             pmu_firmware_counter_increment(firmware_event::MISALIGNED_STORE);
             save_regs(&mut ctx);
             ctx.continue_with(handler::store_misaligned_handler, ())
+        }
+        // K3 keeps REGISTER_PRESERVATION M-mode-only and emulates permitted
+        // S-mode accesses after the resulting PMP fault.
+        Exception::LoadFault | Exception::StoreFault
+            if crate::platform::IS_K3_PLATFORM.load(Ordering::Acquire) =>
+        {
+            save_regs(&mut ctx);
+            ctx.continue_with(handler::access_fault_handler, ())
         }
         _ => {
             error!("Unhandled exception: {:?}", exception);

--- a/firmware/prototyper/src/sbi/trap_stack.rs
+++ b/firmware/prototyper/src/sbi/trap_stack.rs
@@ -178,6 +178,37 @@ unsafe impl<T: Send> Sync for HsmCell<T> {}
 unsafe impl<T: Send> Send for HsmCell<T> {}
 
 impl<T> LocalHsmCell<'_, T> {
+    /// Takes a pending start payload before per-hart state is reinitialized.
+    #[inline]
+    pub fn take_pending(&self) -> Option<T> {
+        match self.0.status.load(Ordering::Acquire) {
+            hart_state::START_PENDING | HART_STATE_START_PENDING_EXT => {
+                let pending = unsafe { (*self.0.inner.get()).take() };
+                self.0.status.store(hart_state::STOPPED, Ordering::Release);
+                pending
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns whether this hart has a pending start payload.
+    #[inline]
+    pub fn has_pending(&self) -> bool {
+        matches!(
+            self.0.status.load(Ordering::Acquire),
+            hart_state::START_PENDING | HART_STATE_START_PENDING_EXT
+        )
+    }
+
+    /// Restores a start payload captured before per-hart initialization.
+    #[inline]
+    pub fn restore_pending(&self, value: T) {
+        unsafe { *self.0.inner.get() = Some(value) };
+        self.0
+            .status
+            .store(hart_state::START_PENDING, Ordering::Release);
+    }
+
     /// Attempts to transition hart from START_PENDING to STARTED state.
     ///
     /// Returns inner data if successful, otherwise returns current state.

--- a/xtask/src/prototyper/config.rs
+++ b/xtask/src/prototyper/config.rs
@@ -163,7 +163,7 @@ fn parse_config(config_source: &Path) -> Result<PlatformAddresses> {
             None => bail!(
                 "config '{}' is missing required key `{}`; \
                  the config schema requires `link_start_address`, `payload_address` \
-                 and `jump_address` — copy them from `firmware/prototyper/config/default.toml`",
+                 and `jump_address`; copy them from `firmware/prototyper/config/default.toml`",
                 config_source.display(),
                 key
             ),
@@ -239,6 +239,10 @@ impl BuildSpec {
         if self.features.iter().any(|feature| feature == "hypervisor") {
             flags.extend(["-C".to_string(), "target-feature=+h".to_string()]);
         }
+        // Zicbom (cache block operations) is required by the RPMI mailbox's
+        // shared-memory cache maintenance (cbo.flush / cbo.inval); always
+        // enable it for the firmware target.
+        flags.extend(["-C".to_string(), "target-feature=+zicbom".to_string()]);
         flags.extend([
             "-C".to_string(),
             format!("link-arg=-T{}", linker_script.display()),


### PR DESCRIPTION
Add SpacemiT K3 SoC and board support with a shared-memory RPMI mailbox transport and the platform service wiring for CPPC, MPXY, and SRST.

Validate shared-memory queue state and serialize mailbox operations before matching complete RPMI acknowledgements. Discover only usable CPPC, MPXY, and SRST services and apply SBI 3.0 validation, capability, and error rules, keeping K3 backend request layouts compatible with its management firmware while separating SBI MPXY channel IDs from RPMI service-group IDs.

Validate protected PMP windows, Sv39 translations, and emulated MMIO accesses before touching platform state, preserve K3 warm-start state, and enter the next stage with the required cache, snoop, and interrupt state. Forward DBCN bytes unchanged through the XScale UART backend.

<details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
