### PR TITLE
fix(ci): handle deleted changelog files

### DIFF
--- a/.github/workflows/Changelog.yml
+++ b/.github/workflows/Changelog.yml
@@ -48,7 +48,10 @@ jobs:
           for directory in "${directories[@]}"; do
             changelog="$directory/CHANGELOG.md"
             if grep -q "^$directory/" changed_files.txt; then
-              if ! grep -Fxq "$changelog" changed_files.txt; then
+              if [[ ! -f "$changelog" ]]; then
+                echo "::error file=$changelog::Required changelog was deleted"
+                exit_code=1
+              elif ! grep -Fxq "$changelog" changed_files.txt; then
                 echo "::error file=$changelog::Detected changes in $directory but $changelog was not updated"
                 exit_code=1
               else


### PR DESCRIPTION
## Description

### Bug

The changelog validation only checked whether `CHANGELOG.md` appeared in the changed files list.

Since the workflow uses `git diff --name-only`, it cannot distinguish between modified and deleted files. Therefore, deleting a required `CHANGELOG.md` file could still pass the validation check.

## Fix

Add a file existence check before validating the changelog update.

If a required `CHANGELOG.md` file is deleted, the workflow now reports an error instead of treating it as a valid update.

The existing check for whether `CHANGELOG.md` is included in the changes remains unchanged.

## Validation

- Checked workflow YAML syntax
- Checked extracted validation script with `bash -n`
- Verified the deleted `CHANGELOG.md` scenario locally
- Passed `git diff --check`