### PR TITLE
refactor(prototyper): introduce fallible driver backends

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project will be documented in this file. See [conven
 - Add SpacemiT K1 SoC platform support for RustSBI Prototyper, including OrangePi RV2 board configuration.
 
 ### Modified
+- Replace Prototyper reset devices with typed SRST requests and a fallible `ResetBackend` interface.
+  Prepare each backend's associated command once and pass it directly to reset execution.
+  Reject reserved and unimplemented specific parameters with `SBI_ERR_INVALID_PARAM`, distinguish
+  missing dependencies from reset failures, and honor shutdown requests regardless of the standard
+  reset reason.
 - Forward unsupported misaligned loads to S-mode so Linux vector alignment probes do not panic.
 - refactor(prototyper): unify build commands (#227)
 - deps: update `sbi-spec` to version 0.0.10.

--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. See [conven
 - Add SpacemiT K1 SoC platform support for RustSBI Prototyper, including OrangePi RV2 board configuration.
 
 ### Modified
+- Replace Prototyper IPI devices with fallible `IpiBackend` windows and SBI-layer target validation.
 - Replace Prototyper console devices with fallible, non-blocking `DbcnBackend` slice operations.
 - Replace Prototyper reset devices with typed requests and a fallible `ResetBackend` interface.
 - Forward unsupported misaligned loads to S-mode so Linux vector alignment probes do not panic.

--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased
 
 ### Added
+- Add DBCN contract tests with deferred error reporting to the test kernel.
 - Add RV32 support to RustSBI Prototyper and test-kernel while preserving RV64 support.
 - Add Yuzuki Neko board configuration with an RV32 firmware jump target of `0x40000000`.
 - Add SBI Collaborative Processor Performance Control extension support to RustSBI Prototyper.
@@ -21,11 +22,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Add SpacemiT K1 SoC platform support for RustSBI Prototyper, including OrangePi RV2 board configuration.
 
 ### Modified
-- Replace Prototyper reset devices with typed SRST requests and a fallible `ResetBackend` interface.
-  Prepare each backend's associated command once and pass it directly to reset execution.
-  Reject reserved and unimplemented specific parameters with `SBI_ERR_INVALID_PARAM`, distinguish
-  missing dependencies from reset failures, and honor shutdown requests regardless of the standard
-  reset reason.
+- Replace Prototyper console devices with fallible, non-blocking `DbcnBackend` slice operations.
+- Replace Prototyper reset devices with typed requests and a fallible `ResetBackend` interface.
 - Forward unsupported misaligned loads to S-mode so Linux vector alignment probes do not panic.
 - refactor(prototyper): unify build commands (#227)
 - deps: update `sbi-spec` to version 0.0.10.

--- a/firmware/prototyper/src/driver/aia.rs
+++ b/firmware/prototyper/src/driver/aia.rs
@@ -12,7 +12,7 @@ use riscv_aia::register::mtopei;
 use runtime::memory::{MemoryRegistry, MmioRegion};
 
 use crate::cfg::NUM_HART_MAX;
-use crate::driver::{InterruptDevices, IpiDevice, SstcTimer};
+use crate::driver::{InterruptDevices, IpiBackend, IpiError, IpiRequest, SstcTimer};
 use crate::platform::qemu_aplic::QemuAplicConfig;
 use crate::platform::{BoardInfo, ImsicInfo, board_info};
 use crate::riscv::csr::imsic;
@@ -54,20 +54,30 @@ impl ImsicIpi {
     }
 }
 
-impl IpiDevice for ImsicIpi {
+impl IpiBackend for ImsicIpi {
     #[inline(always)]
-    fn send_ipi(&self, hart_id: usize) {
-        let Some(file) = self.hart_files.get(hart_id).and_then(Option::as_ref) else {
-            warn!("IMSIC IPI: hart {} has no mapped interrupt file", hart_id);
-            return;
-        };
-        file.write(Register::SetEipnumLe.offset(), self.ipi_iid.number() as u32)
-            .expect("BUG: IMSIC SETEIPNUM register escaped its interrupt-file window");
+    fn send_ipi(&mut self, req: IpiRequest) -> Result<(), IpiError> {
+        for hart_id in req.harts() {
+            let file = self
+                .hart_files
+                .get(hart_id)
+                .and_then(Option::as_ref)
+                .ok_or(IpiError::Failed)?;
+            file.write(Register::SetEipnumLe.offset(), self.ipi_iid.number() as u32)
+                .map_err(|_| IpiError::Failed)?;
+        }
+        Ok(())
     }
 
     #[inline(always)]
-    fn clear_ipi(&self) {
+    fn clear_ipi(&mut self, hart_id: usize) -> Result<(), IpiError> {
+        // IMSIC clearing uses CSRs on the attached hart; only the firmware
+        // IPI identity is enabled in the machine interrupt file.
+        if hart_id != current_hartid() {
+            return Err(IpiError::Failed);
+        }
         let _ = mtopei::claim();
+        Ok(())
     }
 
     #[inline(always)]

--- a/firmware/prototyper/src/driver/clint/sifive.rs
+++ b/firmware/prototyper/src/driver/clint/sifive.rs
@@ -11,7 +11,7 @@ use core::mem::{align_of, size_of};
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
 use crate::cfg::NUM_HART_MAX;
-use crate::driver::{InterruptDevices, IpiDevice, TimerDevice};
+use crate::driver::{InterruptDevices, IpiBackend, IpiError, IpiRequest, TimerDevice};
 
 // The ACLINT legacy mapping places MTIMECMP at 0x4000 and MTIME at 0xbff8.
 const MTIMECMP_OFFSET: usize = 0x4000;
@@ -49,12 +49,11 @@ impl IpiRegister {
         self as usize
     }
 
-    fn offset_for_hart(self, hart_id: usize) -> usize {
-        assert!(
-            hart_id < NUM_HART_MAX,
-            "BUG: SiFive CLINT IPI hart index is out of range"
-        );
-        self.offset() + hart_id * size_of::<u32>()
+    fn offset_for_hart(self, hart_id: usize) -> Result<usize, IpiError> {
+        hart_id
+            .checked_mul(size_of::<u32>())
+            .and_then(|offset| self.offset().checked_add(offset))
+            .ok_or(IpiError::Failed)
     }
 }
 
@@ -169,25 +168,24 @@ impl SiFiveIpi {
         Self { registers }
     }
 
-    fn write(&self, reg: IpiRegister, hart_id: usize, value: IpiState) {
+    fn write(&self, reg: IpiRegister, hart_id: usize, value: IpiState) -> Result<(), IpiError> {
         self.registers
-            .write(reg.offset_for_hart(hart_id), value as u32)
-            .expect("BUG: SiFive CLINT IPI register escaped its MMIO window")
+            .write(reg.offset_for_hart(hart_id)?, value as u32)
+            .map_err(|_| IpiError::Failed)
     }
 }
 
-impl IpiDevice for SiFiveIpi {
+impl IpiBackend for SiFiveIpi {
     #[inline(always)]
-    fn send_ipi(&self, hart_id: usize) {
-        self.write(IpiRegister::Msip, hart_id, IpiState::Pending)
+    fn send_ipi(&mut self, req: IpiRequest) -> Result<(), IpiError> {
+        for hart_id in req.harts() {
+            self.write(IpiRegister::Msip, hart_id, IpiState::Pending)?;
+        }
+        Ok(())
     }
 
     #[inline(always)]
-    fn clear_ipi(&self) {
-        self.write(
-            IpiRegister::Msip,
-            crate::riscv::current_hartid(),
-            IpiState::Clear,
-        )
+    fn clear_ipi(&mut self, hart_id: usize) -> Result<(), IpiError> {
+        self.write(IpiRegister::Msip, hart_id, IpiState::Clear)
     }
 }

--- a/firmware/prototyper/src/driver/clint/thead.rs
+++ b/firmware/prototyper/src/driver/clint/thead.rs
@@ -20,7 +20,7 @@ use core::mem::{align_of, size_of};
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
 use crate::cfg::NUM_HART_MAX;
-use crate::driver::{InterruptDevices, IpiDevice, TimerDevice};
+use crate::driver::{InterruptDevices, IpiBackend, IpiError, IpiRequest, TimerDevice};
 
 // The ACLINT legacy mapping places MTIMECMP at offset 0x4000.
 const MTIMECMP_OFFSET: usize = 0x4000;
@@ -59,12 +59,11 @@ impl IpiRegister {
         self as usize
     }
 
-    fn offset_for_hart(self, hart_id: usize) -> usize {
-        assert!(
-            hart_id < NUM_HART_MAX,
-            "BUG: T-Head CLINT IPI hart index is out of range"
-        );
-        self.offset() + hart_id * size_of::<u32>()
+    fn offset_for_hart(self, hart_id: usize) -> Result<usize, IpiError> {
+        hart_id
+            .checked_mul(size_of::<u32>())
+            .and_then(|offset| self.offset().checked_add(offset))
+            .ok_or(IpiError::Failed)
     }
 }
 
@@ -144,25 +143,24 @@ impl THeadIpi {
         Self { msip }
     }
 
-    fn write(&self, reg: IpiRegister, hart_id: usize, value: IpiState) {
+    fn write(&self, reg: IpiRegister, hart_id: usize, value: IpiState) -> Result<(), IpiError> {
         self.msip
-            .write(reg.offset_for_hart(hart_id), value as u32)
-            .expect("BUG: T-Head CLINT IPI register escaped its MMIO window")
+            .write(reg.offset_for_hart(hart_id)?, value as u32)
+            .map_err(|_| IpiError::Failed)
     }
 }
 
-impl IpiDevice for THeadIpi {
+impl IpiBackend for THeadIpi {
     #[inline(always)]
-    fn send_ipi(&self, hart_id: usize) {
-        self.write(IpiRegister::Msip, hart_id, IpiState::Pending)
+    fn send_ipi(&mut self, req: IpiRequest) -> Result<(), IpiError> {
+        for hart_id in req.harts() {
+            self.write(IpiRegister::Msip, hart_id, IpiState::Pending)?;
+        }
+        Ok(())
     }
 
     #[inline(always)]
-    fn clear_ipi(&self) {
-        self.write(
-            IpiRegister::Msip,
-            crate::riscv::current_hartid(),
-            IpiState::Clear,
-        )
+    fn clear_ipi(&mut self, hart_id: usize) -> Result<(), IpiError> {
+        self.write(IpiRegister::Msip, hart_id, IpiState::Clear)
     }
 }

--- a/firmware/prototyper/src/driver/console/axi_lite.rs
+++ b/firmware/prototyper/src/driver/console/axi_lite.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 use core::mem::size_of;
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
-use crate::driver::console::{ConsoleDevice, acquire_registers};
+use crate::driver::console::{DbcnBackend, DbcnError, acquire_registers};
 
 /// Register offsets within the UART Lite register map.
 #[repr(usize)]
@@ -43,7 +43,7 @@ bitflags! {
 pub(super) fn bind(
     registers: DeviceRegisterRange,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let registers = acquire_registers::<u32>(registers, SPAN, memory)?;
     Ok(Box::new(UartAxiLite::new(registers)))
 }
@@ -74,8 +74,8 @@ impl UartAxiLite {
     }
 }
 
-impl ConsoleDevice for UartAxiLite {
-    fn read(&self, buf: &mut [u8]) -> usize {
+impl DbcnBackend for UartAxiLite {
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for byte in buf.iter_mut() {
             if !self.status().contains(Status::RX_VALID) {
@@ -84,10 +84,10 @@ impl ConsoleDevice for UartAxiLite {
             *byte = self.read_reg(Register::Rx) as u8;
             count += 1;
         }
-        count
+        Ok(count)
     }
 
-    fn write(&self, buf: &[u8]) -> usize {
+    fn write_slice(&mut self, buf: &[u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for &byte in buf {
             if self.status().contains(Status::TX_FULL) {
@@ -96,6 +96,6 @@ impl ConsoleDevice for UartAxiLite {
             self.write_reg(Register::Tx, byte as u32);
             count += 1;
         }
-        count
+        Ok(count)
     }
 }

--- a/firmware/prototyper/src/driver/console/bl808.rs
+++ b/firmware/prototyper/src/driver/console/bl808.rs
@@ -9,7 +9,7 @@ use alloc::boxed::Box;
 use core::mem::size_of;
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
-use crate::driver::console::{ConsoleDevice, acquire_registers};
+use crate::driver::console::{DbcnBackend, DbcnError, acquire_registers};
 
 #[repr(usize)]
 #[derive(Clone, Copy)]
@@ -30,7 +30,7 @@ const SPAN: usize = Register::RxData.offset() + size_of::<u32>();
 pub(super) fn bind(
     registers: DeviceRegisterRange,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let registers = acquire_registers::<u32>(registers, SPAN, memory)?;
     Ok(Box::new(UartBl808::new(registers)))
 }
@@ -80,20 +80,20 @@ impl UartBl808 {
     }
 }
 
-impl ConsoleDevice for UartBl808 {
-    fn read(&self, buf: &mut [u8]) -> usize {
+impl DbcnBackend for UartBl808 {
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<usize, DbcnError> {
         let available_count = self.fifo_counts().rx_available_count();
         if available_count == 0 {
-            return 0;
+            return Ok(0);
         }
         let len = core::cmp::min(available_count, buf.len());
         buf.iter_mut()
             .take(len)
             .for_each(|byte| *byte = self.read_u8(Register::RxData));
-        len
+        Ok(len)
     }
 
-    fn write(&self, buf: &[u8]) -> usize {
+    fn write_slice(&mut self, buf: &[u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for &byte in buf {
             if self.fifo_counts().tx_available_count() == 0 {
@@ -102,6 +102,6 @@ impl ConsoleDevice for UartBl808 {
             count += 1;
             self.write_u8(Register::TxData, byte);
         }
-        count
+        Ok(count)
     }
 }

--- a/firmware/prototyper/src/driver/console/mod.rs
+++ b/firmware/prototyper/src/driver/console/mod.rs
@@ -1,4 +1,4 @@
-//! UART console drivers.
+//! Byte-oriented console backends.
 //!
 //! # References
 //!
@@ -22,13 +22,67 @@ use crate::platform::BoardInfo;
 
 pub(crate) use kind::ConsoleKind;
 
-/// A byte-oriented console device.
-pub(crate) trait ConsoleDevice: Send {
-    /// Reads bytes into `buf` and returns the number read.
-    fn read(&self, buf: &mut [u8]) -> usize;
+/// Low-level error category for one backend slice operation.
+///
+/// These are the backend errors shared by all three DBCN functions in SBI v3.0,
+/// Section 12, Tables 50-52. Lack of progress is `Ok(0)`, not an error.
+///
+/// Important:
+/// - `InvalidParam` is intentionally absent.
+///   Physical-memory-range validation and translation belong to the SBI entry layer.
+/// - `write_slice` / `read_slice` operate on one concrete contiguous slice only.
+///   They are not identical to SBI `write` / `read`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DbcnError {
+    /// Console access is not allowed; mapped to `SBI_ERR_DENIED` (-4).
+    #[allow(
+        dead_code,
+        reason = "current UART backends do not restrict console access"
+    )]
+    Denied,
+    /// Backend I/O failure; mapped to `SBI_ERR_FAILED` (-1), not `SBI_ERR_IO`.
+    Failed,
+}
 
-    /// Writes bytes from `buf` and returns the number written.
-    fn write(&self, buf: &[u8]) -> usize;
+/// A backend that can serve as the byte-oriented data path of an SBI DBCN console.
+///
+/// Important:
+/// - This trait is intentionally not named `Uart`.
+/// - This trait is also intentionally not phrased in terms of SBI calls.
+/// - It models one backend operation on one contiguous slice.
+///
+/// Relationship with SBI DBCN:
+/// - SBI `write` may translate one physical memory range into 1..N slices, then
+///   call `write_slice` repeatedly.
+/// - SBI `read` may translate one physical memory range into 1..N slices, then
+///   call `read_slice` repeatedly.
+/// - SBI `write_byte` uses `write_slice(&[byte])`, retrying `Ok(0)` to preserve
+///   the SBI call's blocking semantics.
+pub trait DbcnBackend {
+    /// Try to write bytes from one contiguous source slice.
+    ///
+    /// Returns:
+    /// - `Ok(n)` where `0 <= n <= src.len()`, meaning exactly the first `n` bytes
+    ///   of `src` are accepted by the backend;
+    /// - `Err(DbcnError::Denied)` if writes are not allowed;
+    /// - `Err(DbcnError::Failed)` on backend I/O failure.
+    ///
+    /// This is a non-blocking slice operation. It is not the SBI `write` call itself.
+    fn write_slice(&mut self, src: &[u8]) -> Result<usize, DbcnError>;
+
+    /// Try to read bytes into one contiguous destination slice.
+    ///
+    /// Returns:
+    /// - `Ok(n)` where `0 <= n <= dst.len()`, meaning exactly `n` bytes are consumed
+    ///   from the backend receive queue and written into the destination slice;
+    /// - `Err(DbcnError::Denied)` if reads are not allowed;
+    /// - `Err(DbcnError::Failed)` on backend I/O failure.
+    ///
+    /// This is a non-blocking slice operation. It is not the SBI `read` call itself.
+    ///
+    /// Note: this abstraction specifies the backend state transition and the
+    /// number of bytes read. It does not model the concrete contents of `dst` yet.
+    fn read_slice(&mut self, dst: &mut [u8]) -> Result<usize, DbcnError>;
 }
 
 pub(super) const BAUD_RATE: u32 = 115_200;
@@ -62,7 +116,7 @@ fn acquire_registers<T: MmioValue>(
 pub(super) fn bind(
     board: &BoardInfo,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Option<Box<dyn ConsoleDevice>>> {
+) -> runtime::Result<Option<Box<dyn DbcnBackend + Send>>> {
     let Some(console) = board.console.as_ref() else {
         return Ok(None);
     };

--- a/firmware/prototyper/src/driver/console/pl011.rs
+++ b/firmware/prototyper/src/driver/console/pl011.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 use core::mem::size_of;
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
-use crate::driver::console::{BAUD_RATE, ConsoleDevice, acquire_registers};
+use crate::driver::console::{BAUD_RATE, DbcnBackend, DbcnError, acquire_registers};
 
 // PL011 derives Baud16 from UARTCLK / 16 and stores the fractional divisor in
 // sixty-fourths.
@@ -66,7 +66,7 @@ pub(super) fn bind(
     registers: DeviceRegisterRange,
     clock_hz: Option<u32>,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let clock_hz = clock_hz.ok_or(runtime::Error::InvalidArgs)?;
     let divisors = BaudDivisors::from_clock_hz(clock_hz).ok_or(runtime::Error::InvalidArgs)?;
     let registers = acquire_registers::<u32>(registers, SPAN, memory)?;
@@ -141,30 +141,33 @@ impl UartPl011 {
         Flags::from_bits_retain(self.read_reg(Register::Flags))
     }
 
-    fn read_byte(&self) -> Option<u8> {
+    fn read_byte(&self) -> Result<Option<u8>, DbcnError> {
         if self.flags().contains(Flags::RX_FIFO_EMPTY) {
-            return None;
+            return Ok(None);
         }
         let data_register = self.read_reg(Register::Data);
-        let errors = DataStatus::from_bits_retain(data_register);
-        errors.is_empty().then_some(data_register as u8)
+        let errors = DataStatus::from_bits_truncate(data_register);
+        if !errors.is_empty() {
+            return Err(DbcnError::Failed);
+        }
+        Ok(Some(data_register as u8))
     }
 }
 
-impl ConsoleDevice for UartPl011 {
-    fn read(&self, buf: &mut [u8]) -> usize {
+impl DbcnBackend for UartPl011 {
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for byte in buf.iter_mut() {
-            let Some(received_byte) = self.read_byte() else {
+            let Some(received_byte) = self.read_byte()? else {
                 break;
             };
             *byte = received_byte;
             count += 1;
         }
-        count
+        Ok(count)
     }
 
-    fn write(&self, buf: &[u8]) -> usize {
+    fn write_slice(&mut self, buf: &[u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for &byte in buf {
             if self.flags().contains(Flags::TX_FIFO_FULL) {
@@ -173,6 +176,6 @@ impl ConsoleDevice for UartPl011 {
             self.write_reg(Register::Data, byte as u32);
             count += 1;
         }
-        count
+        Ok(count)
     }
 }

--- a/firmware/prototyper/src/driver/console/sifive.rs
+++ b/firmware/prototyper/src/driver/console/sifive.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 use core::mem::size_of;
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
-use crate::driver::console::{ConsoleDevice, acquire_registers};
+use crate::driver::console::{DbcnBackend, DbcnError, acquire_registers};
 
 /// Register offsets within the SiFive UART register map.
 #[repr(usize)]
@@ -46,7 +46,7 @@ bitflags! {
 pub(super) fn bind(
     registers: DeviceRegisterRange,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let registers = acquire_registers::<u32>(registers, SPAN, memory)?;
     Ok(Box::new(UartSiFive::new(registers)))
 }
@@ -111,8 +111,8 @@ impl UartSiFive {
     }
 }
 
-impl ConsoleDevice for UartSiFive {
-    fn read(&self, buf: &mut [u8]) -> usize {
+impl DbcnBackend for UartSiFive {
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for byte in buf.iter_mut() {
             match self.read_byte() {
@@ -123,10 +123,10 @@ impl ConsoleDevice for UartSiFive {
                 None => break,
             }
         }
-        count
+        Ok(count)
     }
 
-    fn write(&self, buf: &[u8]) -> usize {
+    fn write_slice(&mut self, buf: &[u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for &byte in buf {
             if self.tx_fifo_full() {
@@ -135,6 +135,6 @@ impl ConsoleDevice for UartSiFive {
             self.write_reg(Register::TxData, byte as u32);
             count += 1;
         }
-        count
+        Ok(count)
     }
 }

--- a/firmware/prototyper/src/driver/console/uart16550.rs
+++ b/firmware/prototyper/src/driver/console/uart16550.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 use core::mem::size_of;
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
-use crate::driver::console::{ConsoleDevice, acquire_registers};
+use crate::driver::console::{DbcnBackend, DbcnError, acquire_registers};
 
 #[repr(usize)]
 #[derive(Clone, Copy)]
@@ -38,7 +38,7 @@ bitflags! {
 pub(super) fn bind_u8(
     registers: DeviceRegisterRange,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let registers = acquire_registers::<u8>(registers, U8_SPAN, memory)?;
     Ok(Box::new(Uart16550::new(U8RegisterAccess(registers))))
 }
@@ -46,7 +46,7 @@ pub(super) fn bind_u8(
 pub(super) fn bind_u32(
     registers: DeviceRegisterRange,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let registers = acquire_registers::<u32>(registers, U32_SPAN, memory)?;
     Ok(Box::new(Uart16550::new(U32RegisterAccess(registers))))
 }
@@ -102,8 +102,8 @@ impl<Access: RegisterAccess> Uart16550<Access> {
     }
 }
 
-impl<Access: RegisterAccess + Send> ConsoleDevice for Uart16550<Access> {
-    fn read(&self, buf: &mut [u8]) -> usize {
+impl<Access: RegisterAccess> DbcnBackend for Uart16550<Access> {
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for byte in buf.iter_mut() {
             if !self.line_status().contains(LineStatus::DATA_READY) {
@@ -112,10 +112,10 @@ impl<Access: RegisterAccess + Send> ConsoleDevice for Uart16550<Access> {
             *byte = self.registers.read(Register::Data);
             count += 1;
         }
-        count
+        Ok(count)
     }
 
-    fn write(&self, buf: &[u8]) -> usize {
+    fn write_slice(&mut self, buf: &[u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for &byte in buf {
             if !self
@@ -127,6 +127,6 @@ impl<Access: RegisterAccess + Send> ConsoleDevice for Uart16550<Access> {
             self.registers.write(Register::Data, byte);
             count += 1;
         }
-        count
+        Ok(count)
     }
 }

--- a/firmware/prototyper/src/driver/console/xscale.rs
+++ b/firmware/prototyper/src/driver/console/xscale.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 use core::mem::size_of;
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
-use crate::driver::console::{ConsoleDevice, acquire_registers, uart_divisor};
+use crate::driver::console::{DbcnBackend, DbcnError, acquire_registers, uart_divisor};
 
 #[repr(usize)]
 #[derive(Clone, Copy)]
@@ -57,7 +57,7 @@ pub(super) fn bind(
     registers: DeviceRegisterRange,
     clock_hz: Option<u32>,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let clock_hz = clock_hz.ok_or(runtime::Error::InvalidArgs)?;
     let baud = BaudSetup::from_clock_hz(clock_hz).ok_or(runtime::Error::InvalidArgs)?;
     bind_with_baud(registers, baud, memory)
@@ -67,7 +67,7 @@ pub(super) fn bind_spacemit_k1(
     registers: DeviceRegisterRange,
     clock_hz: Option<u32>,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     // Some K1 device trees name a clock provider without supplying its rate.
     // In that case, preserve the divisor installed by the previous boot stage.
     let baud = match clock_hz {
@@ -81,7 +81,7 @@ fn bind_with_baud(
     registers: DeviceRegisterRange,
     baud: BaudSetup,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ConsoleDevice>> {
+) -> runtime::Result<Box<dyn DbcnBackend + Send>> {
     let registers = acquire_registers::<u32>(registers, SPAN, memory)?;
     Ok(Box::new(UartXScale::new(registers, baud)))
 }
@@ -170,8 +170,8 @@ impl UartXScale {
     }
 }
 
-impl ConsoleDevice for UartXScale {
-    fn read(&self, buf: &mut [u8]) -> usize {
+impl DbcnBackend for UartXScale {
+    fn read_slice(&mut self, buf: &mut [u8]) -> Result<usize, DbcnError> {
         let mut count = 0;
         for byte in buf.iter_mut() {
             if !self.line_status().contains(LineStatus::DATA_READY) {
@@ -180,19 +180,21 @@ impl ConsoleDevice for UartXScale {
             *byte = self.read_reg(Register::DataOrDivisorLow) as u8;
             count += 1;
         }
-        count
+        Ok(count)
     }
 
-    fn write(&self, buf: &[u8]) -> usize {
+    fn write_slice(&mut self, buf: &[u8]) -> Result<usize, DbcnError> {
+        let mut count = 0;
         for &byte in buf {
-            while !self
+            if !self
                 .line_status()
                 .contains(LineStatus::TX_HOLDING_REGISTER_EMPTY)
             {
-                core::hint::spin_loop();
+                break;
             }
             self.write_reg(Register::DataOrDivisorLow, byte as u32);
+            count += 1;
         }
-        buf.len()
+        Ok(count)
     }
 }

--- a/firmware/prototyper/src/driver/ipi.rs
+++ b/firmware/prototyper/src/driver/ipi.rs
@@ -1,0 +1,75 @@
+//! Backend operations on ordinary SBI hart-mask windows.
+
+/// One ordinary sPI hart-mask window request forwarded to the backend.
+///
+/// This backend models only the normal `(hart_mask, hart_mask_base)` window
+/// form of the SBI hart-mask encoding.
+///
+/// The SBI special encoding `hart_mask_base == usize::MAX` means "ignore
+/// hart_mask and target all available harts"; the SBI adaptation layer expands
+/// it into ordinary window requests before calling the backend.
+///
+/// One call selects at most XLEN harts, matching MSWI / CLINT hardware
+/// provisioned for the actual hart count rather than a specification maximum.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IpiRequest {
+    pub hart_mask: usize,
+    pub hart_mask_base: usize,
+}
+
+impl IpiRequest {
+    /// Iterates the targets of an already validated ordinary window.
+    pub(crate) fn harts(self) -> impl Iterator<Item = usize> {
+        (0..usize::BITS)
+            .filter(move |bit| self.hart_mask & (1 << bit) != 0)
+            .map(move |bit| self.hart_mask_base + bit as usize)
+    }
+}
+
+/// Low-level error category for one sPI backend operation.
+///
+/// Important:
+/// - `InvalidParam` is intentionally absent.
+///   Raw `(hart_mask, hart_mask_base)` decoding and target validation belong to
+///   the SBI adaptation layer.
+/// - Requests reaching this backend have already passed SBI target validation.
+/// - The backend therefore only reports unspecified operational failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IpiError {
+    /// Mapped by the SBI adaptation layer to `SBI_ERR_FAILED`.
+    Failed,
+}
+
+/// A backend that implements one ordinary backend-side sPI send operation.
+///
+/// This operation follows SBI decoding and validation: `InvalidParam` and the
+/// special "all available harts" encoding are not backend-visible outcomes or
+/// request forms; higher layers split all-hart targets into ordinary windows.
+pub trait IpiBackend {
+    /// Sends supervisor IPIs to the targets of one ordinary request window.
+    ///
+    /// Returns `Ok(())` if all targets were signaled, or `Err(IpiError::Failed)`
+    /// for an unspecified or unknown operational failure; some targets may
+    /// already have been signaled when an error is returned.
+    ///
+    /// Requests have already been decoded, validated, and normalized by the
+    /// SBI adaptation layer, including expansion of "all available harts".
+    fn send_ipi(&mut self, req: IpiRequest) -> Result<(), IpiError>;
+
+    /// *Internal function* that clears the firmware IPI pending register for
+    /// the specified hart.
+    ///
+    /// This is an internal firmware operation, not an SBI function; it does
+    /// not clear the supervisor's SSIP bit or software event bookkeeping.
+    /// Returns `Failed` if the register cannot be cleared, including when a
+    /// backend can only clear the calling hart and a remote hart was requested.
+    fn clear_ipi(&mut self, hart_id: usize) -> Result<(), IpiError>;
+
+    /// *Internal function* that reports whether firmware IPIs arrive through
+    /// an IMSIC interrupt file.
+    ///
+    /// This internal property selects the firmware interrupt handling path.
+    fn is_imsic(&self) -> bool {
+        false
+    }
+}

--- a/firmware/prototyper/src/driver/mod.rs
+++ b/firmware/prototyper/src/driver/mod.rs
@@ -11,6 +11,7 @@
 mod aia;
 mod clint;
 mod console;
+mod ipi;
 mod reset;
 
 use alloc::boxed::Box;
@@ -24,6 +25,7 @@ use crate::riscv::current_hartid;
 pub(crate) use aia::{IMSIC_COMPATIBLES, IMSIC_FILE_SPAN, initialize_hart_imsic};
 pub(crate) use clint::ClintKind;
 pub(crate) use console::{ConsoleKind, DbcnBackend, DbcnError};
+pub(crate) use ipi::{IpiBackend, IpiError, IpiRequest};
 
 pub(crate) use reset::{
     I2cAddress, P1_PMIC_COMPATIBLES, PMIC_I2C_COMPATIBLES, ResetDevice, ResetError, ResetReason,
@@ -49,7 +51,7 @@ impl Devices {
 /// Timer and IPI devices selected for the platform.
 pub(crate) struct InterruptDevices {
     pub(crate) timer: Box<dyn TimerDevice>,
-    pub(crate) ipi: Box<dyn IpiDevice>,
+    pub(crate) ipi: Box<dyn IpiBackend + Send>,
 }
 
 /// Timer operations used by the SBI timer extension.
@@ -59,20 +61,6 @@ pub(crate) trait TimerDevice: Send {
 
     /// Programs the timer comparison value for `hart_id`.
     fn set_timer(&self, hart_id: usize, value: u64);
-}
-
-/// Inter-processor interrupt operations implemented by a platform device.
-pub(crate) trait IpiDevice: Send {
-    /// Signals a firmware IPI to `hart_id`.
-    fn send_ipi(&self, hart_id: usize);
-
-    /// Clears the current hart's pending firmware IPI.
-    fn clear_ipi(&self);
-
-    /// Reports whether firmware IPIs arrive through an IMSIC interrupt file.
-    fn is_imsic(&self) -> bool {
-        false
-    }
 }
 
 /// Timer implementation using the Sstc `stimecmp` CSR.

--- a/firmware/prototyper/src/driver/mod.rs
+++ b/firmware/prototyper/src/driver/mod.rs
@@ -26,14 +26,15 @@ pub(crate) use clint::ClintKind;
 pub(crate) use console::{ConsoleDevice, ConsoleKind};
 
 pub(crate) use reset::{
-    I2cAddress, P1_PMIC_COMPATIBLES, PMIC_I2C_COMPATIBLES, ResetDevice, SIFIVE_TEST_COMPATIBLES,
+    I2cAddress, P1_PMIC_COMPATIBLES, PMIC_I2C_COMPATIBLES, ResetDevice, ResetError, ResetReason,
+    ResetRequest, ResetType, SIFIVE_TEST_COMPATIBLES,
 };
 
 /// Platform devices constructed from the discovered hardware description.
 pub(crate) struct Devices {
     pub(crate) interrupts: Option<InterruptDevices>,
     pub(crate) console: Option<Box<dyn ConsoleDevice>>,
-    pub(crate) reset: Option<Box<dyn ResetDevice>>,
+    pub(crate) reset: Option<Box<dyn ResetDevice + Send>>,
 }
 
 impl Devices {

--- a/firmware/prototyper/src/driver/mod.rs
+++ b/firmware/prototyper/src/driver/mod.rs
@@ -23,7 +23,7 @@ use crate::riscv::current_hartid;
 
 pub(crate) use aia::{IMSIC_COMPATIBLES, IMSIC_FILE_SPAN, initialize_hart_imsic};
 pub(crate) use clint::ClintKind;
-pub(crate) use console::{ConsoleDevice, ConsoleKind};
+pub(crate) use console::{ConsoleKind, DbcnBackend, DbcnError};
 
 pub(crate) use reset::{
     I2cAddress, P1_PMIC_COMPATIBLES, PMIC_I2C_COMPATIBLES, ResetDevice, ResetError, ResetReason,
@@ -33,7 +33,7 @@ pub(crate) use reset::{
 /// Platform devices constructed from the discovered hardware description.
 pub(crate) struct Devices {
     pub(crate) interrupts: Option<InterruptDevices>,
-    pub(crate) console: Option<Box<dyn ConsoleDevice>>,
+    pub(crate) console: Option<Box<dyn DbcnBackend + Send>>,
     pub(crate) reset: Option<Box<dyn ResetDevice + Send>>,
 }
 

--- a/firmware/prototyper/src/driver/reset/mod.rs
+++ b/firmware/prototyper/src/driver/reset/mod.rs
@@ -11,16 +11,104 @@ use runtime::memory::MemoryRegistry;
 
 use crate::platform::BoardInfo;
 
-/// Platform reset operations used by the SBI reset extension.
-pub(crate) trait ResetDevice: Send {
-    /// Reports a failed test run.
-    fn fail(&self, code: u16) -> !;
+/// Parsed reset type accepted by the SRST driver layer.
+///
+/// Reserved raw values are intentionally not representable here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResetType {
+    /// SBI standard reset type 0x00000000.
+    Shutdown,
+    /// SBI standard reset type 0x00000001.
+    ColdReboot,
+    /// SBI standard reset type 0x00000002.
+    WarmReboot,
+    /// Vendor / platform specific reset type: 0xF0000000 ..= 0xFFFFFFFF.
+    VendorSpecific(u32),
+}
 
-    /// Reports a successful test run and powers off when supported.
-    fn pass(&self) -> !;
+/// Parsed reset reason accepted by the SRST driver layer.
+///
+/// Reserved raw values are intentionally not representable here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResetReason {
+    /// SBI standard reset reason 0x00000000.
+    NoReason,
+    /// SBI standard reset reason 0x00000001.
+    SystemFailure,
+    /// SBI implementation specific reset reason: 0xE0000000 ..= 0xEFFFFFFF.
+    SbiSpecific(u32),
+    /// Vendor / platform specific reset reason: 0xF0000000 ..= 0xFFFFFFFF.
+    VendorSpecific(u32),
+}
 
-    /// Restarts the platform.
-    fn reset(&self) -> !;
+/// Fully parsed SRST request.
+///
+/// This is the unit consumed by the driver layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResetRequest {
+    pub reset_type: ResetType,
+    pub reset_reason: ResetReason,
+}
+
+/// Low-level error category for an SRST backend.
+///
+/// Important:
+/// - `InvalidParam` is intentionally absent.
+/// - Successful reset is intentionally absent too, because a successful
+///   SRST request does not return.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResetError {
+    /// The request is implemented, but the platform lacks a required dependency.
+    ///
+    /// Mapped to SBI RET_ERR_NOT_SUPPORTED.
+    #[allow(
+        dead_code,
+        reason = "current backends acquire their dependencies at bind time"
+    )]
+    NotSupported,
+    /// The reset failed for unspecified or unknown other reasons.
+    ///
+    /// Mapped to SBI RET_ERR_FAILED.
+    Failed,
+}
+
+pub trait ResetBackend {
+    /// Backend-specific command produced by validating a reset request.
+    type Request;
+
+    /// Validate the reset request and prepare its backend-specific command.
+    ///
+    /// If this returns `None`, the upper layer returns SBI_ERR_INVALID_PARAM
+    /// without calling `system_reset`.
+    ///
+    /// This checks whether the parameter values have an implementation, not
+    /// whether all runtime dependencies are available. Missing dependencies
+    /// are reported by `system_reset` as `ResetError::NotSupported`.
+    fn prepare_reset(&self, req: ResetRequest) -> Option<Self::Request>;
+
+    /// Attempt to reset the system.
+    ///
+    /// Semantics:
+    /// - `req` is the command returned by this backend's `prepare_reset`;
+    /// - parameter validation and command selection are already complete;
+    /// - if this function returns, it must be an error path.
+    fn system_reset(&mut self, req: Self::Request) -> ResetError;
+}
+
+/// Object-safe adapter for reset backends with different command types.
+pub(crate) trait ResetDevice {
+    /// Validate and execute a request without exposing the command type.
+    ///
+    /// `None` means the request is invalid for this backend. `Some(error)`
+    /// means execution failed. A successful reset does not return.
+    fn reset(&mut self, req: ResetRequest) -> Option<ResetError>;
+}
+
+impl<B: ResetBackend> ResetDevice for B {
+    fn reset(&mut self, req: ResetRequest) -> Option<ResetError> {
+        let command = self.prepare_reset(req)?;
+        Some(self.system_reset(command))
+    }
 }
 
 pub(crate) const SIFIVE_TEST_COMPATIBLES: [&str; 1] = ["sifive,test0"];
@@ -31,7 +119,7 @@ pub(crate) const PMIC_I2C_COMPATIBLES: [&str; 2] = ["spacemit,k1-i2c", "ky,i2c"]
 pub(super) fn bind(
     board: &BoardInfo,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Option<Box<dyn ResetDevice>>> {
+) -> runtime::Result<Option<Box<dyn ResetDevice + Send>>> {
     if let Some(registers) = board.reset {
         return Ok(Some(sifive_test::bind(registers, memory)?));
     }

--- a/firmware/prototyper/src/driver/reset/pmic_spacemit_p1.rs
+++ b/firmware/prototyper/src/driver/reset/pmic_spacemit_p1.rs
@@ -11,7 +11,7 @@ use alloc::boxed::Box;
 use bitflags::bitflags;
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry};
 
-use crate::driver::reset::ResetDevice;
+use super::{ResetBackend, ResetDevice, ResetError, ResetReason, ResetRequest, ResetType};
 
 use controller::K1I2cController;
 
@@ -44,6 +44,21 @@ bitflags! {
     }
 }
 
+impl PowerControl {
+    fn for_request(req: ResetRequest) -> Option<Self> {
+        match (req.reset_type, req.reset_reason) {
+            (ResetType::Shutdown, ResetReason::NoReason | ResetReason::SystemFailure) => {
+                Some(Self::SHUTDOWN)
+            }
+            (
+                ResetType::ColdReboot | ResetType::WarmReboot,
+                ResetReason::NoReason | ResetReason::SystemFailure,
+            ) => Some(Self::RESET),
+            _ => None,
+        }
+    }
+}
+
 struct P1Pmic {
     i2c: K1I2cController,
     address: I2cAddress,
@@ -54,7 +69,7 @@ pub(super) fn bind(
     address: I2cAddress,
     timebase_frequency_hz: Option<u32>,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ResetDevice>> {
+) -> runtime::Result<Box<dyn ResetDevice + Send>> {
     Ok(Box::new(P1Pmic {
         i2c: K1I2cController::bind(registers, timebase_frequency_hz, memory)?,
         address,
@@ -82,24 +97,17 @@ impl P1Pmic {
     }
 }
 
-impl ResetDevice for P1Pmic {
-    fn fail(&self, _code: u16) -> ! {
-        if !self.set_power_control(PowerControl::RESET) {
-            error!("P1 PMIC: reset transaction failed");
-        }
-        self.park()
+impl ResetBackend for P1Pmic {
+    type Request = PowerControl;
+
+    fn prepare_reset(&self, req: ResetRequest) -> Option<Self::Request> {
+        PowerControl::for_request(req)
     }
 
-    fn pass(&self) -> ! {
-        if !self.set_power_control(PowerControl::SHUTDOWN) {
-            error!("P1 PMIC: shutdown transaction failed");
-        }
-        self.park()
-    }
-
-    fn reset(&self) -> ! {
-        if !self.set_power_control(PowerControl::RESET) {
-            error!("P1 PMIC: reset transaction failed");
+    fn system_reset(&mut self, req: Self::Request) -> ResetError {
+        if !self.set_power_control(req) {
+            error!("P1 PMIC: power-control transaction failed");
+            return ResetError::Failed;
         }
         self.park()
     }

--- a/firmware/prototyper/src/driver/reset/sifive_test.rs
+++ b/firmware/prototyper/src/driver/reset/sifive_test.rs
@@ -9,7 +9,7 @@ use alloc::boxed::Box;
 use core::mem::{align_of, size_of};
 use runtime::memory::{DeviceRegisterRange, MemoryRegistry, MmioRegion};
 
-use crate::driver::reset::ResetDevice;
+use super::{ResetBackend, ResetDevice, ResetError, ResetReason, ResetRequest, ResetType};
 
 #[repr(usize)]
 #[derive(Clone, Copy)]
@@ -38,6 +38,20 @@ impl FinishCommand {
     fn new(action: FinishAction, code: u16) -> Self {
         Self(u32::from(action as u16) | (u32::from(code) << u16::BITS))
     }
+
+    fn for_request(req: ResetRequest) -> Option<Self> {
+        match (req.reset_type, req.reset_reason) {
+            (ResetType::Shutdown, ResetReason::NoReason) => Some(Self::new(FinishAction::Pass, 0)),
+            (ResetType::Shutdown, ResetReason::SystemFailure) => {
+                Some(Self::new(FinishAction::Fail, u16::MAX))
+            }
+            (
+                ResetType::ColdReboot | ResetType::WarmReboot,
+                ResetReason::NoReason | ResetReason::SystemFailure,
+            ) => Some(Self::new(FinishAction::Reset, 0)),
+            _ => None,
+        }
+    }
 }
 
 /// SiFive test device used by QEMU to exit or reset.
@@ -48,7 +62,7 @@ struct SifiveTestDevice {
 pub(super) fn bind(
     registers: DeviceRegisterRange,
     memory: &mut MemoryRegistry,
-) -> runtime::Result<Box<dyn ResetDevice>> {
+) -> runtime::Result<Box<dyn ResetDevice + Send>> {
     let registers = registers.subrange(0, SPAN)?;
     if !registers.start().is_aligned_to(align_of::<u32>()) {
         return Err(runtime::Error::InvalidArgs);
@@ -65,29 +79,30 @@ impl SifiveTestDevice {
     }
 
     /// Writes the finish value and parks the hart until the board powers off.
-    fn finish(&self, command: FinishCommand) -> ! {
-        self.registers
+    fn finish(&mut self, command: FinishCommand) -> ResetError {
+        if self
+            .registers
             .write(Register::Finish.offset(), command.0)
-            .expect("BUG: SiFive test register escaped its MMIO window");
+            .is_err()
+        {
+            return ResetError::Failed;
+        }
         loop {
             riscv::asm::wfi();
         }
     }
 }
 
-impl ResetDevice for SifiveTestDevice {
+impl ResetBackend for SifiveTestDevice {
+    type Request = FinishCommand;
+
     #[inline]
-    fn fail(&self, code: u16) -> ! {
-        self.finish(FinishCommand::new(FinishAction::Fail, code))
+    fn prepare_reset(&self, req: ResetRequest) -> Option<Self::Request> {
+        FinishCommand::for_request(req)
     }
 
     #[inline]
-    fn pass(&self) -> ! {
-        self.finish(FinishCommand::new(FinishAction::Pass, 0))
-    }
-
-    #[inline]
-    fn reset(&self) -> ! {
-        self.finish(FinishCommand::new(FinishAction::Reset, 0))
+    fn system_reset(&mut self, req: Self::Request) -> ResetError {
+        self.finish(req)
     }
 }

--- a/firmware/prototyper/src/platform/boot.rs
+++ b/firmware/prototyper/src/platform/boot.rs
@@ -113,7 +113,7 @@ fn publish_platform_services(
 
 fn publish_sbi_dispatcher(
     interrupts: Option<InterruptDevices>,
-    reset: Option<Box<dyn ResetDevice>>,
+    reset: Option<Box<dyn ResetDevice + Send>>,
     pmu: Option<SbiPmu>,
 ) {
     let supervisor_memory = state::supervisor_memory();

--- a/firmware/prototyper/src/platform/state.rs
+++ b/firmware/prototyper/src/platform/state.rs
@@ -7,7 +7,7 @@ use runtime::memory::SupervisorMemory;
 use spin::{Mutex, Once, RwLock};
 
 use crate::cfg::NUM_HART_MAX;
-use crate::driver::ConsoleDevice;
+use crate::driver::DbcnBackend;
 
 use super::info::{BoardInfo, HartEnableList};
 
@@ -20,14 +20,14 @@ static READY: AtomicBool = AtomicBool::new(false);
 struct Platform {
     board: BoardInfo,
     supervisor_memory: SupervisorMemory,
-    console: Option<Mutex<Box<dyn ConsoleDevice>>>,
+    console: Option<Mutex<Box<dyn DbcnBackend + Send>>>,
 }
 
 /// Publishes resources constructed by the boot hart.
 pub(super) fn publish_resources(
     board: BoardInfo,
     supervisor_memory: SupervisorMemory,
-    console: Option<Box<dyn ConsoleDevice>>,
+    console: Option<Box<dyn DbcnBackend + Send>>,
 ) {
     let enabled_harts = board.enabled_harts;
     PLATFORM.call_once(|| Platform {
@@ -63,7 +63,7 @@ pub(crate) fn supervisor_memory() -> &'static SupervisorMemory {
     &platform().supervisor_memory
 }
 
-pub(crate) fn console_device() -> Option<&'static Mutex<Box<dyn ConsoleDevice>>> {
+pub(crate) fn console_device() -> Option<&'static Mutex<Box<dyn DbcnBackend + Send>>> {
     PLATFORM
         .get()
         .and_then(|platform| platform.console.as_ref())

--- a/firmware/prototyper/src/sbi/console.rs
+++ b/firmware/prototyper/src/sbi/console.rs
@@ -2,8 +2,8 @@
 //!
 //! # References
 //!
-//! - Specification: [RISC-V SBI DBCN extension](https://docs.riscv.org/reference/sbi/v3.0/ext-debug-console.html) —
-//!   console transfers, error handling, and the legacy console replacement.
+//! - Specification: [RISC-V SBI v3.0, Section 12](https://docs.riscv.org/reference/sbi/_attachments/riscv-sbi.pdf#page=51) —
+//!   DBCN transfers and function-specific error tables 50-52.
 
 #![forbid(unsafe_code)]
 
@@ -13,14 +13,14 @@ use runtime::memory::{PhysAddr, PhysAddrRange, SupervisorMemory};
 use rustsbi::{Console, Physical, SbiRet};
 use spin::Mutex;
 
-use crate::driver::ConsoleDevice;
+use crate::driver::{DbcnBackend, DbcnError};
 
 /// Bounds stack use and work performed while the console device lock is held.
 const MAX_TRANSFER_BYTES: usize = 256;
 
 /// SBI console service over a platform console device.
 pub(crate) struct SbiConsole {
-    device: &'static Mutex<Box<dyn ConsoleDevice>>,
+    device: &'static Mutex<Box<dyn DbcnBackend + Send>>,
     supervisor_memory: &'static SupervisorMemory,
 }
 
@@ -28,7 +28,7 @@ impl SbiConsole {
     /// Creates a new SBI console handle over the published console device.
     #[inline]
     pub(crate) fn new(
-        device: &'static Mutex<Box<dyn ConsoleDevice>>,
+        device: &'static Mutex<Box<dyn DbcnBackend + Send>>,
         supervisor_memory: &'static SupervisorMemory,
     ) -> Self {
         Self {
@@ -39,6 +39,9 @@ impl SbiConsole {
 
     // Console transfers require the complete buffer to belong to registered
     // supervisor memory. A zero-length transfer does not inspect its address.
+    // SBI v3.0 DBCN Tables 50-51 assign INVALID_PARAM to buffers that do not
+    // satisfy Section 3.2. This differs from Section 3.2's generic
+    // INVALID_ADDRESS/FAILED guidance; this adapter follows the DBCN tables.
     #[inline]
     fn validate_buffer<P>(&self, buffer: &Physical<P>) -> Result<(PhysAddr, usize), SbiRet> {
         let start = PhysAddr::new(buffer.phys_addr_lo());
@@ -50,27 +53,38 @@ impl SbiConsole {
         // This implementation cannot represent a physical address wider than
         // the native word.
         if buffer.phys_addr_hi() != 0 {
-            return Err(SbiRet::failed());
+            return Err(SbiRet::invalid_param());
         }
 
         let range =
-            PhysAddrRange::from_start_len(start, len).map_err(|_| SbiRet::invalid_address())?;
+            PhysAddrRange::from_start_len(start, len).map_err(|_| SbiRet::invalid_param())?;
         if self.supervisor_memory.check_range(range).is_err() {
-            return Err(SbiRet::failed());
+            return Err(SbiRet::invalid_param());
         }
 
         Ok((start, len))
     }
 
-    pub(super) fn write_byte_blocking(&self, byte: u8) {
-        while self.device.lock().write(&[byte]) == 0 {
-            core::hint::spin_loop();
+    pub(super) fn write_byte_blocking(&self, byte: u8) -> Result<(), DbcnError> {
+        loop {
+            match self.device.lock().write_slice(&[byte])? {
+                0 => core::hint::spin_loop(),
+                1 => return Ok(()),
+                _ => return Err(DbcnError::Failed),
+            }
         }
     }
 
     pub(super) fn try_read_byte(&self) -> Option<u8> {
         let mut byte = 0;
-        (self.device.lock().read(core::slice::from_mut(&mut byte)) == 1).then_some(byte)
+        match self
+            .device
+            .lock()
+            .read_slice(core::slice::from_mut(&mut byte))
+        {
+            Ok(1) => Some(byte),
+            _ => None,
+        }
     }
 }
 
@@ -96,9 +110,12 @@ impl Console for SbiConsole {
             .read(start, &mut chunk[..chunk_len])
             .is_err()
         {
-            return SbiRet::failed();
+            return SbiRet::invalid_param();
         }
-        let count = self.device.lock().write(&chunk[..chunk_len]);
+        let count = match self.device.lock().write_slice(&chunk[..chunk_len]) {
+            Ok(count) => count,
+            Err(error) => return dbcn_error(error),
+        };
         if count > chunk_len {
             return SbiRet::failed();
         }
@@ -120,7 +137,10 @@ impl Console for SbiConsole {
         // and reports the partial result directly.
         let mut chunk = [0; MAX_TRANSFER_BYTES];
         let chunk_len = len.min(chunk.len());
-        let count = self.device.lock().read(&mut chunk[..chunk_len]);
+        let count = match self.device.lock().read_slice(&mut chunk[..chunk_len]) {
+            Ok(count) => count,
+            Err(error) => return dbcn_error(error),
+        };
         if count > chunk_len {
             return SbiRet::failed();
         }
@@ -131,7 +151,7 @@ impl Console for SbiConsole {
                 .write(start, &chunk[..count])
                 .is_err()
         {
-            return SbiRet::failed();
+            return SbiRet::invalid_param();
         }
         SbiRet::success(count)
     }
@@ -139,8 +159,20 @@ impl Console for SbiConsole {
     /// Writes `byte` to the console.
     #[inline]
     fn write_byte(&self, byte: u8) -> SbiRet {
-        self.write_byte_blocking(byte);
-        SbiRet::success(0)
+        match self.write_byte_blocking(byte) {
+            Ok(()) => SbiRet::success(0),
+            Err(error) => dbcn_error(error),
+        }
+    }
+}
+
+/// Maps backend denial and I/O errors from DBCN Tables 50-52.
+/// Physical-memory errors are handled at entry; unsupported EIDs/FIDs belong
+/// to the SBI dispatcher and are not backend errors.
+fn dbcn_error(error: DbcnError) -> SbiRet {
+    match error {
+        DbcnError::Denied => SbiRet::denied(),
+        DbcnError::Failed => SbiRet::failed(),
     }
 }
 
@@ -149,11 +181,12 @@ impl Console for SbiConsole {
 /// Used by the `print!` and `println!` macros. Retries until all bytes
 /// have been written, spinning whenever a write returns zero.
 /// Does nothing if no console device has been initialized.
+/// Stops on backend errors without recursively logging through the failed device.
 pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write as _;
 
     struct ConsoleWriter<'a> {
-        device: &'a Mutex<Box<dyn ConsoleDevice>>,
+        device: &'a Mutex<Box<dyn DbcnBackend + Send>>,
     }
 
     impl fmt::Write for ConsoleWriter<'_> {
@@ -162,7 +195,14 @@ pub fn _print(args: fmt::Arguments) {
             let bytes = s.as_bytes();
             let mut written = 0;
             while written < bytes.len() {
-                let n = self.device.lock().write(&bytes[written..]);
+                let n = self
+                    .device
+                    .lock()
+                    .write_slice(&bytes[written..])
+                    .map_err(|_| fmt::Error)?;
+                if n > bytes.len() - written {
+                    return Err(fmt::Error);
+                }
                 if n == 0 {
                     core::hint::spin_loop();
                 } else {
@@ -174,7 +214,7 @@ pub fn _print(args: fmt::Arguments) {
     }
 
     if let Some(device) = crate::platform::console_device() {
-        ConsoleWriter { device }.write_fmt(args).unwrap();
+        let _ = ConsoleWriter { device }.write_fmt(args);
     }
 }
 

--- a/firmware/prototyper/src/sbi/hsm.rs
+++ b/firmware/prototyper/src/sbi/hsm.rs
@@ -42,15 +42,17 @@ impl rustsbi::Hsm for SbiHsm {
 
         match remote_hsm(hartid) {
             Some(remote) => {
-                if remote.start(NextStage {
-                    start_addr,
-                    opaque,
-                    next_mode: MPP::Supervisor,
-                }) {
-                    crate::sbi::ipi().unwrap().send_ipi(hartid);
-                    SbiRet::success(0)
-                } else {
-                    SbiRet::already_available()
+                match remote.start_with(
+                    NextStage {
+                        start_addr,
+                        opaque,
+                        next_mode: MPP::Supervisor,
+                    },
+                    || crate::sbi::ipi().unwrap().send_ipi(hartid),
+                ) {
+                    Ok(true) => SbiRet::success(0),
+                    Ok(false) => SbiRet::already_available(),
+                    Err(crate::driver::IpiError::Failed) => SbiRet::failed(),
                 }
             }
             None => SbiRet::invalid_param(),
@@ -90,7 +92,13 @@ impl rustsbi::Hsm for SbiHsm {
         }
 
         crate::sbi::trap::handler::msoft_ipi_handler();
-        crate::sbi::ipi().unwrap().clear_ipi();
+        if crate::sbi::ipi()
+            .unwrap()
+            .clear_ipi(current_hartid())
+            .is_err()
+        {
+            return SbiRet::failed();
+        }
         mie::enable_msoft();
         local_hsm().suspend();
         riscv::asm::wfi();

--- a/firmware/prototyper/src/sbi/ipi.rs
+++ b/firmware/prototyper/src/sbi/ipi.rs
@@ -9,7 +9,7 @@
 
 use super::pmu::pmu_firmware_counter_increment;
 use crate::cfg::NUM_HART_MAX;
-use crate::driver::IpiDevice;
+use crate::driver::{IpiBackend, IpiError, IpiRequest};
 use crate::riscv::current_hartid;
 use crate::sbi::hsm::remote_hsm;
 use crate::sbi::rfence;
@@ -31,7 +31,7 @@ pub(crate) const IPI_TYPE_FENCE: u8 = 1 << 1;
 /// SBI IPI extension.
 pub struct SbiIpi {
     /// IPI device: CLINT `msip` registers or IMSIC MSI files.
-    device: Mutex<Box<dyn IpiDevice>>,
+    device: Mutex<Box<dyn IpiBackend + Send>>,
     /// Maximum hart ID in the system.
     pub max_hart_id: usize,
 }
@@ -41,36 +41,19 @@ impl rustsbi::Ipi for SbiIpi {
     #[inline]
     fn send_ipi(&self, hart_mask: rustsbi::HartMask) -> SbiRet {
         pmu_firmware_counter_increment(firmware_event::IPI_SENT);
-        let mut deliver_harts = Vec::new();
+        let requests = match target_requests(hart_mask, self.max_hart_id) {
+            Ok(requests) => requests,
+            Err(error) => return error,
+        };
 
-        for hart_id in target_harts(hart_mask, self.max_hart_id) {
-            // Reject targets that are out of range, absent, disabled, or in a
-            // state that does not accept IPIs; the delivery loop below
-            // assumes every collected hart passed these checks.
-            if hart_id > self.max_hart_id {
-                return SbiRet::invalid_param();
+        for req in requests {
+            for hart_id in req.harts() {
+                set_ipi_type(hart_id, IPI_TYPE_SSOFT);
             }
-
-            let Some(hsm) = remote_hsm(hart_id) else {
-                return SbiRet::invalid_param();
-            };
-
-            if crate::platform::enabled_harts()
-                .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
-            {
-                return SbiRet::invalid_param();
-            }
-
-            if !hsm.allow_ipi() {
-                return SbiRet::invalid_param();
-            }
-
-            deliver_harts.push(hart_id);
-        }
-
-        for hart_id in deliver_harts {
-            if set_ipi_type(hart_id, IPI_TYPE_SSOFT) == 0 {
-                self.send_ipi(hart_id);
+            // Always signal: pending bits can remain after a failed send.
+            fence(Release);
+            if self.device.lock().send_ipi(req).is_err() {
+                return SbiRet::failed();
             }
         }
 
@@ -81,7 +64,7 @@ impl rustsbi::Ipi for SbiIpi {
 impl SbiIpi {
     /// Creates a new SBI IPI extension.
     #[inline]
-    pub(crate) fn new(device: Box<dyn IpiDevice>, max_hart_id: usize) -> Self {
+    pub(crate) fn new(device: Box<dyn IpiBackend + Send>, max_hart_id: usize) -> Self {
         Self {
             device: Mutex::new(device),
             max_hart_id,
@@ -95,67 +78,57 @@ impl SbiIpi {
         ctx: rfence::RFenceContext,
     ) -> SbiRet {
         let current_hart = current_hartid();
-        let mut deliver_harts = Vec::new();
+        let requests = match target_requests(hart_mask, self.max_hart_id) {
+            Ok(requests) => requests,
+            Err(error) => return error,
+        };
+        let local = rfence::local_rfence().unwrap();
+        let mut result = SbiRet::success(0);
 
-        for hart_id in target_harts(hart_mask, self.max_hart_id) {
-            // Reject targets that are out of range, absent, disabled, or in a
-            // state that does not accept IPIs; the delivery loop below
-            // assumes every collected hart passed these checks.
-            if hart_id > self.max_hart_id {
-                return SbiRet::invalid_param();
+        for hart_id in requests.into_iter().flat_map(IpiRequest::harts) {
+            let remote = rfence::remote_rfence(hart_id).unwrap();
+            local.add();
+            remote.set(ctx);
+            if hart_id == current_hart {
+                continue;
             }
 
-            let Some(hsm) = remote_hsm(hart_id) else {
-                return SbiRet::invalid_param();
-            };
-
-            if crate::platform::enabled_harts()
-                .is_none_or(|list| list.get(hart_id).is_none_or(|res| !(*res)))
-            {
-                return SbiRet::invalid_param();
+            set_ipi_type(hart_id, IPI_TYPE_FENCE);
+            if self.send_ipi(hart_id).is_ok() {
+                continue;
             }
-
-            if !hsm.allow_ipi() {
-                return SbiRet::invalid_param();
+            // Cancel this source's queued request; a receiver that already
+            // took it remains responsible for the acknowledgement.
+            if remote.cancel(current_hart) {
+                rfence::remote_rfence(current_hart).unwrap().sub();
             }
-
-            deliver_harts.push(hart_id);
+            result = SbiRet::failed();
+            break;
         }
 
-        for hart_id in deliver_harts {
-            if let Some(remote) = rfence::remote_rfence(hart_id) {
-                if let Some(local) = rfence::local_rfence() {
-                    local.add();
-                }
-                remote.set(ctx);
-                if hart_id != current_hart {
-                    let old_ipi_type = set_ipi_type(hart_id, IPI_TYPE_FENCE);
-                    if old_ipi_type == 0 {
-                        self.send_ipi(hart_id);
-                    }
-                }
-            }
-        }
-
-        while !rfence::local_rfence().unwrap().is_sync() {
+        // Complete previously submitted operations even if a later send failed.
+        while !local.is_sync() {
             rfence::rfence_single_handler();
         }
 
-        SbiRet::success(0)
+        result
     }
 
     /// Sends a firmware IPI to a hart.
     #[inline]
-    pub(crate) fn send_ipi(&self, hart_id: usize) {
+    pub(crate) fn send_ipi(&self, hart_id: usize) -> Result<(), IpiError> {
         // Publish the pending IPI type before signaling the target device.
         fence(Release);
-        self.device.lock().send_ipi(hart_id);
+        self.device.lock().send_ipi(IpiRequest {
+            hart_mask: 1,
+            hart_mask_base: hart_id,
+        })
     }
 
-    /// Clears the current hart's firmware IPI.
+    /// Clears the specified hart's firmware IPI register.
     #[inline]
-    pub(crate) fn clear_ipi(&self) {
-        self.device.lock().clear_ipi();
+    pub(crate) fn clear_ipi(&self, hart_id: usize) -> Result<(), IpiError> {
+        self.device.lock().clear_ipi(hart_id)
     }
 
     /// Reports whether IMSIC was selected after validation.
@@ -179,13 +152,15 @@ pub fn get_and_reset_ipi_type() -> u8 {
 #[inline]
 pub fn claim_ipi() {
     match crate::sbi::ipi() {
-        Some(ipi) => ipi.clear_ipi(),
+        Some(ipi) => ipi
+            .clear_ipi(current_hartid())
+            .expect("BUG: validated IPI backend could not clear the current hart"),
         None => error!("SBI or IPI device not initialized"),
     }
 }
 
 /// Initializes the SBI IPI extension from the selected device.
-pub(crate) fn init(ipi: Box<dyn IpiDevice>) -> SbiIpi {
+pub(crate) fn init(ipi: Box<dyn IpiBackend + Send>) -> SbiIpi {
     let max_hart_id = crate::platform::enabled_harts()
         .as_ref()
         .and_then(|hart_list| hart_list.iter().rposition(|enabled| *enabled))
@@ -199,11 +174,46 @@ pub(crate) fn uses_imsic() -> bool {
     crate::sbi::ipi().is_some_and(SbiIpi::uses_imsic)
 }
 
-fn target_harts(hart_mask: HartMask, max_hart_id: usize) -> Vec<usize> {
-    let (_mask, mask_base) = hart_mask.into_inner();
-    if mask_base == usize::MAX {
-        (0..=max_hart_id).collect()
-    } else {
-        hart_mask.into_iter().collect()
+fn target_requests(hart_mask: HartMask, max_hart_id: usize) -> Result<Vec<IpiRequest>, SbiRet> {
+    let enabled = crate::platform::enabled_harts().unwrap_or([false; NUM_HART_MAX]);
+    let available = |hart_id: usize| {
+        hart_id <= max_hart_id
+            && enabled.get(hart_id).copied().unwrap_or(false)
+            && remote_hsm(hart_id).is_some_and(|hsm| hsm.allow_ipi())
+    };
+    let (mask, base) = hart_mask.into_inner();
+    let mut requests = Vec::new();
+    if base == usize::MAX {
+        // Ignore mask and expand all available harts into ordinary windows.
+        for (window, harts) in enabled.chunks(usize::BITS as usize).enumerate() {
+            let base = window * usize::BITS as usize;
+            let mask = (0..harts.len()).fold(0, |mask, bit| {
+                mask | (usize::from(available(base + bit)) << bit)
+            });
+            if mask != 0 {
+                requests.push(IpiRequest {
+                    hart_mask: mask,
+                    hart_mask_base: base,
+                });
+            }
+        }
+    } else if mask != 0 {
+        // Validate every selected hart before any event or backend is touched.
+        for bit in 0..usize::BITS {
+            if mask & (1 << bit) == 0 {
+                continue;
+            }
+            let hart_id = base
+                .checked_add(bit as usize)
+                .ok_or_else(SbiRet::invalid_param)?;
+            if !available(hart_id) {
+                return Err(SbiRet::invalid_param());
+            }
+        }
+        requests.push(IpiRequest {
+            hart_mask: mask,
+            hart_mask_base: base,
+        });
     }
+    Ok(requests)
 }

--- a/firmware/prototyper/src/sbi/reset.rs
+++ b/firmware/prototyper/src/sbi/reset.rs
@@ -11,43 +11,73 @@ use alloc::boxed::Box;
 use rustsbi::SbiRet;
 use spin::Mutex;
 
-use crate::driver::ResetDevice;
+use crate::driver::{ResetDevice, ResetError, ResetReason, ResetRequest, ResetType};
 
 /// SBI system-reset extension service.
 pub struct SbiReset {
-    pub reset_dev: Mutex<Box<dyn ResetDevice>>,
+    pub reset_dev: Mutex<Box<dyn ResetDevice + Send>>,
 }
 
 impl SbiReset {
-    pub fn new(reset_dev: Mutex<Box<dyn ResetDevice>>) -> Self {
+    pub fn new(reset_dev: Mutex<Box<dyn ResetDevice + Send>>) -> Self {
         Self { reset_dev }
+    }
+
+    fn reset(&self, req: ResetRequest) -> SbiRet {
+        match self.reset_dev.lock().reset(req) {
+            None => SbiRet::invalid_param(),
+            Some(ResetError::NotSupported) => SbiRet::not_supported(),
+            Some(ResetError::Failed) => SbiRet::failed(),
+        }
     }
 
     #[allow(unused)]
     pub fn fail(&self) -> ! {
         trace!("Test fail, invoke process exit procedure on Reset device");
-        self.reset_dev.lock().fail(0);
+        let ret = self.reset(ResetRequest {
+            reset_type: ResetType::Shutdown,
+            reset_reason: ResetReason::SystemFailure,
+        });
+        error!("System failure reset returned: {ret:?}");
+        crate::fail::stop()
     }
 }
 
 impl rustsbi::Reset for SbiReset {
     #[inline]
     fn system_reset(&self, reset_type: u32, reset_reason: u32) -> SbiRet {
-        use rustsbi::spec::srst::{
-            RESET_REASON_NO_REASON, RESET_REASON_SYSTEM_FAILURE, RESET_TYPE_COLD_REBOOT,
-            RESET_TYPE_SHUTDOWN, RESET_TYPE_WARM_REBOOT,
+        let Some(req) = parse_request(reset_type, reset_reason) else {
+            return SbiRet::invalid_param();
         };
-        match reset_type {
-            RESET_TYPE_SHUTDOWN => match reset_reason {
-                RESET_REASON_NO_REASON => self.reset_dev.lock().pass(),
-                RESET_REASON_SYSTEM_FAILURE => self.reset_dev.lock().fail(u16::MAX),
-                value => self.reset_dev.lock().fail(value as _),
-            },
-            RESET_TYPE_COLD_REBOOT | RESET_TYPE_WARM_REBOOT => self.reset_dev.lock().reset(),
-
-            _ => SbiRet::invalid_param(),
-        }
+        self.reset(req)
     }
+}
+
+/// Validates both raw parameters before querying or invoking a reset backend.
+fn parse_request(reset_type: u32, reset_reason: u32) -> Option<ResetRequest> {
+    use rustsbi::spec::srst::{
+        RESET_REASON_NO_REASON, RESET_REASON_SYSTEM_FAILURE, RESET_TYPE_COLD_REBOOT,
+        RESET_TYPE_SHUTDOWN, RESET_TYPE_WARM_REBOOT,
+    };
+
+    let reset_type = match reset_type {
+        RESET_TYPE_SHUTDOWN => ResetType::Shutdown,
+        RESET_TYPE_COLD_REBOOT => ResetType::ColdReboot,
+        RESET_TYPE_WARM_REBOOT => ResetType::WarmReboot,
+        0xf000_0000..=0xffff_ffff => ResetType::VendorSpecific(reset_type),
+        _ => return None,
+    };
+    let reset_reason = match reset_reason {
+        RESET_REASON_NO_REASON => ResetReason::NoReason,
+        RESET_REASON_SYSTEM_FAILURE => ResetReason::SystemFailure,
+        0xe000_0000..=0xefff_ffff => ResetReason::SbiSpecific(reset_reason),
+        0xf000_0000..=0xffff_ffff => ResetReason::VendorSpecific(reset_reason),
+        _ => return None,
+    };
+    Some(ResetRequest {
+        reset_type,
+        reset_reason,
+    })
 }
 
 #[allow(unused)]

--- a/firmware/prototyper/src/sbi/trap/handler.rs
+++ b/firmware/prototyper/src/sbi/trap/handler.rs
@@ -213,7 +213,8 @@ pub fn sbi_call_handler(
             }
             legacy::LEGACY_CONSOLE_PUTCHAR => {
                 if let Some(console) = crate::sbi::console() {
-                    console.write_byte_blocking(ctx.a0() as u8);
+                    // Legacy putchar has no backend-error return channel.
+                    let _ = console.write_byte_blocking(ctx.a0() as u8);
                     ret.error = 0;
                     ret.value = a1;
                 }

--- a/firmware/prototyper/src/sbi/trap_stack.rs
+++ b/firmware/prototyper/src/sbi/trap_stack.rs
@@ -249,6 +249,15 @@ impl<T: core::fmt::Debug> RemoteHsmCell<'_, T> {
     /// Returns true if successful, false if hart was not in STOPPED state.
     #[inline]
     pub fn start(&self, t: T) -> bool {
+        self.start_with(t, || Ok::<(), core::convert::Infallible>(()))
+            .unwrap()
+    }
+
+    /// Reserves a stopped hart and publishes startup data after waking it.
+    ///
+    /// A failed wake restores STOPPED, so another start can retry; the target
+    /// cannot consume startup data while START_PENDING_EXT is held.
+    pub fn start_with<E>(&self, t: T, wake: impl FnOnce() -> Result<(), E>) -> Result<bool, E> {
         if self
             .0
             .status
@@ -260,13 +269,19 @@ impl<T: core::fmt::Debug> RemoteHsmCell<'_, T> {
             )
             .is_ok()
         {
+            if let Err(error) = wake() {
+                self.0.status.store(hart_state::STOPPED, Ordering::Release);
+                return Err(error);
+            }
+            // SAFETY: the STOPPED -> START_PENDING_EXT transition reserves
+            // the cell for this writer; local start spins until publication.
             unsafe { *self.0.inner.get() = Some(t) };
             self.0
                 .status
                 .store(hart_state::START_PENDING, Ordering::Release);
-            true
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -404,6 +419,18 @@ impl RemoteRFenceCell<'_> {
     #[inline]
     pub(crate) fn try_push(&self, item: (RFenceContext, usize)) -> bool {
         self.0.try_push(item)
+    }
+
+    /// Cancels this source's one queued request after an IPI send failure.
+    ///
+    /// If it has already been taken, the receiver must acknowledge it instead.
+    pub(crate) fn cancel(&self, source_hart: usize) -> bool {
+        let mut queue = self.0.queue.lock();
+        let Some(index) = queue.iter().position(|(_, source)| *source == source_hart) else {
+            return false;
+        };
+        queue.remove(index);
+        true
     }
 
     /// Decrements the synchronization counter.

--- a/firmware/test-kernel/scripts/expected.txt
+++ b/firmware/test-kernel/scripts/expected.txt
@@ -8,7 +8,9 @@ Sbi `Base` test pass
 Sbi `TIME` test pass
 Sbi `sPI` test pass
 Sbi `DBCN` test pass
+Sbi `DBCN` return contract test pass
 DBCN rejected non-zero upper-half write
 DBCN rejected non-zero upper-half read
 [pmu] counters number:
 Sbi `SRST` validation test pass
+SBI tests completed: PASS

--- a/firmware/test-kernel/scripts/expected.txt
+++ b/firmware/test-kernel/scripts/expected.txt
@@ -11,3 +11,4 @@ Sbi `DBCN` test pass
 DBCN rejected non-zero upper-half write
 DBCN rejected non-zero upper-half read
 [pmu] counters number:
+Sbi `SRST` validation test pass

--- a/firmware/test-kernel/src/console.rs
+++ b/firmware/test-kernel/src/console.rs
@@ -1,0 +1,220 @@
+//! Observable return-value and buffer contracts of the SBI DBCN extension.
+//!
+//! Reference: [SBI v3.0, Section 12, Tables 50-52](https://docs.riscv.org/reference/sbi/_attachments/riscv-sbi.pdf#page=51).
+//! Memory-error expectations follow the DBCN-specific tables, whose
+//! `INVALID_PARAM` entry differs from Section 3.2's `INVALID_ADDRESS` wording.
+//!
+//! This kernel runs in Bare mode, so its RAM buffer pointers are physical
+//! addresses. No particular UART address, firmware layout, or transfer limit
+//! is assumed. A non-zero upper address half is not inherently invalid.
+//!
+//! DBCN provides no portable way to inject denial or I/O failures, supply known
+//! receive data, or observe byte delivery. Those checks need a controlled console
+//! fixture; this suite checks the results it can observe without one.
+
+use sbi_spec::binary::{
+    Physical, RET_ERR_DENIED, RET_ERR_FAILED, RET_ERR_INVALID_PARAM, RET_SUCCESS, SbiRet,
+};
+use sbi_testing::sbi;
+
+const BUFFER_LEN: usize = 600;
+const CANARY: u8 = 0xa5;
+const TEST_CASES: usize = 10;
+
+/// Local test failure codes; these are distinct from SBI return error codes.
+#[derive(Clone, Copy, Debug)]
+#[repr(u8)]
+pub(super) enum ErrorCode {
+    UnexpectedReturn = 1,
+    ByteCountOutOfRange = 2,
+    ReadBeforeBuffer = 3,
+    ReadPastBuffer = 4,
+    ReadPastCount = 5,
+    NonzeroWriteByteValue = 6,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct TestError {
+    pub code: ErrorCode,
+    pub operation: &'static str,
+    pub capacity: usize,
+    pub returned_error: isize,
+    pub returned_value: usize,
+}
+
+impl TestError {
+    fn new(code: ErrorCode, operation: &'static str, capacity: usize, ret: SbiRet) -> Self {
+        Self {
+            code,
+            operation,
+            capacity,
+            returned_error: ret.error as isize,
+            returned_value: ret.value,
+        }
+    }
+}
+
+pub(super) enum TestOutcome {
+    Unavailable,
+    Complete { inconclusive: usize },
+}
+
+pub(super) type TestResult = Result<TestOutcome, [Option<TestError>; TEST_CASES]>;
+
+/// Runs every case and returns failures for the caller to report after other suites.
+#[expect(
+    clippy::result_large_err,
+    reason = "fixed-size reports preserve all failures without requiring a heap allocator"
+)]
+pub(super) fn test() -> TestResult {
+    if sbi::probe_extension(sbi::Console).is_unavailable() {
+        return Ok(TestOutcome::Unavailable);
+    }
+
+    // Evaluate all cases before collecting errors; one failure cannot skip later
+    // cases. Each successful bool records whether data-path checks were inconclusive.
+    let results = [
+        test_write(0),
+        test_write(1),
+        test_write(BUFFER_LEN),
+        test_read(0),
+        test_read(1),
+        test_read(16),
+        test_read(BUFFER_LEN),
+        check_invalid_range(
+            "write invalid range",
+            sbi::console_write(Physical::new(2, usize::MAX, usize::MAX)),
+        ),
+        check_invalid_range(
+            "read invalid range",
+            sbi::console_read(Physical::new(2, usize::MAX, usize::MAX)),
+        ),
+        test_write_byte(),
+    ];
+    let inconclusive = results
+        .iter()
+        .filter(|result| matches!(result, Ok(true)))
+        .count();
+    let errors = results.map(Result::err);
+    if errors.iter().any(Option::is_some) {
+        Err(errors)
+    } else {
+        Ok(TestOutcome::Complete { inconclusive })
+    }
+}
+
+fn test_write(len: usize) -> Result<bool, TestError> {
+    let mut input = [b'.'; BUFFER_LEN];
+    input[BUFFER_LEN - 1] = b'\n';
+
+    // Use a valid RAM address even for an empty transfer: DBCN does not
+    // explicitly require ignoring arbitrary addresses when num_bytes is 0.
+    let ret = sbi::console_write(Physical::new(len, input.as_ptr() as usize, 0));
+    // Section 12.1 allows partial writes and zero progress. One call is
+    // sufficient; eventual progress is not a conformance requirement.
+    Ok(check_transfer("write", ret, len)?.is_none())
+}
+
+fn test_read(len: usize) -> Result<bool, TestError> {
+    let mut output = [CANARY; BUFFER_LEN + 2];
+    let start = output[1..].as_mut_ptr() as usize;
+    let ret = sbi::console_read(Physical::new(len, start, 0));
+    // Validate the returned count before using it as a slice bound.
+    let count = check_transfer("read", ret, len)?;
+
+    // Only the requested destination may be written, including on errors.
+    if output[0] != CANARY {
+        return Err(TestError::new(
+            ErrorCode::ReadBeforeBuffer,
+            "read",
+            len,
+            ret,
+        ));
+    }
+    if !output[1 + len..].iter().all(|byte| *byte == CANARY) {
+        return Err(TestError::new(ErrorCode::ReadPastBuffer, "read", len, ret));
+    }
+    if let Some(count) = count {
+        // Section 12.2: the count describes bytes written, and no input
+        // means no writes. Do not assume the receive queue is empty or
+        // infer byte contents without an external source of known input.
+        if !output[1 + count..1 + len]
+            .iter()
+            .all(|byte| *byte == CANARY)
+        {
+            return Err(TestError::new(ErrorCode::ReadPastCount, "read", len, ret));
+        }
+    }
+    // On an error, Section 3 leaves a1 unspecified and Section 12.2 does
+    // not promise rollback of writes within the destination.
+    Ok(count.is_none())
+}
+
+fn check_invalid_range(operation: &'static str, ret: SbiRet) -> Result<bool, TestError> {
+    // This two-byte range overflows the entire 2*XLEN address encoding, not
+    // merely its low half. It cannot describe valid contiguous physical memory.
+    // No assumption about physical address 0, MMIO, or firmware RAM is needed.
+    // Compare only error: a1 is unspecified on these error paths.
+    match ret.error {
+        RET_ERR_INVALID_PARAM => Ok(false),
+        // The tables do not specify error precedence. Denial or failure
+        // may prevent observing the memory-validation result.
+        RET_ERR_DENIED | RET_ERR_FAILED => Ok(true),
+        _ => Err(TestError::new(
+            ErrorCode::UnexpectedReturn,
+            operation,
+            2,
+            ret,
+        )),
+    }
+}
+
+fn test_write_byte() -> Result<bool, TestError> {
+    let ret = sbi::console_write_byte(b'\n');
+    if !matches!(ret.error, RET_SUCCESS | RET_ERR_DENIED | RET_ERR_FAILED) {
+        return Err(TestError::new(
+            ErrorCode::UnexpectedReturn,
+            "write_byte",
+            1,
+            ret,
+        ));
+    }
+    // Section 12.3 explicitly defines a1 as zero on every return, including
+    // errors, overriding Section 3's general rule for error returns.
+    if ret.value != 0 {
+        return Err(TestError::new(
+            ErrorCode::NonzeroWriteByteValue,
+            "write_byte",
+            1,
+            ret,
+        ));
+    }
+    Ok(ret.error != RET_SUCCESS)
+}
+
+/// Checks Tables 50-51 for buffers in the test kernel's accessible RAM.
+fn check_transfer(
+    operation: &'static str,
+    ret: SbiRet,
+    capacity: usize,
+) -> Result<Option<usize>, TestError> {
+    match ret.error {
+        RET_SUCCESS if ret.value <= capacity => Ok(Some(ret.value)),
+        RET_SUCCESS => Err(TestError::new(
+            ErrorCode::ByteCountOutOfRange,
+            operation,
+            capacity,
+            ret,
+        )),
+        RET_ERR_DENIED | RET_ERR_FAILED => Ok(None),
+        // INVALID_PARAM is not expected for these valid buffers. Other SBI
+        // errors, including NOT_SUPPORTED, are absent from Tables 50-51 when
+        // DBCN is advertised and a defined function is called.
+        _ => Err(TestError::new(
+            ErrorCode::UnexpectedReturn,
+            operation,
+            capacity,
+            ret,
+        )),
+    }
+}

--- a/firmware/test-kernel/src/main.rs
+++ b/firmware/test-kernel/src/main.rs
@@ -5,6 +5,8 @@
 #[macro_use]
 extern crate rcore_console;
 
+mod reset;
+
 use core::{
     arch::{asm, naked_asm},
     ptr::null,
@@ -114,6 +116,7 @@ extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
 
     pmu_test(smp);
     fence_test(hartid, smp);
+    reset::test();
 
     if test_result {
         sbi::system_reset(sbi::Shutdown, sbi::NoReason);

--- a/firmware/test-kernel/src/main.rs
+++ b/firmware/test-kernel/src/main.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 extern crate rcore_console;
 
+mod console;
 mod reset;
 
 use core::{
@@ -114,13 +115,43 @@ extern "C" fn rust_main(hartid: usize, dtb_pa: usize) -> ! {
     };
     let test_result = testing.test();
 
+    let console_result = console::test();
     pmu_test(smp);
     fence_test(hartid, smp);
     reset::test();
 
-    if test_result {
+    // Report console diagnostics only after all other suites have run.
+    let console_passed = console_result.is_ok();
+    match console_result {
+        Ok(console::TestOutcome::Unavailable) => {
+            println!("Sbi `DBCN` return contract test skipped: extension unavailable");
+        }
+        Ok(console::TestOutcome::Complete { inconclusive }) => {
+            if inconclusive != 0 {
+                println!("DBCN: {inconclusive} data-path checks inconclusive due to DENIED/FAILED");
+            }
+            println!("Sbi `DBCN` return contract test pass");
+        }
+        Err(errors) => {
+            for error in errors.into_iter().flatten() {
+                println!(
+                    "DBCN {} FAILED: test error {} ({:?}), capacity={}, SBI error={}, value={}",
+                    error.operation,
+                    error.code as u8,
+                    error.code,
+                    error.capacity,
+                    error.returned_error,
+                    error.returned_value
+                );
+            }
+        }
+    }
+
+    if test_result && console_passed {
+        println!("SBI tests completed: PASS");
         sbi::system_reset(sbi::Shutdown, sbi::NoReason);
     } else {
+        println!("SBI tests completed: FAILED");
         sbi::system_reset(sbi::Shutdown, sbi::SystemFailure);
     }
     unreachable!()

--- a/firmware/test-kernel/src/reset.rs
+++ b/firmware/test-kernel/src/reset.rs
@@ -1,0 +1,71 @@
+//! SRST validation and unsupported-request regression tests for Prototyper.
+
+use sbi_spec::{binary::SbiRet, srst::*};
+use sbi_testing::sbi;
+
+struct RawParam(u32);
+
+impl sbi::ResetType for RawParam {
+    fn raw(&self) -> u32 {
+        self.0
+    }
+}
+
+impl sbi::ResetReason for RawParam {
+    fn raw(&self) -> u32 {
+        self.0
+    }
+}
+
+fn check(reset_type: u32, reset_reason: u32, expected: SbiRet) {
+    assert_eq!(
+        sbi::system_reset(RawParam(reset_type), RawParam(reset_reason)),
+        expected,
+        "SRST type {reset_type:#010x}, reason {reset_reason:#010x}"
+    );
+}
+
+pub(super) fn test() {
+    let standard_types = [
+        RESET_TYPE_SHUTDOWN,
+        RESET_TYPE_COLD_REBOOT,
+        RESET_TYPE_WARM_REBOOT,
+    ];
+    let vendor_types = [0xf000_0000, u32::MAX];
+    let reserved_types = [3, 0x7fff_ffff, 0xe000_0000, 0xefff_ffff];
+    let reserved_reasons = [2, 0x7fff_ffff, 0xdfff_ffff];
+    let specific_reasons = [0xe000_0000, 0xefff_ffff, 0xf000_0000, u32::MAX];
+    let valid_reasons = [
+        RESET_REASON_NO_REASON,
+        RESET_REASON_SYSTEM_FAILURE,
+        0xe000_0000,
+        0xefff_ffff,
+        0xf000_0000,
+        u32::MAX,
+    ];
+
+    for reset_type in reserved_types {
+        for reset_reason in valid_reasons.into_iter().chain(reserved_reasons) {
+            check(reset_type, reset_reason, SbiRet::invalid_param());
+        }
+    }
+    // Invalid reasons are rejected even when the type is unimplemented.
+    for reset_type in standard_types.into_iter().chain(vendor_types) {
+        for reset_reason in reserved_reasons {
+            check(reset_type, reset_reason, SbiRet::invalid_param());
+        }
+    }
+    for reset_type in vendor_types {
+        for reset_reason in valid_reasons {
+            check(reset_type, reset_reason, SbiRet::invalid_param());
+        }
+    }
+    for reset_type in standard_types {
+        for reset_reason in specific_reasons {
+            check(reset_type, reset_reason, SbiRet::invalid_param());
+        }
+    }
+
+    println!("Sbi `SRST` validation test pass");
+    // The caller exercises Shutdown + NoReason after all tests complete.
+}

--- a/library/rustsbi/CHANGELOG.md
+++ b/library/rustsbi/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Align `Console` and `Reset` documentation with SBI v3.0.
 - lib: update `riscv` dependency to 0.16.1 to fix RUSTSEC-2024-0436.
 - lib: update dependency version of `rustsbi` to 0.4.1
 

--- a/library/rustsbi/src/console.rs
+++ b/library/rustsbi/src/console.rs
@@ -1,13 +1,12 @@
 use spec::binary::{Physical, SbiRet};
 
-/// Debug Console extension.
+/// Debug Console extension (DBCN, EID `0x4442434E`).
 ///
 /// The debug console extension defines a generic mechanism for debugging
 /// and boot-time early prints from supervisor-mode software.
 ///
-/// Kernel developers should switch to driver-based console implementation
-/// instead of using this extension to prevent possible race conditions between
-/// the firmware and the kernel when drivers are ready.
+/// DBCN supersedes the legacy console putchar (EID `0x01`) and console getchar
+/// (EID `0x02`) extensions, adding multi-byte reads and writes within one SBI call.
 ///
 /// If the underlying physical console has extra bits for error checking
 /// (or correction), then these extra bits should be handled by the SBI
@@ -15,38 +14,40 @@ use spec::binary::{Physical, SbiRet};
 ///
 /// *NOTE:* It is recommended that bytes sent/received using the debug
 /// console extension follow UTF-8 character encoding.
+///
+/// Ref: [SBI v3.0, Section 12](https://docs.riscv.org/reference/sbi/_attachments/riscv-sbi.pdf#page=51).
 pub trait Console {
     /// Write bytes to the debug console from input memory.
-    ///
-    /// # Parameters
-    ///
-    /// The `bytes` parameter specifies the input memory, including its length
-    /// and memory physical base address (both lower and upper bits).
     ///
     /// # Non-blocking function
     ///
     /// This is a non-blocking SBI call, and it may do partial or no write operations
     /// if the debug console is not able to accept more bytes.
     ///
-    /// # Return value
-    ///
-    /// The number of bytes written is returned in `SbiRet.value` and the
-    /// possible return error codes returned in `SbiRet.error` are shown in
-    /// the table below:
-    ///
-    /// | Return code               | Description
-    /// |:--------------------------|:----------------------------------------------
-    /// | `SbiRet::success()`       | Bytes written successfully.
-    /// | `SbiRet::invalid_param()` | The memory pointed to by `bytes` does not satisfy the [requirements](struct.Physical.html#Requirements) described in shared memory physical address range.
-    /// | `SbiRet::failed()`        | Failed to write due to I/O errors.
-    fn write(&self, bytes: Physical<&[u8]>) -> SbiRet;
-    /// Read bytes from the debug console into an output memory.
-    ///
     /// # Parameters
     ///
-    /// The `bytes` parameter specifies the output memory, including the maximum
-    /// bytes which can be written, and its memory physical base address
-    /// (both lower and upper bits).
+    /// [`Physical::num_bytes`] gives the input byte count (`num_bytes` in the SBI
+    /// specification). [`Physical::phys_addr_lo`] and [`Physical::phys_addr_hi`]
+    /// encode `base_addr_lo` and `base_addr_hi`, respectively: the lower and upper
+    /// XLEN bits of the input buffer's physical base address.
+    ///
+    /// # Return value
+    ///
+    /// On success, [`SbiRet::value`] holds the unsigned number of bytes written
+    /// (`sbiret.uvalue` in the specification). On error, its value is unspecified
+    /// by the general calling convention in Section 3.
+    ///
+    /// [`SbiRet::error`] follows the Console Write error table in SBI v3.0,
+    /// Section 12.1 (Table 50):
+    ///
+    /// | Error Code | Description |
+    /// |:-----------|:------------|
+    /// | `SbiRet::success(n)` | Bytes were written successfully. |
+    /// | `SbiRet::invalid_param()` | The range encoded by `bytes` fails the shared-memory requirements in [Section 3.2](https://docs.riscv.org/reference/sbi/_attachments/riscv-sbi.pdf#page=17). |
+    /// | `SbiRet::denied()` | Console output is not permitted. |
+    /// | `SbiRet::failed()` | The write failed because of an I/O error. |
+    fn write(&self, bytes: Physical<&[u8]>) -> SbiRet;
+    /// Read bytes from the debug console into an output memory.
     ///
     /// # Non-blocking function
     ///
@@ -54,35 +55,47 @@ pub trait Console {
     /// into the output memory if there are no bytes to be read in the
     /// debug console.
     ///
+    /// # Parameters
+    ///
+    /// [`Physical::num_bytes`] gives the output buffer's byte capacity (`num_bytes`
+    /// in the SBI specification). [`Physical::phys_addr_lo`] and
+    /// [`Physical::phys_addr_hi`] encode `base_addr_lo` and `base_addr_hi`,
+    /// respectively: the lower and upper XLEN bits of its physical base address.
+    ///
     /// # Return value
     ///
-    /// The number of bytes read is returned in `SbiRet.value` and the
-    /// possible return error codes returned in `SbiRet.error` are shown in
-    /// the table below:
+    /// On success, [`SbiRet::value`] holds the unsigned number of bytes read
+    /// (`sbiret.uvalue` in the specification). On error, its value is unspecified
+    /// by the general calling convention in Section 3.
     ///
-    /// | Return code               | Description
-    /// |:--------------------------|:----------------------------------------------
-    /// | `SbiRet::success()`       | Bytes read successfully.
-    /// | `SbiRet::invalid_param()` | The memory pointed to by `bytes` does not satisfy the [requirements](struct.Physical.html#Requirements) described in shared memory physical address range.
-    /// | `SbiRet::failed()`        | Failed to read due to I/O errors.
+    /// [`SbiRet::error`] follows the Console Read error table in SBI v3.0,
+    /// Section 12.2 (Table 51):
+    ///
+    /// | Error Code | Description |
+    /// |:-----------|:------------|
+    /// | `SbiRet::success(n)` | Bytes were read successfully. |
+    /// | `SbiRet::invalid_param()` | The range encoded by `bytes` fails the shared-memory requirements in [Section 3.2](https://docs.riscv.org/reference/sbi/_attachments/riscv-sbi.pdf#page=17). |
+    /// | `SbiRet::denied()` | Console input is not permitted. |
+    /// | `SbiRet::failed()` | The read failed because of an I/O error. |
     fn read(&self, bytes: Physical<&mut [u8]>) -> SbiRet;
     /// Write a single byte to the debug console.
     ///
     /// # Blocking function
     ///
-    /// This is a blocking SBI call, and it will only return after writing
-    /// the specified byte to the debug console.
-    /// It will also return with `SbiRet::failed()` if there are I/O errors.
+    /// This SBI call blocks until the byte is written, unless console access is
+    /// denied or an I/O error occurs.
     ///
     /// # Return value
     ///
-    /// The `SbiRet.value` is set to zero, and the possible return error
-    /// codes returned in `SbiRet.error` are shown in the table below:
+    /// [`SbiRet::value`] (`sbiret.uvalue` in the specification) is zero on every
+    /// return, including errors. [`SbiRet::error`] follows the Console Write Byte
+    /// error table in SBI v3.0, Section 12.3 (Table 52):
     ///
-    /// | Return code               | Description
-    /// |:--------------------------|:----------------------------------------------
-    /// | `SbiRet::success()`       | Byte written successfully.
-    /// | `SbiRet::failed()`        | Failed to write the byte due to I/O errors.
+    /// | Error Code | Description |
+    /// |:-----------|:------------|
+    /// | `SbiRet::success(0)` | The byte was written. |
+    /// | `SbiRet::denied()` | Console output is not permitted. |
+    /// | `SbiRet::failed()` | The byte write failed because of an I/O error. |
     fn write_byte(&self, byte: u8) -> SbiRet;
     /// Function internal to macros. Do not use.
     #[doc(hidden)]

--- a/library/rustsbi/src/reset.rs
+++ b/library/rustsbi/src/reset.rs
@@ -1,13 +1,13 @@
 use sbi_spec::binary::SbiRet;
 
-/// System Reset extension.
+/// System Reset extension (SRST, EID `0x53525354`).
 ///
 /// Provides a function that allows the supervisor software to request system-level reboot or shutdown.
 ///
 /// The term "system" refers to the world-view of supervisor software and the underlying SBI implementation
 /// could be machine mode firmware or hypervisor.
 ///
-/// Ref: [Section 9, RISC-V Supervisor Binary Interface Specification](https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/riscv-sbi.adoc#9-system-reset-extension-eid-0x53525354-srst)
+/// Ref: [SBI v3.0, Section 10](https://raw.githubusercontent.com/riscv-non-isa/riscv-sbi-doc/v3.0/src/ext-sys-reset.adoc).
 pub trait Reset {
     /// Reset the system based on provided `reset_type` and `reset_reason`.
     ///
@@ -31,15 +31,41 @@ pub trait Reset {
     /// cold reboot and warm reboot will behave functionally the same as the native case but might
     /// not result in any physical power changes.
     ///
+    /// # Parameters
+    ///
+    /// `reset_type` is a 32-bit reset selector with the encodings in the RISC-V
+    /// SBI Specification v3.0, Section 10.1 (Table 26):
+    ///
+    /// | Value | Meaning |
+    /// |:------|:--------|
+    /// | `0x00000000` | Shutdown |
+    /// | `0x00000001` | Cold reboot |
+    /// | `0x00000002` | Warm reboot |
+    /// | `0x00000003..=0xEFFFFFFF` | Reserved for future use |
+    /// | `0xF0000000..=0xFFFFFFFF` | Vendor-specific or platform-specific reset type |
+    ///
+    /// `reset_reason` encodes an optional reset reason in 32 bits, using the
+    /// values in Table 27:
+    ///
+    /// | Value | Meaning |
+    /// |:------|:--------|
+    /// | `0x00000000` | No reason |
+    /// | `0x00000001` | System failure |
+    /// | `0x00000002..=0xDFFFFFFF` | Reserved for future use |
+    /// | `0xE0000000..=0xEFFFFFFF` | Reason specific to the SBI implementation |
+    /// | `0xF0000000..=0xFFFFFFFF` | Vendor-specific or platform-specific reset reason |
+    ///
     /// # Return value
     ///
-    /// The possible return error codes returned in `SbiRet.error` are shown in the table below:
+    /// A return indicates failure. [`SbiRet::error`] follows the System Reset
+    /// error table in SBI v3.0, Section 10.1 (Table 28). The error-return
+    /// convention in Section 3 does not define [`SbiRet::value`] for this function.
     ///
-    /// | Error code                | Description
-    /// |:--------------------------|:---------------
-    /// | `SbiRet::invalid_param()` | `reset_type` or `reset_reason` is not valid.
-    /// | `SbiRet::not_supported()` | `reset_type` is valid but not implemented.
-    /// | `SbiRet::failed()`        | Reset request failed for unknown reasons.
+    /// | Error Code | Description |
+    /// |:-----------|:------------|
+    /// | `SbiRet::invalid_param()` | Either parameter has a reserved value, or a platform-specific value that has no implementation. |
+    /// | `SbiRet::not_supported()` | The reset type has an implementation and is not reserved, but the platform lacks at least one required dependency. |
+    /// | `SbiRet::failed()` | The request could not be completed for another unknown or unspecified reason. |
     fn system_reset(&self, reset_type: u32, reset_reason: u32) -> SbiRet;
     /// Function internal to macros. Do not use.
     #[doc(hidden)]


### PR DESCRIPTION
Those backends matches RISC-V SBI specification and limits what error number this peripheral should return.

For example, this is error type of DBCN extension backend:

```
pub enum DbcnError {
    Denied,
    Failed,
}
```

`InvalidParam` is intentionally absent, for that the DBCN frontend already checks for parameter (physical memory slice) that they are valid. The backend must not return `InvalidParam` error.