### PR TITLE
feat(prototyper): support RV32 and Yuzuki Neko

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased
 
 ### Added
+- Add RV32 support to RustSBI Prototyper and test-kernel while preserving RV64 support.
+- Add Yuzuki Neko board configuration with an RV32 firmware jump target of `0x40000000`.
 - Add SBI Collaborative Processor Performance Control extension support to RustSBI Prototyper.
 - Add SBI Message Proxy extension support to RustSBI Prototyper.
 - Add SBI Steal-time Accounting extension support to RustSBI Prototyper.

--- a/firmware/macros/src/lib.rs
+++ b/firmware/macros/src/lib.rs
@@ -76,6 +76,7 @@ fn expand(attribute: TokenStream, item: TokenStream) -> TokenStream {
                     include_str!("entry/relocation.S"),
                     R_RISCV_RELATIVE = const R_RISCV_RELATIVE,
                     START_ADDRESS = const crate::cfg::SBI_LINK_START_ADDRESS,
+                    XLEN = const usize::BITS,
                 )
             }
 
@@ -107,6 +108,7 @@ fn expand(attribute: TokenStream, item: TokenStream) -> TokenStream {
                     locate_stack = sym crate::sbi::trap_stack::locate,
                     main = sym __rustsbi_prototyper_main,
                     hart_boot = sym crate::sbi::trap::boot::boot,
+                    XLEN = const usize::BITS,
                 )
             }
         };

--- a/firmware/prototyper/config/yuzuki_neko.toml
+++ b/firmware/prototyper/config/yuzuki_neko.toml
@@ -1,0 +1,27 @@
+# Yuzuki Neko (Allwinner F101S3 / XuanTie C907, 16 MiB PSRAM).
+# Matches the SyterKit Yuzuki Neko spinor-boot / usb-boot memory layout:
+#   0x40000000: next-stage image
+#   0x40f40000: device tree (up to 256 KiB, passed in a1)
+#   0x40f80000: SBI firmware (512 KiB, including stack and heap)
+#
+# Build with an RV32 M-mode loader and an RV32 S-mode next stage:
+# cargo prototyper build --target riscv32imac-unknown-none-elf \
+#     --config-file firmware/prototyper/config/yuzuki_neko.toml jump
+# The loader must initialize PSRAM, clocks, UART1 and the C907 before entry.
+# Console and interrupt controllers are discovered from the supplied DTB.
+
+num_hart_max = 1
+stack_size_per_hart = 16384 # 16 KiB
+heap_size = 0x15000 # 84 KiB
+page_size = 4096
+log_level = "INFO"
+link_start_address = 0x40f80000
+# Unused in jump mode. This address is the end of PSRAM, so this config
+# must not be used to embed a payload; load the next stage separately.
+payload_address = 0x41000000
+jump_address = 0x40000000
+tlb_flush_limit = 16384 # page_size * 4
+
+[[next_addr]]
+start = 0x40000000
+end = 0x40f40000

--- a/firmware/prototyper/src/driver/clint/sifive.rs
+++ b/firmware/prototyper/src/driver/clint/sifive.rs
@@ -95,14 +95,49 @@ impl SiFiveTimer {
     }
 
     fn read(&self, reg: TimerRegister) -> u64 {
-        self.registers
+        #[cfg(target_pointer_width = "64")]
+        return self
+            .registers
             .read(reg.offset())
-            .expect("BUG: SiFive CLINT timer register escaped its MMIO window")
+            .expect("BUG: SiFive CLINT timer register escaped its MMIO window");
+
+        #[cfg(target_pointer_width = "32")]
+        loop {
+            let high = self.read_word(reg.offset() + 4);
+            let low = self.read_word(reg.offset());
+            if high == self.read_word(reg.offset() + 4) {
+                return (u64::from(high) << 32) | u64::from(low);
+            }
+        }
     }
 
     fn write_mtimecmp(&self, hart_id: usize, value: u64) {
+        let offset = TimerRegister::mtimecmp_offset_for_hart(hart_id);
+        #[cfg(target_pointer_width = "64")]
         self.registers
-            .write(TimerRegister::mtimecmp_offset_for_hart(hart_id), value)
+            .write(offset, value)
+            .expect("BUG: SiFive CLINT timer register escaped its MMIO window");
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            // Compare-safe split writes, as in the T-Head CLINT backend.
+            self.write_word(offset, u32::MAX);
+            self.write_word(offset + 4, (value >> 32) as u32);
+            self.write_word(offset, value as u32);
+        }
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn read_word(&self, offset: usize) -> u32 {
+        self.registers
+            .read(offset)
+            .expect("BUG: SiFive CLINT timer register escaped its MMIO window")
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn write_word(&self, offset: usize, value: u32) {
+        self.registers
+            .write(offset, value)
             .expect("BUG: SiFive CLINT timer register escaped its MMIO window")
     }
 }

--- a/firmware/prototyper/src/entry/relocation.S
+++ b/firmware/prototyper/src/entry/relocation.S
@@ -10,6 +10,8 @@
    lla t1, __rel_dyn_end
    li  t3, {R_RISCV_RELATIVE}
 1:
+   bgeu t0, t1, 3f
+.if {XLEN} == 64
    ld  t4, 8(t0)
    bne t4, t3, 2f
    ld t4, 0(t0)  // Get target address
@@ -19,7 +21,19 @@
    sd t5, 0(t4)  // Write the relocated address
 2:
    addi t0, t0, 24 // Get next rela item
-   blt t0, t1, 1b
+.else
+   lw t4, 4(t0)  // Elf32_Rela.r_info
+   bne t4, t3, 2f
+   lw t4, 0(t0)  // Elf32_Rela.r_offset
+   lw t5, 8(t0)  // Elf32_Rela.r_addend
+   add t4, t4, t2
+   add t5, t5, t2
+   sw t5, 0(t4)
+2:
+   addi t0, t0, 12
+.endif
+   j 1b
+3:
    fence.i
 
 // Return

--- a/firmware/prototyper/src/entry/start.S
+++ b/firmware/prototyper/src/entry/start.S
@@ -24,8 +24,13 @@ csrw    mie, zero
     lla     t1, sbi_bss_end
 2:
     bgeu    t0, t1, 3f
+.if {XLEN} == 64
     sd      zero, 0(t0)
     addi    t0, t0, 8
+.else
+    sw      zero, 0(t0)
+    addi    t0, t0, 4
+.endif
     j       2b
 3:
     lla     t0, 7f

--- a/firmware/prototyper/src/firmware/mod.rs
+++ b/firmware/prototyper/src/firmware/mod.rs
@@ -581,6 +581,35 @@ static mut FIRMWARE_END_ADDRESS: usize = 0;
 static mut FIRMWARE_RODATA_START_ADDRESS: usize = 0;
 static mut FIRMWARE_RODATA_END_ADDRESS: usize = 0;
 
+/// Programs one of the first sixteen PMP entries, accounting for XLEN.
+///
+/// # Safety
+/// Called during M-mode initialization on a hart with these PMP entries.
+unsafe fn set_pmp_config(
+    index: usize,
+    range: register::Range,
+    permission: Permission,
+    locked: bool,
+) {
+    use riscv::register::*;
+    let slot = index % size_of::<usize>();
+    // SAFETY: each match arm addresses a valid slot in its native-width CSR.
+    unsafe {
+        match index / size_of::<usize>() {
+            0 => pmpcfg0::set_pmp(slot, range, permission, locked),
+            #[cfg(target_pointer_width = "32")]
+            1 => pmpcfg1::set_pmp(slot, range, permission, locked),
+            #[cfg(target_pointer_width = "32")]
+            2 => pmpcfg2::set_pmp(slot, range, permission, locked),
+            #[cfg(target_pointer_width = "32")]
+            3 => pmpcfg3::set_pmp(slot, range, permission, locked),
+            #[cfg(target_pointer_width = "64")]
+            1 => pmpcfg2::set_pmp(slot, range, permission, locked),
+            _ => unreachable!("firmware uses only the first sixteen PMP entries"),
+        }
+    }
+}
+
 /// Installs PMP entries isolating firmware memory from S-mode.
 pub fn set_pmp(firmware_ram: &Range<usize>) {
     // SAFETY: M-mode PMP programming on this hart; the linker symbols and
@@ -644,52 +673,52 @@ pub fn set_pmp(firmware_ram: &Range<usize>) {
                 .max()
                 .unwrap_or(machine_imsic_start + 0x1000);
 
-            pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
+            set_pmp_config(0, Range::OFF, Permission::NONE, false);
             pmpaddr0::write(0);
-            pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
+            set_pmp_config(1, Range::TOR, Permission::RWX, false);
             pmpaddr1::write(clint_start >> 2);
-            pmpcfg0::set_pmp(2, Range::TOR, Permission::NONE, false);
+            set_pmp_config(2, Range::TOR, Permission::NONE, false);
             pmpaddr2::write(clint_end >> 2);
-            pmpcfg0::set_pmp(3, Range::TOR, Permission::RWX, false);
+            set_pmp_config(3, Range::TOR, Permission::RWX, false);
             pmpaddr3::write(aplic_start >> 2);
-            pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
+            set_pmp_config(4, Range::TOR, Permission::NONE, false);
             pmpaddr4::write(aplic_end >> 2);
-            pmpcfg0::set_pmp(5, Range::TOR, Permission::RWX, false);
+            set_pmp_config(5, Range::TOR, Permission::RWX, false);
             pmpaddr5::write(machine_imsic_start >> 2);
-            pmpcfg0::set_pmp(6, Range::TOR, Permission::NONE, false);
+            set_pmp_config(6, Range::TOR, Permission::NONE, false);
             pmpaddr6::write(machine_imsic_end >> 2);
-            pmpcfg0::set_pmp(7, Range::TOR, Permission::RWX, false);
+            set_pmp_config(7, Range::TOR, Permission::RWX, false);
             pmpaddr7::write(firmware_ram.start >> 2);
-            pmpcfg2::set_pmp(0, Range::TOR, Permission::RWX, false);
+            set_pmp_config(8, Range::TOR, Permission::RWX, false);
             pmpaddr8::write(FIRMWARE_START_ADDRESS >> 2);
-            pmpcfg2::set_pmp(1, Range::TOR, Permission::R, false);
+            set_pmp_config(9, Range::TOR, Permission::R, false);
             pmpaddr9::write(FIRMWARE_RODATA_START_ADDRESS >> 2);
-            pmpcfg2::set_pmp(2, Range::TOR, Permission::NONE, false);
+            set_pmp_config(10, Range::TOR, Permission::NONE, false);
             pmpaddr10::write(FIRMWARE_RODATA_END_ADDRESS >> 2);
-            pmpcfg2::set_pmp(3, Range::TOR, Permission::RW, false);
+            set_pmp_config(11, Range::TOR, Permission::RW, false);
             pmpaddr11::write(FIRMWARE_END_ADDRESS >> 2);
-            pmpcfg2::set_pmp(4, Range::TOR, Permission::RWX, false);
+            set_pmp_config(12, Range::TOR, Permission::RWX, false);
             pmpaddr12::write(firmware_ram.end >> 2);
-            pmpcfg2::set_pmp(5, Range::TOR, Permission::RWX, false);
+            set_pmp_config(13, Range::TOR, Permission::RWX, false);
             pmpaddr13::write(usize::MAX >> 2);
             return;
         }
 
-        pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
+        set_pmp_config(0, Range::OFF, Permission::NONE, false);
         pmpaddr0::write(0);
-        pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
+        set_pmp_config(1, Range::TOR, Permission::RWX, false);
         pmpaddr1::write(firmware_ram.start >> 2);
-        pmpcfg0::set_pmp(2, Range::TOR, Permission::RWX, false);
+        set_pmp_config(2, Range::TOR, Permission::RWX, false);
         pmpaddr2::write(FIRMWARE_START_ADDRESS >> 2);
-        pmpcfg0::set_pmp(3, Range::TOR, Permission::R, false);
+        set_pmp_config(3, Range::TOR, Permission::R, false);
         pmpaddr3::write(FIRMWARE_RODATA_START_ADDRESS >> 2);
-        pmpcfg0::set_pmp(4, Range::TOR, Permission::NONE, false);
+        set_pmp_config(4, Range::TOR, Permission::NONE, false);
         pmpaddr4::write(FIRMWARE_RODATA_END_ADDRESS >> 2);
-        pmpcfg0::set_pmp(5, Range::TOR, Permission::RW, false); // FIXME: should be `R`; `RW` temporarily allows S-mode DTB modification
+        set_pmp_config(5, Range::TOR, Permission::RW, false); // FIXME: should be `R`; `RW` temporarily allows S-mode DTB modification
         pmpaddr5::write(FIRMWARE_END_ADDRESS >> 2);
-        pmpcfg0::set_pmp(6, Range::TOR, Permission::RWX, false);
+        set_pmp_config(6, Range::TOR, Permission::RWX, false);
         pmpaddr6::write(firmware_ram.end >> 2);
-        pmpcfg0::set_pmp(7, Range::TOR, Permission::RWX, false);
+        set_pmp_config(7, Range::TOR, Permission::RWX, false);
         pmpaddr7::write(usize::MAX >> 2);
     }
 }
@@ -731,13 +760,17 @@ impl fmt::Display for RangeWrapper {
 /// Logs the active PMP configuration.
 pub fn log_pmp_cfg(_firmware_ram: &Range<usize>) {
     use riscv::register::*;
-    let pmp_config = pmpcfg0::read();
-
-    let get_pmp_range =
-        |index: usize| -> RangeWrapper { RangeWrapper(pmp_config.into_config(index).range) };
-    let get_pmp_permission = |index: usize| -> PermissionWrapper {
-        PermissionWrapper(pmp_config.into_config(index).permission)
+    let pmp_config = |index: usize| {
+        #[cfg(target_pointer_width = "32")]
+        if index >= 4 {
+            return pmpcfg1::read().into_config(index - 4);
+        }
+        pmpcfg0::read().into_config(index)
     };
+
+    let get_pmp_range = |index: usize| -> RangeWrapper { RangeWrapper(pmp_config(index).range) };
+    let get_pmp_permission =
+        |index: usize| -> PermissionWrapper { PermissionWrapper(pmp_config(index).permission) };
     info!("PMP Configuration");
 
     info!(

--- a/firmware/prototyper/src/platform/qemu_aplic/registers.rs
+++ b/firmware/prototyper/src/platform/qemu_aplic/registers.rs
@@ -49,9 +49,9 @@ impl EncodedMsiAddress {
             return Err(Error::InvalidArgs);
         }
 
-        let base_ppn = base.as_usize() >> PAGE_SHIFT;
-        if base_ppn & low_bits_mask(hart_index_bits) != 0
-            || base_ppn >> u32::BITS > low_bits_mask(HIGH_PPN_WIDTH)
+        let base_ppn = (base.as_usize() as u64) >> PAGE_SHIFT;
+        if base_ppn & low_bits_mask(hart_index_bits) as u64 != 0
+            || base_ppn >> u32::BITS > low_bits_mask(HIGH_PPN_WIDTH) as u64
         {
             return Err(Error::InvalidArgs);
         }

--- a/firmware/prototyper/src/riscv/csr.rs
+++ b/firmware/prototyper/src/riscv/csr.rs
@@ -114,19 +114,19 @@ pub mod menvcfg {
     use core::arch::asm;
 
     /// Fence of I/O implies memory.
-    pub const FIOM: usize = 0x1 << 0;
+    pub const FIOM: u64 = 0x1 << 0;
     /// Cache-block-invalidate effect: flush (CBIE=01).
-    pub const CBIE_FLUSH: usize = 0x01 << 4;
+    pub const CBIE_FLUSH: u64 = 0x01 << 4;
     /// Intended cache-block-invalidate effect: invalidate.
-    pub const CBIE_INVALIDATE: usize = 0x11 << 4;
+    pub const CBIE_INVALIDATE: u64 = 0x11 << 4;
     /// Cache-block-clean flush enable.
-    pub const CBCFE: usize = 0x1 << 6;
+    pub const CBCFE: u64 = 0x1 << 6;
     /// Cache-block-zero enable.
-    pub const CBZE: usize = 0x1 << 7;
+    pub const CBZE: u64 = 0x1 << 7;
     /// Page-based memory types enable.
-    pub const PBMTE: usize = 0x1 << 62;
+    pub const PBMTE: u64 = 0x1 << 62;
     /// Supervisor timer counter enable.
-    pub const STCE: usize = 0x1 << 63;
+    pub const STCE: u64 = 0x1 << 63;
 
     /// Sets the STCE bit to enable supervisor timer counter.
     #[inline(always)]
@@ -135,16 +135,16 @@ pub mod menvcfg {
     }
 
     /// Sets specified bits in menvcfg register.
-    pub fn set_bits(option: usize) {
-        let mut bits: usize;
-        // SAFETY: M-mode read of this hart's own menvcfg.
+    pub fn set_bits(option: u64) {
+        // SAFETY: M-mode update of this hart's own menvcfg. On RV32 the
+        // upper half is menvcfgh (0x31a); callers probe the extension before
+        // requesting its high bits.
         unsafe {
-            asm!("csrr {}, menvcfg", out(reg) bits, options(nomem));
-        }
-        bits |= option;
-        // SAFETY: M-mode write to this hart's own menvcfg.
-        unsafe {
-            asm!("csrw menvcfg, {}", in(reg) bits, options(nomem));
+            asm!("csrs menvcfg, {}", in(reg) option as usize, options(nomem));
+            #[cfg(target_pointer_width = "32")]
+            if option >> 32 != 0 {
+                asm!("csrs 0x31a, {}", in(reg) (option >> 32) as usize, options(nomem));
+            }
         }
     }
 }
@@ -156,32 +156,39 @@ pub mod mstateen {
     use super::{CSR_MSTATEEN0, CSR_MSTATEEN1, CSR_MSTATEEN2, CSR_MSTATEEN3};
 
     /// Counter delegation state.
-    pub const CTR: usize = 1usize << 54;
+    pub const CTR: u64 = 1u64 << 54;
     /// Context CSRs.
-    pub const CONTEXT: usize = 1usize << 57;
+    pub const CONTEXT: u64 = 1u64 << 57;
     /// IMSIC state.
-    pub const IMSIC: usize = 1usize << 58;
+    pub const IMSIC: u64 = 1u64 << 58;
     /// AIA state.
-    pub const AIA: usize = 1usize << 59;
+    pub const AIA: u64 = 1u64 << 59;
     /// Supervisor indirect CSR select state.
-    pub const SVSLCT: usize = 1usize << 60;
+    pub const SVSLCT: u64 = 1u64 << 60;
     /// Hypervisor environment configuration state.
-    pub const HSENVCFG: usize = 1usize << 62;
+    pub const HSENVCFG: u64 = 1u64 << 62;
     /// State-enable CSRs themselves.
-    pub const STATEN: usize = 1usize << 63;
+    pub const STATEN: u64 = 1u64 << 63;
+
+    fn write<const CSR: u16, const CSR_HIGH: u16>(value: u64) {
+        // SAFETY: callers probe mstateen before use. RV32 exposes bits
+        // 63:32 through mstateenNh, at the low CSR number plus 0x10.
+        unsafe {
+            asm!("csrw {csr}, {value}", csr = const CSR, value = in(reg) value as usize, options(nomem));
+            #[cfg(target_pointer_width = "32")]
+            asm!("csrw {csr}, {value}", csr = const CSR_HIGH, value = in(reg) (value >> 32) as usize, options(nomem));
+        }
+    }
 
     /// Enables S-mode access to the AIA-related state groups in the
     /// `mstateen` CSRs.
     #[inline(always)]
     pub fn enable_smode_aia() {
         let stateen0 = STATEN | CONTEXT | IMSIC | AIA | SVSLCT | HSENVCFG | CTR;
-        // SAFETY: M-mode writes to this hart's own state-enable registers.
-        unsafe {
-            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN0, value = in(reg) stateen0, options(nomem));
-            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN1, value = in(reg) STATEN, options(nomem));
-            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN2, value = in(reg) STATEN, options(nomem));
-            asm!("csrw {csr}, {value}", csr = const CSR_MSTATEEN3, value = in(reg) STATEN, options(nomem));
-        }
+        write::<CSR_MSTATEEN0, { CSR_MSTATEEN0 + 0x10 }>(stateen0);
+        write::<CSR_MSTATEEN1, { CSR_MSTATEEN1 + 0x10 }>(STATEN);
+        write::<CSR_MSTATEEN2, { CSR_MSTATEEN2 + 0x10 }>(STATEN);
+        write::<CSR_MSTATEEN3, { CSR_MSTATEEN3 + 0x10 }>(STATEN);
     }
 }
 
@@ -241,31 +248,41 @@ pub mod stimecmp {
         // SAFETY: callers have probed Sstc; M-mode may program stimecmp on
         // this hart when the extension is implemented.
         unsafe {
+            #[cfg(target_pointer_width = "64")]
             asm!("csrrw zero, stimecmp, {}", in(reg) value, options(nomem));
+            // Avoid an early interrupt while replacing the two halves.
+            #[cfg(target_pointer_width = "32")]
+            asm!(
+                "csrw stimecmp, {max}",
+                "csrw 0x15d, {high}",
+                "csrw stimecmp, {low}",
+                max = in(reg) usize::MAX,
+                high = in(reg) (value >> 32) as usize,
+                low = in(reg) value as usize,
+                options(nomem),
+            );
         }
     }
 }
 
 /// Machine cycle counter.
 pub mod mcycle {
-    use core::arch::asm;
     /// Writes the raw 64-bit counter value.
     pub fn write(value: u64) {
         // SAFETY: M-mode write to this hart's own counter.
         unsafe {
-            asm!("csrrw zero, mcycle, {}", in(reg) value, options(nomem));
+            riscv::register::mcycle::write64(value);
         }
     }
 }
 
 /// Machine instructions-retired counter.
 pub mod minstret {
-    use core::arch::asm;
     /// Writes the raw 64-bit counter value.
     pub fn write(value: u64) {
         // SAFETY: M-mode write to this hart's own counter.
         unsafe {
-            asm!("csrrw zero, minstret, {}", in(reg) value, options(nomem));
+            riscv::register::minstret::write64(value);
         }
     }
 }
@@ -433,6 +450,11 @@ pub fn write_mhpmcounter(mhpm_offset: u16, mhpmcounter_val: u64) {
                     // SAFETY: M-mode; `counter_idx` is in 3..=31 and the probed
                     // `mhpm_mask` guarantees the counter exists on this hart.
                     N => pastey::paste!{ unsafe {
+                        #[cfg(target_pointer_width = "32")]
+                        asm!("csrw {csr}, {value}",
+                            csr = const 0xb80 + N,
+                            value = in(reg) (mhpmcounter_val >> 32) as usize,
+                            options(nomem));
                         [<mhpmcounter ~N>]::write(mhpmcounter_val as usize) }
                     },
                 )*

--- a/firmware/prototyper/src/sbi/early_trap.rs
+++ b/firmware/prototyper/src/sbi/early_trap.rs
@@ -43,15 +43,28 @@ impl Default for TrapInfo {
 pub(crate) unsafe extern "C" fn expected_trap() {
     naked_asm!(
         "csrr a4, mepc",
+        ".if {XLEN} == 64",
         "sd a4, 0*8(a3)",
+        ".else",
+        "sw a4, 0*4(a3)",
+        ".endif",
         "csrr a4, mcause",
+        ".if {XLEN} == 64",
         "sd a4, 1*8(a3)",
+        ".else",
+        "sw a4, 1*4(a3)",
+        ".endif",
         "csrr a4, mtval",
+        ".if {XLEN} == 64",
         "sd a4, 2*8(a3)",
+        ".else",
+        "sw a4, 2*4(a3)",
+        ".endif",
         "csrr a4, mepc",
         "addi a4, a4, 4",
         "csrw mepc, a4",
         "mret",
+        XLEN = const usize::BITS,
     )
 }
 

--- a/firmware/prototyper/src/sbi/pmu.rs
+++ b/firmware/prototyper/src/sbi/pmu.rs
@@ -417,10 +417,24 @@ impl Pmu for SbiPmu {
 
     /// Function: Read a firmware counter high bits (FID #6).
     #[inline]
-    fn counter_fw_read_hi(&self, _counter_idx: usize) -> SbiRet {
-        // The Specification states the this function always return zero in sbiret.value for RV64 (or higher) systems.
-        // Currently RustSBI Prototyper only supports RV64 systems
-        SbiRet::success(0)
+    fn counter_fw_read_hi(&self, counter_idx: usize) -> SbiRet {
+        #[cfg(target_pointer_width = "64")]
+        {
+            let _ = counter_idx;
+            SbiRet::success(0)
+        }
+        #[cfg(target_pointer_width = "32")]
+        {
+            let ret = self.counter_fw_read(counter_idx);
+            if ret.is_err() {
+                return ret;
+            }
+            let state = &hart_local(current_hartid()).pmu_state;
+            match state.get_fw_counter(counter_idx) {
+                Some(value) => SbiRet::success((value >> 32) as usize),
+                None => SbiRet::invalid_param(),
+            }
+        }
     }
 
     /// Function: Set PMU snapshot shared memory (FID #7).

--- a/firmware/prototyper/src/sbi/trap/boot.rs
+++ b/firmware/prototyper/src/sbi/trap/boot.rs
@@ -28,24 +28,31 @@ unsafe extern "C" fn boot_entry() -> ! {
         "call    {locate_stack}",
         "csrw    mscratch, sp",
         // Allocate stack space
-        "addi   sp, sp, -3*8",
+        "addi   sp, sp, -{frame_size}",
         // Call handler with context pointer
         "mv     a0, sp",
         "call   {boot_handler}",
         // Restore mepc
-        "ld     t0, 0*8(sp)
-        csrw    mepc, t0",
-        // Restore registers
+        ".if {XLEN} == 64",
+        "ld      t0, 0*8(sp)",
         "ld      a0, 1*8(sp)",
         "ld      a1, 2*8(sp)",
+        ".else",
+        "lw      t0, 0*4(sp)",
+        "lw      a0, 1*4(sp)",
+        "lw      a1, 2*4(sp)",
+        ".endif",
+        "csrw    mepc, t0",
         // Restore stack pointer
-        "add     sp, sp, 3*8",
+        "addi    sp, sp, {frame_size}",
         // Switch stacks back
         "csrrw  sp, mscratch, sp",
         // Return from machine mode
         "mret",
         locate_stack = sym trap_stack::locate,
         boot_handler = sym boot_handler,
+        XLEN = const usize::BITS,
+        frame_size = const size_of::<BootContext>().next_multiple_of(16),
     )
 }
 

--- a/firmware/prototyper/src/sbi/trap/handler.rs
+++ b/firmware/prototyper/src/sbi/trap/handler.rs
@@ -202,7 +202,11 @@ pub fn sbi_call_handler(
         match a7 {
             legacy::LEGACY_SET_TIMER => {
                 if let Some(timer) = crate::sbi::timer() {
-                    rustsbi::Timer::set_timer(timer, ctx.a0() as u64);
+                    #[cfg(target_pointer_width = "64")]
+                    let value = ctx.a0() as u64;
+                    #[cfg(target_pointer_width = "32")]
+                    let value = ((a1 as u64) << 32) | ctx.a0() as u64;
+                    rustsbi::Timer::set_timer(timer, value);
                     ret.error = 0;
                     ret.value = a1;
                 }
@@ -343,7 +347,7 @@ pub extern "C" fn load_misaligned_handler(ctx: EntireContext) -> EntireResult {
     );
     match var_type {
         VarType::Signed | VarType::UnSigned => save_reg_x(&mut ctx, target_reg as usize, read_data),
-        VarType::Float => set_reg_f(target_reg as usize, len, read_data),
+        VarType::Float => set_reg_f(target_reg as usize, len, raw_data),
     };
     // SAFETY: M-mode mepc write; the increment skips the emulated access.
     unsafe {
@@ -376,7 +380,7 @@ pub extern "C" fn store_misaligned_handler(ctx: EntireContext) -> EntireResult {
     };
     let (target_reg, var_type, len) = inst_type;
     let raw_data = match var_type {
-        VarType::Signed | VarType::UnSigned => get_reg_x(&mut ctx, target_reg as usize),
+        VarType::Signed | VarType::UnSigned => get_reg_x(&mut ctx, target_reg as usize) as u64,
         VarType::Float => get_reg_f(target_reg as usize, len),
     };
 

--- a/firmware/prototyper/src/sbi/trap/helper.rs
+++ b/firmware/prototyper/src/sbi/trap/helper.rs
@@ -96,23 +96,23 @@ pub fn save_byte(addr: usize, data: usize) {
 }
 
 #[inline(always)]
-pub fn get_data(addr: usize, len: usize) -> usize {
-    let mut data: usize = 0;
+pub fn get_data(addr: usize, len: usize) -> u64 {
+    let mut data: u64 = 0;
     for i in (addr..addr + len).rev() {
         data <<= 8;
-        data |= get_unsigned_byte(i) as usize;
+        data |= u64::from(get_unsigned_byte(i));
     }
     data
 }
 
 #[inline(always)]
 pub fn get_inst(addr: usize) -> (usize, usize) {
-    let low_data = get_data(addr, 2);
+    let low_data = get_data(addr, 2) as usize;
     // We assume we only have 16bit and 32bit inst.
     if riscv_decode::instruction_length(low_data as u16) == 2 {
         return (low_data, 2);
     } else {
-        return (low_data | (get_data(addr + 2, 2) << 16), 4);
+        return (low_data | ((get_data(addr + 2, 2) as usize) << 16), 4);
     }
 }
 
@@ -162,14 +162,21 @@ pub fn get_reg_x(ctx: &mut EntireContextSeparated, reg_id: usize) -> usize {
     }
 }
 
-pub fn get_reg_f(reg_id: usize, len: usize) -> usize {
-    let mut data: usize;
+pub fn get_reg_f(reg_id: usize, len: usize) -> u64 {
+    let mut data = 0u64;
     match len {
         4 => {
             seq_macro::seq!(N in 0..32 {
                 match reg_id {
                     #(
-                        N => unsafe { asm!("fmv.x.w {data}, f{x}", data = out(reg) data, x = const N, options(nomem)) },
+                        // SAFETY: an emulated floating-point store identifies
+                        // a live F register; the aligned buffer is owned here.
+                        N => unsafe { asm!(
+                            ".option push", ".option arch, +f",
+                            "fsw f{x}, 0({ptr})", ".option pop",
+                            ptr = in(reg) &mut data, x = const N,
+                            options(nostack),
+                        ) },
                     )*
                     _ => unreachable!()
                 }
@@ -179,7 +186,14 @@ pub fn get_reg_f(reg_id: usize, len: usize) -> usize {
             seq_macro::seq!(N in 0..32 {
                 match reg_id {
                     #(
-                        N => unsafe { asm!("fmv.x.d {data}, f{x}", data = out(reg) data, x = const N, options(nomem)) },
+                        // SAFETY: same as above, with a full 64-bit buffer.
+                        // fsd works on RV32D as well as RV64D; fmv.x.d does not.
+                        N => unsafe { asm!(
+                            ".option push", ".option arch, +d",
+                            "fsd f{x}, 0({ptr})", ".option pop",
+                            ptr = in(reg) &mut data, x = const N,
+                            options(nostack),
+                        ) },
                     )*
                     _ => unreachable!()
                 }
@@ -190,13 +204,20 @@ pub fn get_reg_f(reg_id: usize, len: usize) -> usize {
     data
 }
 
-pub fn set_reg_f(reg_id: usize, len: usize, value: usize) {
+pub fn set_reg_f(reg_id: usize, len: usize, value: u64) {
     match len {
         4 => {
             seq_macro::seq!(N in 0..32 {
                 match reg_id {
                     #(
-                        N => unsafe { asm!("fmv.w.x f{x}, {data}", data = in(reg) value, x = const N, options(nomem)) },
+                        // SAFETY: restoring the emulated load's destination
+                        // F register from an aligned, initialized buffer.
+                        N => unsafe { asm!(
+                            ".option push", ".option arch, +f",
+                            "flw f{x}, 0({ptr})", ".option pop",
+                            ptr = in(reg) &value, x = const N,
+                            options(nostack, readonly),
+                        ) },
                     )*
                     _ => unreachable!()
                 }
@@ -206,7 +227,13 @@ pub fn set_reg_f(reg_id: usize, len: usize, value: usize) {
             seq_macro::seq!(N in 0..32 {
                 match reg_id {
                     #(
-                        N => unsafe { asm!("fmv.d.x f{x}, {data}", data = in(reg) value, x = const N, options(nomem)) },
+                        // SAFETY: same as above, preserving all 64 bits on RV32.
+                        N => unsafe { asm!(
+                            ".option push", ".option arch, +d",
+                            "fld f{x}, 0({ptr})", ".option pop",
+                            ptr = in(reg) &value, x = const N,
+                            options(nostack, readonly),
+                        ) },
                     )*
                     _ => unreachable!()
                 }

--- a/firmware/prototyper/src/sbi/trap_stack.rs
+++ b/firmware/prototyper/src/sbi/trap_stack.rs
@@ -40,6 +40,12 @@ unsafe impl Sync for HartStack {}
 #[unsafe(link_section = ".bss.stack")]
 static ROOT_STACK: [HartStack; NUM_HART_MAX] = [const { HartStack::zero() }; NUM_HART_MAX];
 
+// The pinned fast-trap revision stores six native words at the stack top.
+// Pad RV32's 24-byte descriptor so both its trap entry and our Rust entry
+// receive a 16-byte-aligned stack. RV64's 48-byte descriptor is already aligned.
+const TRAP_STACK_TOP_PADDING: usize =
+    (6 * size_of::<usize>()).next_multiple_of(16) - 6 * size_of::<usize>();
+
 // Make sure stack address can be aligned.
 const _: () = assert!(STACK_SIZE_PER_HART.is_multiple_of(core::mem::align_of::<HartStack>()));
 
@@ -71,12 +77,14 @@ pub(crate) unsafe extern "C" fn locate() {
          1: add  sp, sp, t0             // Calculate stack pointer
             addi t1, t1, -1             // Decrement counter
             bnez t1, 1b                 // Loop if not zero
+            addi sp, sp, {top_padding}
             call t1, {move_stack}       // Call stack reuse function
             ret                         // Return
         ",
         per_hart_stack_size = const STACK_SIZE_PER_HART,
         stack               =   sym ROOT_STACK,
         move_stack          =   sym fast_trap::reuse_stack_for_trap,
+        top_padding         = const -(TRAP_STACK_TOP_PADDING as isize),
     )
 }
 
@@ -448,7 +456,7 @@ impl HartStack {
         // Create and load trap stack, forgetting it to avoid drop
         forget(
             FreeTrapStack::new(
-                range.start as usize..range.end as usize,
+                range.start as usize..range.end as usize - TRAP_STACK_TOP_PADDING,
                 |_| {}, // Empty callback
                 context_ptr,
                 fast_handler,

--- a/firmware/test-kernel/src/main.rs
+++ b/firmware/test-kernel/src/main.rs
@@ -63,8 +63,13 @@ unsafe extern "C" fn _start(hartid: usize, device_tree_paddr: usize) -> ! {
         "   la      t0, sbss
             la      t1, ebss
         1:  bgeu    t0, t1, 2f
+            .if {XLEN} == 64
             sd      zero, 0(t0)
             addi    t0, t0, 8
+            .else
+            sw      zero, 0(t0)
+            addi    t0, t0, 4
+            .endif
             j       1b",
         "2:",
         "   la sp, {stack} + {stack_size}",
@@ -72,6 +77,7 @@ unsafe extern "C" fn _start(hartid: usize, device_tree_paddr: usize) -> ! {
         stack_size = const STACK_SIZE,
         stack      =   sym STACK,
         main       =   sym rust_main,
+        XLEN       = const usize::BITS,
     )
 }
 
@@ -195,7 +201,9 @@ fn pmu_test(smp: usize) {
     assert!(restart_cycle_num > stopped_cycle_num);
 
     /* PMU test for firmware  event */
-    let counter_mask = CounterMask::from_mask_base(0x7ffffffff, 0);
+    // RV32's mask covers counters 0..31, including the firmware counters
+    // used below; RV64 can also select counters 32..34.
+    let counter_mask = CounterMask::from_mask_base(0x7_ffff_ffffu64 as usize, 0);
 
     // Mapping a counter to the `SBI_PMU_FW_ACCESS_LOAD` event should result in unsupported
     let result = sbi::pmu_counter_config_matching(


### PR DESCRIPTION
Support RV32; add the Yuzuki Neko platform configuration.

Tested on qemu-system-riscv32 and qemu-system-riscv64.
