### PR TITLE
fix(prototyper): initialize hart-local state before use

### DIFF
--- a/firmware/prototyper/src/main.rs
+++ b/firmware/prototyper/src/main.rs
@@ -37,6 +37,8 @@ fn main(boot: BootInfo) {
 }
 
 fn boot_hart(mut boot: BootInfo) {
+    // SAFETY: Only the boot hart initializes state; secondaries wait for publication.
+    unsafe { trap_stack::init() };
     heap::init();
     let platform_description = boot
         .take_platform_description()
@@ -69,10 +71,10 @@ fn boot_hart(mut boot: BootInfo) {
 }
 
 fn secondary_hart(boot: &BootInfo) {
+    platform::wait_until_ready();
     detect_hart_features();
     trap_stack::prepare_for_trap();
 
-    platform::wait_until_ready();
     platform::initialize_secondary_hart();
     firmware::set_pmp(&platform::firmware_ram_range());
 

--- a/firmware/prototyper/src/riscv/csr.rs
+++ b/firmware/prototyper/src/riscv/csr.rs
@@ -83,6 +83,9 @@ pub fn has_csr<const CSR: u16>() -> bool {
             "mv {}, a0",
             const CSR,
             out(reg) res,
+            out("a0") _,
+            out("a1") _,
+            out("a2") _,
             options(nomem));
         asm!("csrw mtvec, {}", in(reg) mtvec);
     }

--- a/firmware/prototyper/src/sbi/early_trap.rs
+++ b/firmware/prototyper/src/sbi/early_trap.rs
@@ -75,6 +75,8 @@ pub(crate) unsafe fn csr_read_allow<const CSR_NUM: u16>(trap_info: *mut TrapInfo
             tinfo = in(reg) tinfo,
             ret = out(reg) ret,
             csr = const CSR_NUM,
+            out("a3") _,
+            out("a4") _,
             options(nostack, preserves_flags)
         );
         asm!("csrw mtvec, {}", in(reg) mtvec);
@@ -99,6 +101,8 @@ pub(crate) unsafe fn csr_write_allow<const CSR_NUM: u16>(trap_info: *mut TrapInf
             tinfo = in(reg) tinfo,
             csr = const CSR_NUM,
             value = in(reg) value,
+            out("a3") _,
+            out("a4") _,
             options(nostack, preserves_flags)
         );
         asm!("csrw mtvec, {}", in(reg) mtvec);

--- a/firmware/prototyper/src/sbi/features.rs
+++ b/firmware/prototyper/src/sbi/features.rs
@@ -13,6 +13,7 @@ use crate::sbi::early_trap::TrapInfo;
 use crate::sbi::trap_stack::{hart_local, with_current, with_hart};
 use runtime::node_is_enabled;
 
+#[derive(Default)]
 pub struct HartFeatures {
     extensions: [bool; Extension::COUNT],
     privileged_version: PrivilegedVersion,
@@ -24,10 +25,15 @@ impl HartFeatures {
     pub const fn privileged_version(&self) -> PrivilegedVersion {
         self.privileged_version
     }
+
+    pub const fn mhpm_mask(&self) -> u32 {
+        self.mhpm_mask
+    }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PrivilegedVersion {
+    #[default]
     Unknown = 0,
     Version1_10 = 1,
     Version1_11 = 2,

--- a/firmware/prototyper/src/sbi/hart_context.rs
+++ b/firmware/prototyper/src/sbi/hart_context.rs
@@ -69,12 +69,21 @@ const _: () = assert!(STACK_SIZE_PER_HART.is_multiple_of(core::mem::align_of::<H
 const _: () = assert!(core::mem::offset_of!(HartContext, frame) == 0);
 
 impl HartLocal {
-    /// Initialize the hart-local state by creating new HSM and RFence cells
+    /// Creates hart-local state before feature discovery.
+    pub(crate) fn new() -> Self {
+        Self {
+            hsm: HsmCell::new(),
+            rfence: RFenceCell::new(),
+            ipi_type: AtomicU8::new(0),
+            features: HartFeatures::default(),
+            pmu_state: PmuState::new(0),
+        }
+    }
+
+    /// Configures PMU state from this hart's detected counters.
     #[inline]
-    pub fn init(&mut self) {
-        self.hsm = HsmCell::new();
-        self.rfence = RFenceCell::new();
-        self.pmu_state = PmuState::new();
+    pub fn init_pmu(&mut self) {
+        self.pmu_state = PmuState::new(self.features.mhpm_mask());
     }
 
     #[inline]
@@ -104,7 +113,7 @@ impl HartLocal {
             }
         }
         // reset hart pmu state
-        self.pmu_state = PmuState::new();
+        self.init_pmu();
     }
 }
 

--- a/firmware/prototyper/src/sbi/pmu.rs
+++ b/firmware/prototyper/src/sbi/pmu.rs
@@ -46,8 +46,7 @@ pub struct PmuState {
 
 impl PmuState {
     /// Creates a new PMU state with default configuration.
-    pub fn new() -> Self {
-        let mhpm_mask = hart_mhpm_mask(current_hartid());
+    pub fn new(mhpm_mask: u32) -> Self {
         let hw_counters_num = mhpm_mask.count_ones() as usize;
         let total_counters_num = hw_counters_num + PMU_FIRMWARE_COUNTER_MAX;
 

--- a/firmware/prototyper/src/sbi/trap_stack.rs
+++ b/firmware/prototyper/src/sbi/trap_stack.rs
@@ -11,10 +11,10 @@ use crate::sbi::trap::fast_handler;
 use alloc::collections::VecDeque;
 use core::cell::UnsafeCell;
 use core::hint::spin_loop;
-use core::mem::forget;
+use core::mem::{MaybeUninit, forget};
 use core::ptr::{addr_of, addr_of_mut};
 use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
-use fast_trap::FreeTrapStack;
+use fast_trap::{FlowContext, FreeTrapStack};
 use rustsbi::spec::hsm::hart_state;
 use spin::Mutex;
 
@@ -25,7 +25,7 @@ use spin::Mutex;
 /// - Middle: Stack space for the hart.
 /// - Top: Trap handling space.
 #[repr(C, align(128))]
-struct HartStack(UnsafeCell<[u8; STACK_SIZE_PER_HART]>);
+struct HartStack(UnsafeCell<MaybeUninit<[u8; STACK_SIZE_PER_HART]>>);
 
 // SAFETY: `HartStack` is raw storage addressed by hart id: the naked entry
 // (`locate`) reaches it via `sym ROOT_STACK` and the trap framework via the
@@ -38,10 +38,24 @@ unsafe impl Sync for HartStack {}
 /// Root stack array for all harts, placed in BSS stack section.
 #[used]
 #[unsafe(link_section = ".bss.stack")]
-static ROOT_STACK: [HartStack; NUM_HART_MAX] = [const { HartStack::zero() }; NUM_HART_MAX];
+static ROOT_STACK: [HartStack; NUM_HART_MAX] = [const { HartStack::uninit() }; NUM_HART_MAX];
 
 // Make sure stack address can be aligned.
 const _: () = assert!(STACK_SIZE_PER_HART.is_multiple_of(core::mem::align_of::<HartStack>()));
+const _: () = assert!(size_of::<HartContext>() < STACK_SIZE_PER_HART);
+
+/// Initializes the state at the bottom of every stack slot.
+///
+/// # Safety
+/// Call once on the boot hart before accessing hart state.
+/// Other harts must wait until platform publication.
+pub(crate) unsafe fn init() {
+    for slot in &ROOT_STACK {
+        let context = slot.0.get().cast::<HartContext>();
+        // SAFETY: Each aligned prefix is reserved; write does not drop DDR contents.
+        unsafe { addr_of_mut!((*context).local).write(HartLocal::new()) };
+    }
+}
 
 /// Returns the raw slot of `hart_id`, or `None` when out of range.
 #[inline]
@@ -426,10 +440,9 @@ pub fn reset_hart(hart_id: usize) {
 }
 
 impl HartStack {
-    /// All-zero slot, usable as an array repeat operand (const fn form;
-    /// a `const` item would carry interior mutability).
-    const fn zero() -> Self {
-        Self(UnsafeCell::new([0; STACK_SIZE_PER_HART]))
+    /// Reserves stack storage without initializing its bytes.
+    const fn uninit() -> Self {
+        Self(UnsafeCell::new(MaybeUninit::uninit()))
     }
 
     /// Initializes stack for trap handling.
@@ -437,18 +450,21 @@ impl HartStack {
     /// - Creates and loads FreeTrapStack with the stack range.
     fn load_as_stack(slot: &'static Self) {
         let context = slot.0.get().cast::<HartContext>();
-        // SAFETY: this hart owns `slot`, and the trap entry starts using the
-        // installed frame pointer only once `FreeTrapStack::load` runs below.
-        let context_ptr = unsafe { (*addr_of_mut!((*context).frame)).context_ptr() };
-        unsafe { (*addr_of_mut!((*context).local)).init() };
+        // SAFETY: This hart owns its frame; initialize it before forming references.
+        let context_ptr = unsafe {
+            addr_of_mut!((*context).frame.trap).write(FlowContext::ZERO);
+            (*addr_of_mut!((*context).frame)).context_ptr()
+        };
+        // SAFETY: init constructed local state before this hart was released.
+        unsafe { (*addr_of_mut!((*context).local)).init_pmu() };
 
         // Get stack memory range.
-        let range = unsafe { (*slot.0.get()).as_ptr_range() };
+        let start = slot.0.get().cast::<u8>() as usize;
 
         // Create and load trap stack, forgetting it to avoid drop
         forget(
             FreeTrapStack::new(
-                range.start as usize..range.end as usize,
+                start..start + STACK_SIZE_PER_HART,
                 |_| {}, // Empty callback
                 context_ptr,
                 fast_handler,


### PR DESCRIPTION
HartLocal resides in stack memory excluded from BSS clearing. Feature discovery accesses this uninitialized state, and ordinary
assignment to the RFence queue attempts to drop uninitialized contents, causing boot failures when RAM is not zeroed.

This will happen on real hardware when the memory is not natually zeroed upon hardware reset. QEMU will zero all the memory, hiding this bug from being revealed.

Real board output:

<img width="826" height="476" alt="图片" src="https://github.com/user-attachments/assets/94e4c31d-d456-4dbd-9033-c14a0ad4e5e8" />

<img width="1482" height="1628" alt="图片" src="https://github.com/user-attachments/assets/7cd73051-68cd-4d3f-9526-05fea3fd8d3e" />

Serial log:

<details>
  <summary>Full serial log on SpacemiT Muse Card (SpacemiT M1 SoC)</summary>

```bash
sys: 0x200
try sd...
bm:3
ERROR:   sd: invalid bootinfo magic code:0x1000b8fa
ERROR:   invalid bootinfo image.
ERROR:   sd f! l:90
bm:4
nor m:0xc8 d:0x4017
j...

U-Boot SPL 2022.10spacemit-00008-g5620db9a (Jun 13 2025 - 11:27:43 +0800)
[   0.490] DDR type LPDDR4X
[   0.490] set ddr tx odt to 80ohm!
[   0.511] lpddr4_silicon_init consume 21ms
[   0.512] Change DDR data rate to 2400MT/s
[   0.815] Boot from fit configuration k1-x_MUSE-Card
[   0.817] ## Checking hash(es) for config conf_11 ... OK
[   0.822] ## Checking hash(es) for Image uboot ... crc32+ OK
[   0.833] ## Checking hash(es) for Image fdt_11 ... crc32+ OK
[   0.876] Boot from fit configuration k1-x_MUSE-Card
[   0.878] ## Checking hash(es) for config conf ... OK
[   0.883] ## Checking hash(es) for Image sbi ... crc32+ OK
[RustSBI] INFO  - Hello RustSBI!
[RustSBI] INFO  - RustSBI version 0.4.1
[RustSBI] INFO  - .______       __    __      _______.___________.  _______..______   __
[RustSBI] INFO  - |   _  \     |  |  |  |    /       |           | /       ||   _  \ |  |
[RustSBI] INFO  - |  |_)  |    |  |  |  |   |   (----`---|  |----`|   (----`|  |_)  ||  |
[RustSBI] INFO  - |      /     |  |  |  |    \   \       |  |      \   \    |   _  < |  |
[RustSBI] INFO  - |  |\  \----.|  `--'  |.----)   |      |  |  .----)   |   |  |_)  ||  |
[RustSBI] INFO  - | _| `._____| \______/ |_______/       |__|  |_______/    |______/ |__|
[RustSBI] INFO  - Initializing RustSBI machine-mode environment.
[RustSBI] INFO  - Platform Name                 : spacemit k1-x MUSE-Card board
[RustSBI] INFO  - Platform HART Count           : 8
[RustSBI] INFO  - Enabled HARTs                 : [0, 1, 2, 3, 4, 5, 6, 7]
[RustSBI] INFO  - Platform IPI Extension        : SiFiveClint (Base Address: 0xe4000000)
[RustSBI] INFO  - Platform Console Extension    : UartSpacemitK1 (Base Address: 0xd4017000)
[RustSBI] WARN  - Platform Reset Device         : Not Available
[RustSBI] INFO  - Platform HSM Extension        : Available
[RustSBI] INFO  - Platform RFence Extension     : Available
[RustSBI] INFO  - Platform SUSP Extension       : Available
[RustSBI] INFO  - Platform PMU Extension        : Available
[RustSBI] INFO  - Platform RAM                  : 0x0 - 0x80000000
[RustSBI] INFO  -                               : 0x100000000 - 0x280000000
[RustSBI] INFO  - PMP Configuration
[RustSBI] INFO  - PMP   Range      Permission      Address                       
[RustSBI] INFO  - 0     OFF        NONE            0x0000000000000000
[RustSBI] INFO  - 1     TOR        RWX             0x0000000000000000
[RustSBI] INFO  - 2     TOR        RWX             0x0000000000010000
[RustSBI] INFO  - 3     TOR        R               0x0000000000043000
[RustSBI] INFO  - 4     TOR        NONE            0x0000000000052000
[RustSBI] INFO  - 5     TOR        RW              0x0000000000178000
[RustSBI] INFO  - 6     TOR        RWX             0x0000000080000000
[RustSBI] INFO  - 7     TOR        RWX             0x000000fffffff000
[RustSBI] INFO  - Boot HART ID                  : 0
[RustSBI] INFO  - Boot HART Privileged Version: : Version1_12
[RustSBI] INFO  - Boot HART MHPM Mask:          : 0x07ffff
[RustSBI] INFO  - Redirecting hart 0 to 0x00000000200000 in Supervisor mode.
[   1.174] 

U-Boot 2022.10spacemit-00008-g5620db9a (Jun 13 2025 - 11:27:43 +0800)

[   1.179] CPU:   rv64imafdcv
[   1.182] Model: spacemit k1-x MUSE-Card board
[   1.186] DRAM:  DDR size = 8192 MB
[   1.190] 8 GiB
[   1.267] reset driver probe start 
[   1.270] reset driver probe finish 
[   1.297] Core:  419 devices, 32 uclasses, devicetree: board
[   1.311] WDT:   Started PMIC_WDT with servicing (60s timeout)
[   1.316] WDT:   Started watchdog@D4080000 with servicing (60s timeout)
[   1.324] MMC:   sdh@d4280000: probe done.
[   1.328] sdh@d4280000: 0
[   1.330] Loading Environment from SPIFlash... k1x_qspi spi@d420c000: qspi iobase:0x0x00000000d420c000, ahb_addr:0x0x00000000b8000000, max_hz:26500000Hz
[   1.346] k1x_qspi spi@d420c000: rx buf size:128, tx buf size:256, ahb buf size=512
[   1.354] k1x_qspi spi@d420c000: AHB read enabled
[   1.358] k1x_qspi spi@d420c000: bus clock: 26500000Hz, PMUap reg[0xd4282860]:0x0000075b
[   1.366] k1x_qspi spi@d420c000: AHB buf size: 512
[   1.372] SF: Detected gd25q64 with page size 256 Bytes, erase size 64 KiB, total 8 MiB
OK
[   1.394] pcie_dw_k1x pcie@ca400000: has no power on gpio.
[   1.397] pcie_dw_k1x pcie@ca400000: has no power-on-status flag, use default.
[   1.404] Now init Rterm...
[   1.406] pcie prot id = 1, porta_init_done = 0
[   1.411] Now waiting portA resister tuning done...
[   1.415] porta redonly_reg2: 00005d47
[   1.419] pcie_rcal = 0x00005d47
[   1.422] pcie port id = 1, lane num = 2
[   1.426] Now int init_puphy...
[   1.429] waiting pll lock...
[   1.431] Now finish init_puphy....
[   1.435] pcie_dw_k1x pcie@ca400000: Unable to get phy0
[   1.440] pcie_dw_k1x pcie@ca400000: Unable to get phy1
[   2.546] PCIE-0: Link down
[   2.550] Cannot find blk device
[   2.550] Cannot find blk device
[   2.553] can not get available blk dev
[   2.557] initialize_console_log_buffer
[   2.560] Have allocated memory for console log buffer
[   2.565] In:    serial
[   2.567] Out:   serial
[   2.570] Err:   serial
[   2.573] Default to 100kHz
[   2.690] valid ethaddr: fe:fe:fe:52:c0:6a
[   2.691] TLV item: product_name = k1-x_MUSE-Card
[   2.702] Found device 'hdmi@c0400500', disp_uc_priv=000000007de9c890
[   2.814] HDMI cannot get HPD signal
[   2.814] spacemit_display_init: device 'dpu@c0340000' display won't probe (ret=-1)
[   2.936] HDMI cannot get HPD signal
[   2.936] display devices not found or not probed yet: -1
[   2.941] All buttons probed successfully
[   2.946] Read PMIC reg ab value f4
[   2.949] Failed to get fastboot key config: -19
[   2.953] Net:   RGMII interface
[   2.956] eth0: ethernet@cac80000
[   2.962] Hit any key to stop autoboot:  0 
Scanning for bootflows in all bootdevs
[   5.977] Seq  Method       State   Uclass    Part  Name                      Filename
[   5.985] ---  -----------  ------  --------  ----  ------------------------  ----------------
[   5.993] Scanning global bootmeth 'efi_mgr':
[   5.997] Scanning bootdev 'sdh@d4280000.bootdev':
[   6.135] sdh@d4280000: set tx_delaycode: 143
[   6.220] sdh@d4280000: pass window [0 80) 
[   6.317] sdh@d4280000: pass window [85 174) 
[   6.320] sdh@d4280000: pass window [175 176) 
[   6.325] sdh@d4280000: pass window [177 178) 
[   6.405] sdh@d4280000: pass window [189 255) 
[   6.406] sdh@d4280000: tuning done, use the firstly delay_code:129
[   6.420] Scanning bootdev 'ethernet@cac80000.bootdev':
[   6.669] ethernet@cac80000 Waiting for PHY auto negotiation to complete......... TIMEOUT !
[  11.550] phy_startup() failed: -110FAILED: -110missing environment variable: pxeuuid
[  11.555] Retrieving file: pxelinux.cfg/01-fe-fe-fe-52-c0-6a
[  11.703] ethernet@cac80000 Waiting for PHY auto negotiation to complete......... TIMEOUT !
[  16.584] phy_startup() failed: -110FAILED: -110Retrieving file: pxelinux.cfg/0A005CFD
[  16.728] ethernet@cac80000 Waiting for PHY auto negotiation to complete.....
```
</details>