### PR TITLE
fix(pmpm): reject out-of-range slot indices

### DIFF
--- a/library/pmpm/CHANGELOG.md
+++ b/library/pmpm/CHANGELOG.md
@@ -5,3 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- Reject out-of-range PMP slot indices instead of aliasing valid bitmap entries.

--- a/library/pmpm/src/bitmap.rs
+++ b/library/pmpm/src/bitmap.rs
@@ -60,7 +60,10 @@ impl PMPSlotAllocator {
     }
 
     pub fn free(&mut self, idx: u32) -> Result<(), PmpError> {
-        let free_slot = 1u64 << (idx & (MAX_PMP_ENTRY_COUNT - 1));
+        if idx >= MAX_PMP_ENTRY_COUNT {
+            return Err(PmpError::IndexOutOfRange);
+        }
+        let free_slot = 1u64 << idx;
         loop {
             let cur_slots = self.pmp_slots.load(Ordering::Acquire);
             if (cur_slots & free_slot & self.alloc_mask) == 0 {
@@ -83,7 +86,10 @@ impl PMPSlotAllocator {
     }
 
     pub fn is_alloc(&self, idx: u32) -> Result<bool, PmpError> {
-        let check_slot = 1u64 << (idx & (MAX_PMP_ENTRY_COUNT - 1));
+        if idx >= MAX_PMP_ENTRY_COUNT {
+            return Err(PmpError::IndexOutOfRange);
+        }
+        let check_slot = 1u64 << idx;
         if (check_slot & self.alloc_mask) == 0 {
             return Err(PmpError::IndexOutOfRange);
         }
@@ -182,10 +188,16 @@ mod tests {
         // 3. Error: Index not allocated (idx 5 is in range, but free)
         assert_eq!(allocator.free(5), Err(PmpError::IndexOutOfRange));
 
-        // 4. Success: Free allocated slot 4
+        // 4. Error: Out-of-range index must not alias slot 4
+        assert_eq!(
+            allocator.free(MAX_PMP_ENTRY_COUNT + 4),
+            Err(PmpError::IndexOutOfRange)
+        );
+
+        // 5. Success: Free allocated slot 4
         assert_eq!(allocator.free(4), Ok(()));
 
-        // 5. Error: Index not allocated (idx 4 is now free)
+        // 6. Error: Index not allocated (idx 4 is now free)
         assert_eq!(allocator.free(4), Err(PmpError::IndexOutOfRange));
     }
 
@@ -212,6 +224,10 @@ mod tests {
         );
         assert_eq!(
             allocator.is_alloc(MAX_PMP_ENTRY_COUNT),
+            Err(PmpError::IndexOutOfRange)
+        );
+        assert_eq!(
+            allocator.is_alloc(MAX_PMP_ENTRY_COUNT + TEST_BIT1),
             Err(PmpError::IndexOutOfRange)
         );
 


### PR DESCRIPTION
`PMPSlotAllocator` manages `MAX_PMP_ENTRY_COUNT` slots, so valid indices are in the range `[0, MAX_PMP_ENTRY_COUNT)`. However, `free` and `is_alloc` mask the provided index before accessing the bitmap. With 16 slots, for example, index 20 is treated as slot 4 and index 31 as slot 15.

As a result, `free(20)` can release slot 4, while `is_alloc(31)` can return the state of slot 15. Both calls should return `IndexOutOfRange`.

This change checks the index before accessing the bitmap. Behavior for valid indices and the allocation order remain unchanged.

The existing out-of-range tests used indices that mapped to slots outside `alloc_mask`, so they still returned `IndexOutOfRange` and did not expose the aliasing. The added cases use out-of-range indices that map to slots included in the mask, covering both methods.

Tested:

- `cargo +stable test --locked`
- `cargo +1.88 test --locked`
- `cargo +stable check --locked --all-features --target riscv64imac-unknown-none-elf -p pmpm`
- `cargo +1.88 check --locked --all-features --target riscv64imac-unknown-none-elf -p pmpm`
- `cargo fmt --all -- --check`