### PR TITLE
fix(prototyper): reject invalid pmu counter masks

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -26,4 +26,7 @@ All notable changes to this project will be documented in this file. See [conven
 - fix(prototyper): temporary PMU fix for possible S-mode DTB modification
 - fix(prototyper): validate DBCN console shared memory range
 
+### Fixed
+- Reject PMU counter masks containing out-of-range counter indices.
+
 ### Removed

--- a/firmware/prototyper/src/sbi/pmu.rs
+++ b/firmware/prototyper/src/sbi/pmu.rs
@@ -220,9 +220,11 @@ impl Pmu for SbiPmu {
 
         with_current(|local| {
             let pmu_state = &mut local.pmu_state;
+            let last_counter_idx = counter_idx_mask
+                .checked_ilog2()
+                .and_then(|offset| counter_idx_base.checked_add(offset as usize));
 
-            if counter_idx_base >= pmu_state.total_counters_num
-                || (counter_idx_mask & ((1 << pmu_state.total_counters_num) - 1)) == 0
+            if last_counter_idx.is_none_or(|idx| idx >= pmu_state.total_counters_num)
                 || !event.check_event_type()
                 || (is_firmware_event && !event.firmware_event_valid())
             {

--- a/firmware/test-kernel/src/main.rs
+++ b/firmware/test-kernel/src/main.rs
@@ -155,6 +155,13 @@ fn pmu_test(smp: usize) {
     let result = sbi::pmu_counter_config_matching(counter_mask, Flag::new(0b010), 0x1, 0);
     assert!(result.is_ok());
     let cycle_counter_idx = result.value;
+
+    // SKIP_MATCH still requires every counter in the set to be valid.
+    let invalid_counter_mask =
+        CounterMask::from_mask_base((1 << cycle_counter_idx) | (1 << counters_num), 0);
+    let result = sbi::pmu_counter_config_matching(invalid_counter_mask, Flag::new(0b001), 0x1, 0);
+    assert_eq!(result, SbiRet::invalid_param());
+
     let counter_info = sbi::pmu_counter_get_info(cycle_counter_idx);
     assert!(counter_info.is_ok());
     let counter_info = CounterInfo::new(counter_info.value);


### PR DESCRIPTION
counter_config_matching currently accepts a counter set if the mask contains at least one valid counter. With SKIP_MATCH, a set containing both a configured counter and an out-of-range counter can therefore succeed, even though the SBI specification requires SBI_ERR_INVALID_PARAM when any selected counter is invalid.

Validate the highest selected counter index before matching. Return SBI_ERR_INVALID_PARAM if counter_idx_base + offset overflows or the resulting index is outside 0..total_counters_num.

The regression test combines an already configured counter with `counters_num`, the first invalid index. Before this change, the call returns the configured counter instead of `SBI_ERR_INVALID_PARAM`.

Follow-up to #191. Related to #190.

Tested:

- `cargo fmt --check`
- Clippy for `rustsbi-prototyper` and `rustsbi-test-kernel`
- `cargo prototyper test --timeout 20 --retries 1`
- QEMU boot tests for dynamic and jump modes