### PR TITLE
refactor(firmware): introduce runtime memory access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustsbi-firmware-runtime"
+version = "0.0.0"
+
+[[package]]
 name = "rustsbi-macros"
 version = "0.0.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "library/pmpm",
     "library/smm",
     "firmware/macros",
+    "firmware/runtime",
     "firmware/prototyper",
     "firmware/bench-kernel",
     "firmware/test-kernel",

--- a/firmware/runtime/Cargo.toml
+++ b/firmware/runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rustsbi-firmware-runtime"
+description = "Runtime support for RustSBI firmware"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+test = true
+bench = false

--- a/firmware/runtime/src/lib.rs
+++ b/firmware/runtime/src/lib.rs
@@ -1,0 +1,28 @@
+//! Runtime mechanisms for RustSBI policy firmware.
+//!
+//! The [`memory`] module turns trusted physical-resource descriptions into
+//! bounded handles for supervisor RAM and MMIO.
+//! Board discovery and resource policy remain in the consuming firmware.
+
+#![no_std]
+#![warn(missing_docs)]
+
+extern crate alloc;
+
+pub mod memory;
+
+/// An error returned by a Runtime operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// An argument is invalid for the requested operation.
+    InvalidArgs,
+    /// The caller does not have access to the requested resource.
+    AccessDenied,
+    /// The requested resource is unavailable.
+    NotEnoughResources,
+    /// Address arithmetic overflowed.
+    Overflow,
+}
+
+/// A result returned by a Runtime operation.
+pub type Result<T> = core::result::Result<T, Error>;

--- a/firmware/runtime/src/memory/address.rs
+++ b/firmware/runtime/src/memory/address.rs
@@ -1,0 +1,34 @@
+//! Physical address values.
+
+/// An address in the physical address space.
+///
+/// The current representation supports platforms whose physical-address
+/// width does not exceed the native pointer width (`usize`, which equals XLEN
+/// on RISC-V). Wider physical addresses, such as a 34-bit physical address on
+/// RV32, require a different representation and are not supported.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PhysAddr(usize);
+
+impl PhysAddr {
+    /// Creates a physical-address value.
+    #[inline]
+    pub const fn new(value: usize) -> Self {
+        Self(value)
+    }
+
+    /// Returns the address as a native integer.
+    #[inline]
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+
+    /// Adds a byte offset without wrapping.
+    #[inline]
+    pub const fn checked_add(self, offset: usize) -> Option<Self> {
+        match self.0.checked_add(offset) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+}

--- a/firmware/runtime/src/memory/mmio.rs
+++ b/firmware/runtime/src/memory/mmio.rs
@@ -1,0 +1,126 @@
+//! Typed access to memory-mapped device registers.
+
+use core::marker::PhantomData;
+use core::mem::{align_of, size_of};
+
+use super::PhysAddrRange;
+use crate::{Error, Result};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A fixed-width integer supported by [`MmioRegion`].
+///
+/// This trait is sealed and implemented for `u8`, `u16`, `u32`, and `u64`.
+pub trait MmioValue: sealed::Sealed + Copy {}
+
+macro_rules! impl_mmio_value {
+    ($($value:ty),* $(,)?) => {
+        $(
+            impl sealed::Sealed for $value {}
+            impl MmioValue for $value {}
+        )*
+    };
+}
+
+impl_mmio_value!(u8, u16, u32, u64);
+
+/// A bounded MMIO window accessed in units of `T`.
+///
+/// `T` is fixed when the window is acquired, and values use native byte order.
+/// Mixed-width register blocks use separate, non-overlapping windows.
+pub struct MmioRegion<T: MmioValue> {
+    range: PhysAddrRange,
+    value: PhantomData<T>,
+}
+
+impl<T: MmioValue> MmioRegion<T> {
+    pub(crate) const fn new(range: PhysAddrRange) -> Self {
+        Self {
+            range,
+            value: PhantomData,
+        }
+    }
+
+    /// Creates another handle to the same MMIO window.
+    #[inline]
+    pub fn share(&self) -> Self {
+        Self::new(self.range)
+    }
+
+    /// Returns a handle to the selected non-empty subrange.
+    ///
+    /// The range must lie entirely within this MMIO window.
+    pub fn subregion(&self, offset: usize, len: usize) -> Result<Self> {
+        self.range.subrange(offset, len).map(Self::new)
+    }
+
+    /// Reads one `T` at byte offset `offset`.
+    ///
+    /// Returns [`Error::InvalidArgs`] if the access is out of bounds or
+    /// misaligned. Hardware access faults are not recovered.
+    pub fn read(&self, offset: usize) -> Result<T> {
+        let address = self.access_address(offset)?;
+        // SAFETY:
+        // 1. `MmioValue` is sealed to integer types with no invalid values.
+        // 2. `access_address` checked the complete access and its alignment.
+        // 3. Registration keeps the MMIO window accessible.
+        Ok(unsafe { (address as *const T).read_volatile() })
+    }
+
+    /// Writes one `T` at byte offset `offset`.
+    ///
+    /// Returns [`Error::InvalidArgs`] if the access is out of bounds or
+    /// misaligned. Hardware access faults are not recovered.
+    pub fn write(&self, offset: usize, value: T) -> Result<()> {
+        let address = self.access_address(offset)?;
+        // SAFETY:
+        // 1. `MmioValue` is sealed to integer types supported by this method.
+        // 2. `access_address` checked the complete access and its alignment.
+        // 3. Registration keeps the MMIO window accessible.
+        unsafe { (address as *mut T).write_volatile(value) };
+        Ok(())
+    }
+
+    /// Resolves one aligned, in-bounds `T` at `offset`.
+    fn access_address(&self, offset: usize) -> Result<usize> {
+        let access = self.range.subrange(offset, size_of::<T>())?;
+        let address = access.start().as_usize();
+        if !address.is_multiple_of(align_of::<T>()) {
+            return Err(Error::InvalidArgs);
+        }
+        Ok(address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::PhysAddr;
+
+    #[repr(align(8))]
+    struct Aligned([u8; 16]);
+
+    #[test]
+    fn access_width_is_fixed_by_the_handle_type() {
+        let mut backing = Aligned([0; 16]);
+        let range = PhysAddrRange::from_start_len(
+            PhysAddr::new(backing.0.as_mut_ptr() as usize),
+            backing.0.len(),
+        )
+        .unwrap();
+        let words = MmioRegion::<u32>::new(range);
+
+        assert_eq!(words.write(4, 0x1234_5678), Ok(()));
+        assert_eq!(words.read(4), Ok(0x1234_5678));
+        assert_eq!(words.read(1), Err(Error::InvalidArgs));
+        assert_eq!(words.read(14), Err(Error::InvalidArgs));
+        assert_eq!(words.write(1, 0), Err(Error::InvalidArgs));
+        assert_eq!(words.subregion(usize::MAX, 1).err(), Some(Error::Overflow));
+
+        let bytes = MmioRegion::<u8>::new(range);
+        assert_eq!(bytes.write(1, 0x5a), Ok(()));
+        assert_eq!(bytes.read(1), Ok(0x5a));
+    }
+}

--- a/firmware/runtime/src/memory/mod.rs
+++ b/firmware/runtime/src/memory/mod.rs
@@ -1,0 +1,17 @@
+//! Validated access to physical memory.
+//!
+//! [`MemoryRegistry`] records the platform's RAM, reserved, and MMIO ranges.
+//! It returns bounded [`SupervisorMemory`] and [`MmioRegion`] handles without
+//! exposing raw memory references.
+
+mod address;
+mod mmio;
+mod region;
+mod registry;
+mod supervisor;
+
+pub use address::PhysAddr;
+pub use mmio::{MmioRegion, MmioValue};
+pub use region::PhysAddrRange;
+pub use registry::MemoryRegistry;
+pub use supervisor::{ReadMemory, SupervisorMemory, WriteMemory};

--- a/firmware/runtime/src/memory/region.rs
+++ b/firmware/runtime/src/memory/region.rs
@@ -1,0 +1,122 @@
+//! Non-empty physical-address ranges.
+
+use super::PhysAddr;
+use crate::{Error, Result};
+
+/// A non-empty half-open range of physical addresses.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PhysAddrRange {
+    start: PhysAddr,
+    end: PhysAddr,
+}
+
+impl PhysAddrRange {
+    /// Creates the half-open range `[start, end)`.
+    ///
+    /// Returns [`Error::InvalidArgs`] when the range is empty or reversed.
+    pub fn new(start: PhysAddr, end: PhysAddr) -> Result<Self> {
+        if start >= end {
+            return Err(Error::InvalidArgs);
+        }
+        Ok(Self { start, end })
+    }
+
+    /// Creates the half-open range `[start, start + len)`.
+    ///
+    /// Returns [`Error::InvalidArgs`] when `len` is zero and [`Error::Overflow`]
+    /// when the end address is not representable.
+    pub fn from_start_len(start: PhysAddr, len: usize) -> Result<Self> {
+        if len == 0 {
+            return Err(Error::InvalidArgs);
+        }
+        let Some(end) = start.checked_add(len) else {
+            return Err(Error::Overflow);
+        };
+        Self::new(start, end)
+    }
+
+    /// Returns the first address in the range.
+    #[inline]
+    pub const fn start(self) -> PhysAddr {
+        self.start
+    }
+
+    /// Returns the first address after the range.
+    #[inline]
+    pub const fn end(self) -> PhysAddr {
+        self.end
+    }
+
+    /// Returns the size of the range in bytes.
+    #[inline]
+    pub const fn size(self) -> usize {
+        self.end.as_usize() - self.start.as_usize()
+    }
+
+    pub(crate) fn contains(self, other: Self) -> bool {
+        self.start <= other.start && other.end <= self.end
+    }
+
+    pub(crate) fn overlaps(self, other: Self) -> bool {
+        self.start < other.end && other.start < self.end
+    }
+
+    pub(crate) fn adjacent(self, other: Self) -> bool {
+        self.end == other.start || other.end == self.start
+    }
+
+    pub(crate) fn join(self, other: Self) -> Self {
+        let start = if self.start < other.start {
+            self.start
+        } else {
+            other.start
+        };
+        let end = if self.end > other.end {
+            self.end
+        } else {
+            other.end
+        };
+        Self { start, end }
+    }
+
+    pub(crate) fn subrange(self, offset: usize, len: usize) -> Result<Self> {
+        if len == 0 {
+            return Err(Error::InvalidArgs);
+        }
+        let start = self.start.checked_add(offset).ok_or(Error::Overflow)?;
+        let end = start.checked_add(len).ok_or(Error::Overflow)?;
+        if end > self.end {
+            return Err(Error::InvalidArgs);
+        }
+        Ok(Self { start, end })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranges_reject_empty_and_wrapping_inputs() {
+        assert_eq!(
+            PhysAddrRange::new(PhysAddr::new(1), PhysAddr::new(1)),
+            Err(Error::InvalidArgs)
+        );
+        assert_eq!(
+            PhysAddrRange::new(PhysAddr::new(2), PhysAddr::new(1)),
+            Err(Error::InvalidArgs)
+        );
+        assert_eq!(
+            PhysAddrRange::from_start_len(PhysAddr::new(usize::MAX), 2),
+            Err(Error::Overflow)
+        );
+    }
+
+    #[test]
+    fn subranges_reject_empty_overflowing_and_out_of_bounds_requests() {
+        let range = PhysAddrRange::from_start_len(PhysAddr::new(0x1000), 0x100).unwrap();
+        assert_eq!(range.subrange(0, 0), Err(Error::InvalidArgs));
+        assert_eq!(range.subrange(usize::MAX, 1), Err(Error::Overflow));
+        assert_eq!(range.subrange(0x80, 0x81), Err(Error::InvalidArgs));
+    }
+}

--- a/firmware/runtime/src/memory/registry.rs
+++ b/firmware/runtime/src/memory/registry.rs
@@ -1,0 +1,374 @@
+//! Registration of RAM and MMIO ranges.
+
+use alloc::vec::Vec;
+
+use super::{MmioRegion, MmioValue, PhysAddrRange, SupervisorMemory};
+use crate::{Error, Result};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RangeKind {
+    Ram,
+    Reserved,
+    Mmio,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RegisteredRange {
+    range: PhysAddrRange,
+    kind: RangeKind,
+}
+
+impl RegisteredRange {
+    const fn new(range: PhysAddrRange, kind: RangeKind) -> Self {
+        Self { range, kind }
+    }
+}
+
+/// Physical ranges registered for one firmware instance.
+///
+/// The registry is local state; Runtime does not install a global instance.
+/// Supervisor RAM is handed out once, and overlapping MMIO windows are never
+/// handed out independently.
+pub struct MemoryRegistry {
+    ranges: Vec<RegisteredRange>,
+    acquired_mmio: Vec<PhysAddrRange>,
+    supervisor_memory_acquired: bool,
+}
+
+impl MemoryRegistry {
+    /// Registers the platform's RAM, reserved, and MMIO ranges.
+    ///
+    /// Adjacent ranges in the same input group are combined. A reserved range
+    /// may be contained in RAM or MMIO; every other overlap is rejected.
+    /// Returns [`Error::InvalidArgs`] if the ranges violate these rules.
+    ///
+    /// # Safety
+    ///
+    /// 1. Every non-reserved RAM or MMIO address must identify the stated
+    ///    resource and remain accessible for the firmware's lifetime.
+    /// 2. Access to returned supervisor RAM must not conflict with live Rust
+    ///    references. The reserved input must exclude firmware allocations and
+    ///    statics.
+    /// 3. Side effects from any MMIO access made through a returned handle must
+    ///    not violate Rust memory safety.
+    /// 4. No other registry may independently hand out overlapping RAM or MMIO
+    ///    access.
+    pub unsafe fn from_ranges(
+        ram: impl IntoIterator<Item = PhysAddrRange>,
+        reserved: impl IntoIterator<Item = PhysAddrRange>,
+        mmio: impl IntoIterator<Item = PhysAddrRange>,
+    ) -> Result<Self> {
+        Ok(Self {
+            ranges: normalize(ram, reserved, mmio)?,
+            acquired_mmio: Vec::new(),
+            supervisor_memory_acquired: false,
+        })
+    }
+
+    /// Returns the registered supervisor RAM, excluding reserved ranges.
+    ///
+    /// This succeeds once. It returns [`Error::AccessDenied`] after the handle
+    /// has been issued and [`Error::NotEnoughResources`] if no RAM remains.
+    pub fn acquire_supervisor_memory(&mut self) -> Result<SupervisorMemory> {
+        if self.supervisor_memory_acquired {
+            return Err(Error::AccessDenied);
+        }
+
+        let mut available = Vec::new();
+        for ram in self.ranges(RangeKind::Ram) {
+            let mut cursor = ram.start();
+            for reserved in self.ranges(RangeKind::Reserved) {
+                if !ram.overlaps(reserved) {
+                    continue;
+                }
+                if cursor < reserved.start() {
+                    available.push(PhysAddrRange::new(cursor, reserved.start())?);
+                }
+                cursor = reserved.end();
+            }
+            if cursor < ram.end() {
+                available.push(PhysAddrRange::new(cursor, ram.end())?);
+            }
+        }
+
+        if available.is_empty() {
+            return Err(Error::NotEnoughResources);
+        }
+        self.supervisor_memory_acquired = true;
+        Ok(SupervisorMemory::new(available))
+    }
+
+    /// Returns a typed handle to a registered MMIO window.
+    ///
+    /// `T` fixes the width of every access through the returned handle and must
+    /// match the device's register layout. The range must be non-reserved and
+    /// must not overlap a window returned earlier.
+    /// Returns [`Error::AccessDenied`] when these requirements are not met.
+    pub fn acquire_mmio<T: MmioValue>(&mut self, range: PhysAddrRange) -> Result<MmioRegion<T>> {
+        if !self
+            .ranges(RangeKind::Mmio)
+            .any(|registered| registered.contains(range))
+            || self
+                .ranges(RangeKind::Reserved)
+                .any(|reserved| reserved.overlaps(range))
+            || self
+                .acquired_mmio
+                .iter()
+                .copied()
+                .any(|acquired| acquired.overlaps(range))
+        {
+            return Err(Error::AccessDenied);
+        }
+
+        self.acquired_mmio.push(range);
+        Ok(MmioRegion::new(range))
+    }
+
+    fn ranges(&self, kind: RangeKind) -> impl Iterator<Item = PhysAddrRange> + '_ {
+        self.ranges
+            .iter()
+            .filter(move |registered| registered.kind == kind)
+            .map(|registered| registered.range)
+    }
+}
+
+fn normalize(
+    ram: impl IntoIterator<Item = PhysAddrRange>,
+    reserved: impl IntoIterator<Item = PhysAddrRange>,
+    mmio: impl IntoIterator<Item = PhysAddrRange>,
+) -> Result<Vec<RegisteredRange>> {
+    let descriptions: Vec<_> = ram
+        .into_iter()
+        .map(|range| RegisteredRange::new(range, RangeKind::Ram))
+        .chain(
+            reserved
+                .into_iter()
+                .map(|range| RegisteredRange::new(range, RangeKind::Reserved)),
+        )
+        .chain(
+            mmio.into_iter()
+                .map(|range| RegisteredRange::new(range, RangeKind::Mmio)),
+        )
+        .collect();
+    let mut normalized = Vec::new();
+
+    for kind in [RangeKind::Ram, RangeKind::Reserved, RangeKind::Mmio] {
+        let mut same_kind: Vec<_> = descriptions
+            .iter()
+            .copied()
+            .filter(|registered| registered.kind == kind)
+            .collect();
+        same_kind.sort_unstable_by_key(|registered| registered.range.start());
+
+        for registered in same_kind {
+            let Some(previous) = normalized.last_mut() else {
+                normalized.push(registered);
+                continue;
+            };
+            if previous.kind != kind {
+                normalized.push(registered);
+            } else if previous.range.overlaps(registered.range) {
+                return Err(Error::InvalidArgs);
+            } else if previous.range.adjacent(registered.range) {
+                previous.range = previous.range.join(registered.range);
+            } else {
+                normalized.push(registered);
+            }
+        }
+    }
+
+    normalized.sort_unstable_by_key(|registered| registered.range.start());
+    for (index, first) in normalized.iter().copied().enumerate() {
+        for second in normalized[index + 1..].iter().copied() {
+            if second.range.start() >= first.range.end() {
+                break;
+            }
+            let allowed_reserved_range = match (first.kind, second.kind) {
+                (RangeKind::Reserved, RangeKind::Ram | RangeKind::Mmio) => {
+                    second.range.contains(first.range)
+                }
+                (RangeKind::Ram | RangeKind::Mmio, RangeKind::Reserved) => {
+                    first.range.contains(second.range)
+                }
+                _ => false,
+            };
+            if !allowed_reserved_range {
+                return Err(Error::InvalidArgs);
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{PhysAddr, ReadMemory, WriteMemory};
+
+    fn range(start: usize, len: usize) -> PhysAddrRange {
+        PhysAddrRange::from_start_len(PhysAddr::new(start), len).unwrap()
+    }
+
+    fn registry(
+        ram: &[PhysAddrRange],
+        reserved: &[PhysAddrRange],
+        mmio: &[PhysAddrRange],
+    ) -> MemoryRegistry {
+        MemoryRegistry {
+            ranges: normalize(
+                ram.iter().copied(),
+                reserved.iter().copied(),
+                mmio.iter().copied(),
+            )
+            .unwrap(),
+            acquired_mmio: Vec::new(),
+            supervisor_memory_acquired: false,
+        }
+    }
+
+    fn can_read(memory: &SupervisorMemory, range: PhysAddrRange) -> bool {
+        let mut output = alloc::vec![0; range.size()];
+        memory.read(range.start(), &mut output).is_ok()
+    }
+
+    #[test]
+    fn rejects_conflicting_overlaps() {
+        let ram = range(0x1000, 0x1000);
+        let overlapping_ram = range(0x1800, 0x1000);
+        assert_eq!(
+            normalize([ram, overlapping_ram], [], []).unwrap_err(),
+            Error::InvalidArgs
+        );
+
+        let mmio = range(0x1800, 0x100);
+        assert_eq!(
+            normalize([ram], [], [mmio]).unwrap_err(),
+            Error::InvalidArgs
+        );
+    }
+
+    #[test]
+    fn reserved_range_splits_supervisor_memory() {
+        let mut backing = [0u8; 0x1000];
+        let base = backing.as_mut_ptr() as usize;
+        let mut registry = registry(&[range(base, 0x1000)], &[range(base + 0x400, 0x200)], &[]);
+        let mut memory = registry.acquire_supervisor_memory().unwrap();
+
+        assert!(can_read(&memory, range(base, 0x400)));
+        assert_eq!(
+            memory.read(PhysAddr::new(base + 0x400), &mut [0; 1]),
+            Err(Error::InvalidArgs)
+        );
+        assert_eq!(memory.write(PhysAddr::new(base + 0x600), &[1]), Ok(()));
+        assert_eq!(
+            registry.acquire_supervisor_memory().err(),
+            Some(Error::AccessDenied)
+        );
+    }
+
+    #[test]
+    fn one_access_cannot_cross_ram_banks_or_holes() {
+        let mut backing = [0u8; 0x300];
+        let base = backing.as_mut_ptr() as usize;
+        let mut registry = registry(&[range(base, 0x100), range(base + 0x200, 0x100)], &[], &[]);
+        let memory = registry.acquire_supervisor_memory().unwrap();
+
+        assert_eq!(
+            memory.read(PhysAddr::new(base + 0x80), &mut [0; 0x80]),
+            Ok(())
+        );
+        assert_eq!(
+            memory.read(PhysAddr::new(base + 0x80), &mut [0; 0x180]),
+            Err(Error::InvalidArgs)
+        );
+    }
+
+    #[test]
+    fn mmio_is_issued_once_unless_explicitly_shared() {
+        let mut registry = registry(&[], &[], &[range(0x2000, 0x100)]);
+        let mmio = registry.acquire_mmio::<u32>(range(0x2040, 0x20)).unwrap();
+        let _shared = mmio.share();
+        let _narrow = mmio.subregion(4, 4).unwrap();
+
+        assert_eq!(
+            registry.acquire_mmio::<u32>(range(0x2050, 0x20)).err(),
+            Some(Error::AccessDenied)
+        );
+        assert!(registry.acquire_mmio::<u8>(range(0x2080, 0x20)).is_ok());
+    }
+
+    #[test]
+    fn adjacent_ranges_are_combined_but_holes_are_preserved() {
+        let mut backing = [0u8; 0x400];
+        let base = backing.as_mut_ptr() as usize;
+        let mut registry = registry(
+            &[
+                range(base, 0x100),
+                range(base + 0x100, 0x100),
+                range(base + 0x300, 0x100),
+            ],
+            &[],
+            &[],
+        );
+        let memory = registry.acquire_supervisor_memory().unwrap();
+
+        assert_eq!(
+            memory.read(PhysAddr::new(base + 0x80), &mut [0; 0x100]),
+            Ok(())
+        );
+        assert_eq!(
+            memory.read(PhysAddr::new(base + 0x180), &mut [0; 0x200]),
+            Err(Error::InvalidArgs)
+        );
+    }
+
+    #[test]
+    fn reserved_mmio_cannot_be_acquired() {
+        let mut registry = registry(&[], &[range(0x2040, 0x20)], &[range(0x2000, 0x100)]);
+
+        assert_eq!(
+            registry.acquire_mmio::<u8>(range(0x2030, 0x20)).err(),
+            Some(Error::AccessDenied)
+        );
+        assert!(registry.acquire_mmio::<u8>(range(0x2000, 0x40)).is_ok());
+        assert!(registry.acquire_mmio::<u8>(range(0x2060, 0xa0)).is_ok());
+    }
+
+    #[test]
+    fn input_order_does_not_change_normalization() {
+        let ram = [range(0x1000, 0x200), range(0x1200, 0x200)];
+        let reserved = [range(0x1100, 0x200)];
+        let forward = normalize(ram, reserved, []).unwrap();
+        let reverse = normalize([ram[1], ram[0]], reserved, []).unwrap();
+
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn reserved_range_can_span_adjacent_ram_inputs() {
+        let mut backing = [0u8; 0x200];
+        let base = backing.as_mut_ptr() as usize;
+        let mut registry = registry(
+            &[range(base, 0x100), range(base + 0x100, 0x100)],
+            &[range(base + 0x80, 0x100)],
+            &[],
+        );
+        let memory = registry.acquire_supervisor_memory().unwrap();
+
+        assert!(can_read(&memory, range(base, 0x80)));
+        assert_eq!(
+            memory.read(PhysAddr::new(base + 0x80), &mut [0; 0x100]),
+            Err(Error::InvalidArgs)
+        );
+        assert!(can_read(&memory, range(base + 0x180, 0x80)));
+    }
+
+    #[test]
+    fn acquiring_missing_supervisor_memory_reports_resource_exhaustion() {
+        let mut registry = registry(&[], &[], &[]);
+        assert_eq!(
+            registry.acquire_supervisor_memory().err(),
+            Some(Error::NotEnoughResources)
+        );
+    }
+}

--- a/firmware/runtime/src/memory/supervisor.rs
+++ b/firmware/runtime/src/memory/supervisor.rs
@@ -1,0 +1,151 @@
+//! Bounded access to supervisor-accessible RAM.
+
+use alloc::vec::Vec;
+
+use super::{PhysAddr, PhysAddrRange};
+use crate::{Error, Result};
+
+/// Reads complete byte sequences from registered memory.
+pub trait ReadMemory {
+    /// Copies `output.len()` bytes starting at `start` into `output`.
+    ///
+    /// The operation either initializes the complete output slice or returns
+    /// an error. An empty output succeeds without inspecting `start`.
+    /// A non-empty span must fit within one registered RAM range.
+    fn read(&self, start: PhysAddr, output: &mut [u8]) -> Result<()>;
+}
+
+/// Writes complete byte sequences to registered memory.
+pub trait WriteMemory {
+    /// Copies all of `input` to memory starting at `start`.
+    ///
+    /// The operation either writes the complete input slice or returns an
+    /// error. An empty input succeeds without inspecting `start`.
+    /// A non-empty span must fit within one registered RAM range.
+    fn write(&mut self, start: PhysAddr, input: &[u8]) -> Result<()>;
+}
+
+/// Bounded access to registered supervisor RAM.
+///
+/// The handle may cover multiple RAM banks.
+/// It can be shared for concurrent reads, while writes require an exclusive
+/// borrow. It cannot be cloned or used to manufacture raw slices.
+/// Access faults are not recovered because registered RAM is required to
+/// remain accessible.
+pub struct SupervisorMemory {
+    regions: Vec<PhysAddrRange>,
+}
+
+impl SupervisorMemory {
+    pub(crate) fn new(regions: Vec<PhysAddrRange>) -> Self {
+        Self { regions }
+    }
+
+    fn check_access(&self, start: PhysAddr, len: usize) -> Result<()> {
+        if len == 0 {
+            return Ok(());
+        }
+        let range = PhysAddrRange::from_start_len(start, len)?;
+        if self
+            .regions
+            .iter()
+            .copied()
+            .any(|available| available.contains(range))
+        {
+            Ok(())
+        } else {
+            Err(Error::InvalidArgs)
+        }
+    }
+}
+
+impl ReadMemory for SupervisorMemory {
+    fn read(&self, start: PhysAddr, output: &mut [u8]) -> Result<()> {
+        self.check_access(start, output.len())?;
+        for (offset, byte) in output.iter_mut().enumerate() {
+            // SAFETY:
+            // 1. `check_access` confines the complete span to one registered
+            //    RAM range that permits volatile byte access.
+            // 2. `u8` has no alignment restriction and every bit pattern is
+            //    valid.
+            *byte = unsafe { (start.as_usize() as *const u8).add(offset).read_volatile() };
+        }
+        Ok(())
+    }
+}
+
+impl WriteMemory for SupervisorMemory {
+    fn write(&mut self, start: PhysAddr, input: &[u8]) -> Result<()> {
+        self.check_access(start, input.len())?;
+        for (offset, byte) in input.iter().copied().enumerate() {
+            // SAFETY:
+            // 1. `check_access` confines the complete span to one registered
+            //    RAM range that permits volatile byte access.
+            // 2. `u8` has no alignment restriction.
+            unsafe {
+                (start.as_usize() as *mut u8)
+                    .add(offset)
+                    .write_volatile(byte)
+            };
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn reads_and_writes_complete_bounded_slices() {
+        let mut backing = [1u8, 2, 3, 4];
+        let range = PhysAddrRange::from_start_len(
+            PhysAddr::new(backing.as_mut_ptr() as usize),
+            backing.len(),
+        )
+        .unwrap();
+        let mut memory = SupervisorMemory::new(vec![range]);
+
+        let mut output = [0; 4];
+        assert_eq!(memory.read(range.start(), &mut output), Ok(()));
+        assert_eq!(output, backing);
+
+        assert_eq!(memory.write(range.start(), &[9, 8, 7, 6]), Ok(()));
+        assert_eq!(backing, [9, 8, 7, 6]);
+        assert_eq!(
+            memory.read(range.end(), &mut [0; 1]),
+            Err(Error::InvalidArgs)
+        );
+    }
+
+    #[test]
+    fn zero_length_access_does_not_require_an_addressable_byte() {
+        let mut memory = SupervisorMemory::new(vec![
+            PhysAddrRange::from_start_len(PhysAddr::new(1), 1).unwrap(),
+        ]);
+        assert_eq!(memory.read(PhysAddr::new(usize::MAX), &mut []), Ok(()));
+        assert_eq!(memory.write(PhysAddr::new(usize::MAX), &[]), Ok(()));
+    }
+
+    #[test]
+    fn overflowing_access_is_rejected_before_memory_is_touched() {
+        let memory = SupervisorMemory::new(vec![
+            PhysAddrRange::from_start_len(PhysAddr::new(1), 1).unwrap(),
+        ]);
+        let mut output = [0xaa; 2];
+
+        assert_eq!(
+            memory.read(PhysAddr::new(usize::MAX), &mut output),
+            Err(Error::Overflow)
+        );
+        assert_eq!(output, [0xaa; 2]);
+    }
+
+    #[test]
+    fn supervisor_memory_is_shareable_by_reference() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SupervisorMemory>();
+    }
+}


### PR DESCRIPTION
## Summary

- add a workspace-private firmware Runtime crate with an initial `memory` module
- represent physical addresses and non-empty address ranges explicitly
- register RAM, reserved, and MMIO ranges without installing global state
- provide bounded supervisor-memory access and typed `MmioRegion<T>` handles
- reject conflicting ranges and prevent independent overlapping MMIO acquisition

## Design

Unsafe physical-resource trust is concentrated in `MemoryRegistry::from_ranges`. The returned interfaces keep raw pointers private, require complete in-range supervisor-memory operations, and fix each MMIO window to one access width.

This PR intentionally does not wire Prototyper into the new Runtime. A follow-up can add the Runtime-owned registration seam and migrate one caller at a time.

## Verification

- `cargo test -p rustsbi-firmware-runtime`
- `cargo clippy -p rustsbi-firmware-runtime --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p rustsbi-firmware-runtime --no-deps`
- `cargo check -p rustsbi-firmware-runtime --target riscv64imac-unknown-none-elf`
- `cargo check -p rustsbi-firmware-runtime --target riscv32imac-unknown-none-elf`